### PR TITLE
Do not save during time range selection and fuzzy matching

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -128,6 +128,15 @@ def test_fuzzy_matching():
         st.set_context_config(dict(fuzzy_for=('peaks',)))
         assert st.is_stored(run_id, 'peaks')
 
+    # No saving occurs at all while fuzzy matching
+    with tempfile.TemporaryDirectory() as temp_dir:
+        st = strax.Context(storage=strax.DataDirectory(temp_dir),
+                           register=[Records, Peaks],
+                           fuzzy_for=('records',))
+        st.make(run_id, 'peaks')
+        assert not st.is_stored(run_id, 'peaks')
+        assert not st.is_stored(run_id, 'records')
+
 
 def test_storage_converter():
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
This disables any attempted data saving (with a warning) while the user has fuzzy matching or time range selection options turned on.

Saving when fuzzy matching is turned on is particularly dangerous (thanks @coderdj for pointing this out) because it would produce wrongly tagged data. In principle we could deduce the correct lineage/config from the loaded data, but this becomes quite complicated. For now, disallowing it is safer.

Saving during time range selection is already impossible normally, since time range selection requires the data to be available already. However, it could occur happen when the storage conversion mode was turned on. If so, we would have produced incomplete data that only has the requested time range saved.