### PR TITLE
_close should not require implementation

### DIFF
--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -391,4 +391,4 @@ class Saver:
         raise NotImplementedError
 
     def _close(self):
-        raise NotImplementedError
+        pass


### PR DESCRIPTION
"raise NotImplementedError" is a bit much.  Not all backends require closing if they are atomic.  Therefore, I think we should be able to skip implementing this.  I changed raise `NotImplementedError` to `pass`.