### PR TITLE
Make Mailbox timeout a variable

### DIFF
--- a/strax/mailbox.py
+++ b/strax/mailbox.py
@@ -7,6 +7,7 @@ import logging
 from strax.utils import exporter
 export, __all__ = exporter()
 
+MAILBOX_TIMEOUT = 120 # seconds
 
 @export
 class MailboxException(Exception):
@@ -68,7 +69,7 @@ class Mailbox:
 
     def __init__(self,
                  name='mailbox',
-                 timeout=120,
+                 timeout=MAILBOX_TIMEOUT,
                  max_messages=60):
         self.name = name
         self.timeout = timeout


### PR DESCRIPTION
For processing, it's useful to be able to specify the timeout.  In this case, it's a global variable in mailbox.  This way, processing can overload this before initializing strax.