### PR TITLE
Fix pax conversion

### DIFF
--- a/strax/xenon/pax_interface.py
+++ b/strax/xenon/pax_interface.py
@@ -122,4 +122,6 @@ class RecordsFromPax(strax.Plugin):
             if (self.config['stop_after_zips']
                     and file_i >= self.config['stop_after_zips']):
                 break
-            yield from strax.xenon.pax_interface.pax_to_records(in_fn)
+            yield from strax.xenon.pax_interface.pax_to_records(
+                in_fn,
+                events_per_chunk=self.config['events_per_chunk'])

--- a/strax/xenon/pax_interface.py
+++ b/strax/xenon/pax_interface.py
@@ -99,7 +99,7 @@ def pax_to_records(input_filename,
                  help="Directory with raw pax datasets"),
     strax.Option('stop_after_zips', default=0, track=False,
                  help="Convert only this many zip files. 0 = all."),
-    strax.Option('events_per_chunk', default=10, track=False,
+    strax.Option('events_per_chunk', default=50, track=False,
                  help="Number of events to yield per chunk")
 )
 class RecordsFromPax(strax.Plugin):
@@ -108,6 +108,7 @@ class RecordsFromPax(strax.Plugin):
     depends_on = tuple()
     dtype = strax.record_dtype()
     parallel = False
+    rechunk_on_save = False
 
     def iter(self, *args, **kwargs):
         if not os.path.exists(self.config['pax_raw_dir']):

--- a/strax/xenon/plugins.py
+++ b/strax/xenon/plugins.py
@@ -116,7 +116,7 @@ class Peaks(strax.Plugin):
     depends_on = ('records',)
     data_kind = 'peaks'
     parallel = True
-    rechunk_on_save = False
+    rechunk_on_save = True
     dtype = strax.peak_dtype(n_channels=len(to_pe))
 
     def compute(self, records):


### PR DESCRIPTION
Pax data was mistakenly rechunked upon conversion to the strax format, causing errors in later processing (specifically `event_basics`, or probably any `LoopPlugin` subclass). This fixes the problem.

One more change: peaks' output is now also rechunked to more convenient file sizes. I found this significantly speeds up processing that starts from peaks. Unfortunately it has no effect on full-chain processing, since rechunking currently only affects saving (I'll make an issue for this) 

