### PR TITLE
Basic time-based random access

### DIFF
--- a/strax/processor.py
+++ b/strax/processor.py
@@ -69,8 +69,18 @@ class ThreadedMailboxProcessor:
 
         for d, savers in savers.items():
             for s_i, saver in enumerate(savers):
-                self.mailboxes[d].add_reader(saver.save_from,
-                                             name=f'save_{s_i}:{d}')
+                if d in plugins:
+                    rechunk = plugins[d].rechunk_on_save
+                else:
+                    # This is storage conversion mode
+                    # TODO: Don't know how to get this info, for now,
+                    # be conservative and don't rechunk
+                    rechunk = False
+
+                from functools import partial
+                self.mailboxes[d].add_reader(
+                    partial(saver.save_from, rechunk=rechunk),
+                    name=f'save_{s_i}:{d}')
 
     def iter(self):
         target = self.components.targets[0]


### PR DESCRIPTION
This implements basic random access based on a time selection. If you do `get_df(run_id, 'some_stuff', time_range=(1111123123,  1111153123))`, only part of the data will be fetched and returned. This is essential for waveform watching.

There are two limitations (related to #79):
  * You can only fetch data types of the same data kind. To fetch e.g. both event and peak-level info, you need two calls to get_df/array.
  * One of the requested data types must provide time information. So you can request peak_basics + peak_classification, but not just peak_classification.