### PR TITLE
Redo S3 schema (use one Bucket due to limited number of buckets

### DIFF
--- a/strax/storage/s3.py
+++ b/strax/storage/s3.py
@@ -150,7 +150,7 @@ class S3Backend(strax.StorageBackend):
                                    compressor=compressor)
 
     def _saver(self, key, metadata, meta_only=False):
-        return S3Saver(dirname,
+        return S3Saver(key,
                        metadata=metadata,
                        meta_only=meta_only,
                        **self.kwargs)

--- a/strax/storage/s3.py
+++ b/strax/storage/s3.py
@@ -129,10 +129,10 @@ class S3Backend(strax.StorageBackend):
                                service_name='s3')
         self.kwargs = kwargs  # Used later for setting up Saver
 
-    def get_metadata(self, key):
+    def get_metadata(self, backend_key):
         # Grab metadata object from S3 bucket
         result = self.s3.get_object(Bucket=BUCKET_NAME,
-                                    Key=f'{key}/metadata.json')
+                                    Key=f'{backend_key}/metadata.json')
         # Then read/parse it into ASCII
         text = result["Body"].read().decode()
 


### PR DESCRIPTION
Same thing as before but with a new schema.  Instead of each bucket being a strax key, all objects live in one bucket.  Instead of buckets, I use 'folders' (i.e. key is strax_key/chunk_id).  This seems to be the right way to go.  Once this merges and goes into a release, I'll start using this as the main backend at the moment for XENON data at least.

Also, factor out JSON uploader to S3.