### PR TITLE
Add global variable for configuring mailbox size

### DIFF
--- a/strax/mailbox.py
+++ b/strax/mailbox.py
@@ -8,6 +8,8 @@ from strax.utils import exporter
 export, __all__ = exporter()
 
 MAILBOX_TIMEOUT = 120 # seconds
+MAILBOX_MAX_MESSAGES = 60 # messages
+
 
 @export
 class MailboxException(Exception):
@@ -70,7 +72,7 @@ class Mailbox:
     def __init__(self,
                  name='mailbox',
                  timeout=MAILBOX_TIMEOUT,
-                 max_messages=60):
+                 max_messages=MAILBOX_MAX_MESSAGES):
         self.name = name
         self.timeout = timeout
         self.max_messages = max_messages


### PR DESCRIPTION
Allows overloading mailbox size instead of hard codes.  You have to set the variable before initializing strax.