### PR TITLE
Load incomplete data, collaboration meeting demos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,12 @@
 *.zstd
 *.npy
 *.blosc
+*.h5
 strax_data
 from_fake_daq
 from_eb
+from_eb_finished
+resource_cache
 raw
 reduced_raw
 processed

--- a/notebooks/Online monitor demo.ipynb
+++ b/notebooks/Online monitor demo.ipynb
@@ -11,14 +11,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Jelle, May 2018\n",
+    "Jelle, September 2018\n",
     "\n",
-    "This notebooks shows a basic (cS1, cS2) plot that updates while the DAQ data is incoming. To run it, first start\n",
-    "  * `python fake_daq.py`\n",
-    "  * `python eb.py --mongo`\n",
-    "(each in a separate terminal).\n",
+    "This notebook contains the demos I showed during my [collaboration meeting talk in Coimbra](https://docs.google.com/presentation/d/1W7H5x2JeBb7JcgKXN6POF-YTqO7jSa7rNX_v6rWCpTo).\n",
     "\n",
-    "At the moment you can only start the plot *after* eb.py has put in a chunk of events; you'll get an error otherwise. "
+    "The first plot shows a basic (cS1, cS2) plot that updates while the DAQ data is incoming. To run it, first start\n",
+    "  * `python fake_daq.py --realtime`\n",
+    "  * `python eb.py --norechunk`\n",
+    "(each in a separate terminal). At the moment you can only start the plot *after* eb.py has put in a chunk of events; you'll get an error otherwise. \n",
+    "\n",
+    "The second series of plots uses a full XENON11T background run, which you can find on `/dali/lgrandi/aalbers/strax_data`. \n",
+    "\n",
+    "The final demo shows waveform inspection, and requires finished raw data for a dataset. The easiest way to obtain some is to run the eventbuilding-process described above, then rename `from_eb` to `from_eb_finished`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Setup"
    ]
   },
   {
@@ -27,23 +38,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import time\n",
-    "import itertools\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import strax"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import plots\n",
+    "import strax\n",
     "st = strax.Context(register_all=strax.xenon.plugins,\n",
-    "                   storage=strax.MongoStore('mongodb://localhost'))\n",
+    "                   storage=strax.DataDirectory('./from_eb'),\n",
+    "                   allow_incomplete=True)\n",
+    "st.log.setLevel('ERROR')\n",
     "\n",
     "run_id = '180423_1021'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Online full processing"
    ]
   },
   {
@@ -56,41 +65,88 @@
    "source": [
     "%matplotlib notebook\n",
     "\n",
-    "max_delay = 30 * 1e9\n",
+    "for i in range(10000):\n",
+    "    df = st.get_df(run_id, 'event_info')\n",
+    "    plots.event_scatter(df, update=i != 0, time_cut=True, sleep_factor=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### More setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "st = st.new_context(register=strax.xenon.pax_interface.RecordsFromPax,\n",
+    "                    allow_incomplete=False)\n",
+    "st.storage = [strax.DataDirectory('/home/jelle/strax_data', readonly=True),\n",
+    "              strax.DataDirectory('./strax_data')]\n",
+    "run_id = '170621_0617'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Quick parameter exploration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = st.get_df(run_id, 'event_info',\n",
+    "               config=dict(s1_max_width=2000))\n",
+    "plots.event_scatter(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = st.get_df(run_id, 'event_info',\n",
+    "               config=dict(trigger_min_area=10))\n",
     "\n",
-    "for i in itertools.count():\n",
-    "    # Get all events from mongo\n",
-    "    df = st.get_df(run_id, ['event_basics', 'events'])\n",
-    "    \n",
-    "    # Select recent events\n",
-    "    now = time.time()\n",
-    "    df['delay'] = int(now) * int(1e9) - df['time']\n",
-    "    df = df[df['delay'] < int(max_delay)]\n",
-    "\n",
-    "    # Update the plot\n",
-    "    plt.gca().clear()\n",
-    "    \n",
-    "    plt.scatter(df.s1_area, df.s2_area,\n",
-    "                c=df.s1_area_fraction_top,\n",
-    "                vmin=0, vmax=0.3,\n",
-    "                s=100 * (max_delay - df.delay)/max_delay,\n",
-    "                cmap=plt.cm.jet,\n",
-    "                marker='.', edgecolors='none')\n",
-    "    if i == 0:\n",
-    "        plt.colorbar(label=\"S1 area fraction top\", extend='max')\n",
-    "    plt.xlabel('S1 (PE)')\n",
-    "    plt.ylabel('S2 (PE)')\n",
-    "    plt.xscale('symlog')\n",
-    "    plt.yscale('log')\n",
-    "    plt.ylim(1e2, 1e7)\n",
-    "    plt.xlim(-0.1, 1e6)\n",
-    "    plt.title(time.strftime('%H:%M:%S'))\n",
-    "    \n",
-    "    plt.gcf().canvas.draw()\n",
-    "    \n",
-    "    # Sleep 4x as long as it took to make the plot\n",
-    "    time.sleep(4 * (time.time() - now))\n",
-    "    "
+    "plots.event_scatter(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Trigerless data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "st = strax.Context(register_all=strax.xenon.plugins,\n",
+    "                   storage=strax.DataDirectory('./from_eb_finished'),\n",
+    "                   allow_incomplete=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plots\n",
+    "plots.show_time_range(st, '180423_1021', 1536243210000001040)"
    ]
   }
  ],
@@ -99,6 +155,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/plots.py
+++ b/notebooks/plots.py
@@ -1,0 +1,229 @@
+"""Plotting helper functions for the online demo notebook
+The code in show_time_range is mostly copy-pasted from 
+the visualization notebook.
+"""
+import time
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def event_scatter(df, sleep_factor=2, max_delay=60, time_cut=False, s=5, update=False):
+    max_delay *= 1e9
+
+    # Select recent events
+    if time_cut:
+        now = time.time()
+        df['delay'] = int(now) * int(1e9) - df['time']
+        df = df[df['delay'] < int(max_delay)]
+        s = 200 * (max_delay - df.delay) / max_delay
+    else:
+        s = s
+        if len(df) > 10000:
+            df = df.sample(10000)
+
+    # Update the plot
+    plt.gca().clear()
+
+    plt.scatter(np.nan_to_num(df.cs1),
+                np.nan_to_num(df.cs2),
+                c=df.s1_area_fraction_top,
+                vmin=0, vmax=0.3,
+                s=s,
+                cmap=plt.cm.jet,
+                marker='.', edgecolors='none')
+    if not update:
+        plt.colorbar(label="S1 area fraction top", extend='max')
+    plt.xlabel('cS1 (PE)')
+    plt.ylabel('cS2 (PE)')
+    plt.xscale('symlog')
+    plt.yscale('log')
+    plt.ylim(1e1, 1e7)
+    plt.xlim(-0.1, 1e6)
+    if time_cut:
+        plt.title(time.strftime('%H:%M:%S'))
+
+    plt.gcf().canvas.draw()
+
+    if time_cut:
+        # Sleep for some fraction of the time it took to make the plot
+        time.sleep(sleep_factor * (time.time() - now))
+
+
+
+def show_time_range(st, run_id, t0, dt=10):
+    from functools import partial
+
+    import numpy as np
+    import pandas as pd
+
+    import holoviews as hv
+    from holoviews.operation.datashader import datashade, dynspread
+    hv.extension('bokeh')
+
+    import strax
+
+    import gc
+    # Somebody thought it was a good idea to call gc.collect explicitly somewhere in holoviews
+    # This makes dynamic PMT maps super slow
+    # Until I trace the offender:
+    gc.collect = lambda *args, **kwargs: None
+
+    # Custom wheel zoom tool that only zooms in time
+    from bokeh.models import WheelZoomTool
+    time_zoom = WheelZoomTool(dimensions='width')
+
+    # Get ADC->pe multiplicative conversion factor
+    from pax.configuration import load_configuration
+    from pax.dsputils import adc_to_pe
+    pax_config = load_configuration('XENON1T')["DEFAULT"]
+    to_pe = np.array([adc_to_pe(pax_config, ch)
+                      for ch in range(pax_config['n_channels'])])
+
+    tpc_r = pax_config['tpc_radius']
+
+    # Get locations of PMTs
+    r = []
+    for q in pax_config['pmts']:
+        r.append(dict(x=q['position']['x'],
+                      y=q['position']['y'],
+                      i=q['pmt_position'],
+                      array=q.get('array', 'other')))
+    f = 1.08
+    pmt_locs = pd.DataFrame(r)
+
+    records = st.get_array(run_id, 'raw_records', time_range=(t0, t0 + int(1e10)))
+
+    # TOOD: don't reprocess, just load...
+    hits = strax.find_hits(records)
+    peaks = strax.find_peaks(hits, to_pe, gap_threshold=300, min_hits=3,
+                             result_dtype=strax.peak_dtype(n_channels=260))
+    strax.sum_waveform(peaks, records, to_pe)
+    # Integral in pe
+    areas = records['data'].sum(axis=1) * to_pe[records['channel']]
+
+    def normalize_time(t):
+        return (t - records[0]['time']) / 1e9
+
+    # Create dataframe with record metadata
+    df = pd.DataFrame(dict(area=areas,
+                           time=normalize_time(records['time']),
+                           channel=records['channel']))
+
+    # Convert to holoviews Points
+    points = hv.Points(df,
+                       kdims=[hv.Dimension('time', label='Time', unit='sec'),
+                              hv.Dimension('channel', label='PMT number', range=(0, 260))],
+                       vdims=[hv.Dimension('area', label='Area', unit='pe',
+                                           # range=(0, 1000)
+                                           )])
+
+    def pmt_map(t_0, t_1, array='top', **kwargs):
+        # Compute the PMT pattern (fast)
+        ps = points[(t_0 <= points['time'])
+                    & (points['time'] < t_1)]
+        areas = np.bincount(ps['channel'],
+                            weights=ps['area'],
+                            minlength=len(pmt_locs))
+
+        # Which PMTs should we include?
+        pmt_mask = pmt_locs['array'] == array
+        d = pmt_locs[pmt_mask].copy()
+        d['area'] = areas[pmt_mask]
+
+        # Convert to holoviews points
+        d = hv.Dataset(d,
+                       kdims=[hv.Dimension('x', unit='cm', range=(-tpc_r * f, tpc_r * f)),
+                              hv.Dimension('y', unit='cm', range=(-tpc_r * f, tpc_r * f)),
+                              hv.Dimension('i', label='PMT number'),
+                              hv.Dimension('area',
+                                           label='Area',
+                                           unit='PE')])
+
+        return d.to(hv.Points,
+                    vdims=['area', 'i'],
+                    group='PMTPattern',
+                    label=array.capitalize(),
+                    **kwargs).opts(
+            plot=dict(color_index=2,
+                      tools=['hover'],
+                      show_grid=False),
+            style=dict(size=17,
+                       cmap='magma'))
+
+    def pmt_map_range(x_range, array='top', **kwargs):
+        # For use in dynamicmap with streams
+        if x_range is None:
+            x_range = (0, 0)
+        return pmt_map(x_range[0], x_range[1], array=array, **kwargs)
+
+    xrange_stream = hv.streams.RangeX(source=points)
+
+    # TODO: weigh by area
+
+    def channel_map():
+        return dynspread(datashade(points,
+                                   y_range=(0, 260),
+                                   streams=[xrange_stream])).opts(
+            plot=dict(width=600,
+                      tools=[time_zoom, 'xpan'],
+                      default_tools=['save', 'pan', 'box_zoom', 'save', 'reset'],
+                      show_grid=False))
+
+    def plot_peak(p):
+        # It's better to plot amplitude /time than per bin, since
+        # sampling times are now variable
+        y = p['data'][:p['length']] / p['dt']
+        t_edges = np.arange(p['length'] + 1, dtype=np.int64)
+        t_edges = t_edges * p['dt'] + p['time']
+        t_edges = normalize_time(t_edges)
+
+        # Correct step plotting from Knut
+        t_ = np.zeros(2 * len(y))
+        y_ = np.zeros(2 * len(y))
+        t_[0::2] = t_edges[0:-1]
+        t_[1::2] = t_edges[1::]
+        y_[0::2] = y
+        y_[1::2] = y
+
+        c = hv.Curve(dict(time=t_, amplitude=y_),
+                     kdims=points.kdims[0],
+                     vdims=hv.Dimension('amplitude', label='Amplitude', unit='PE/ns'),
+                     group='PeakSumWaveform')
+        return c.opts(plot=dict(  # interpolation='steps-mid',
+            # default_tools=['save', 'pan', 'box_zoom', 'save', 'reset'],
+            # tools=[time_zoom, 'xpan'],
+            width=600,
+            shared_axes=False,
+            show_grid=True),
+            style=dict(color='b')
+            # norm=dict(framewise=True)
+        )
+
+    def peaks_in(t_0, t_1):
+        return peaks[(normalize_time(peaks['time'] + peaks['length'] * peaks['dt']) > t_0)
+                     & (normalize_time(peaks['time']) < t_1)]
+
+    def plot_peaks(t_0, t_1, n_max=10):
+        # Find peaks in this range
+        ps = peaks_in(t_0, t_1)
+        # Show only the largest n_max peaks
+        if len(ps) > n_max:
+            areas = ps['area']
+            max_area = np.sort(areas)[-n_max]
+            ps = ps[areas >= max_area]
+
+
+        return hv.Overlay(items=[plot_peak(p) for p in ps])
+
+    def plot_peak_range(x_range, **kwargs):
+        # For use in dynamicmap with streams
+        if x_range is None:
+            x_range = (0, 10)
+        return plot_peaks(x_range[0], x_range[1], **kwargs)
+
+
+    top_map = hv.DynamicMap(partial(pmt_map_range, array='top'), streams=[xrange_stream])
+    bot_map = hv.DynamicMap(partial(pmt_map_range, array='bottom'), streams=[xrange_stream])
+    waveform = hv.DynamicMap(plot_peak_range, streams=[xrange_stream])
+    layout = waveform + top_map + channel_map() + bot_map
+    return layout.cols(2)

--- a/notebooks/visualization.ipynb
+++ b/notebooks/visualization.ipynb
@@ -79,11 +79,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This is not how to do it! Need some random access options...\n",
-    "records = strax.io.load_file(\n",
-    "    './raw/180423_1021_raw_records_e4c6f55b5603bdb248a6f496b09265e2e032eb4c/000000',\n",
-    "    dtype=strax.record_dtype(),\n",
-    "    compressor='blosc')"
+    "st = strax.Context(register_all=strax.xenon.plugins,\n",
+    "                   storage=strax.DataDirectory('./from_eb'),\n",
+    "                   allow_incomplete=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_id = '180423_1021'\n",
+    "t0 = 1536165263137124040"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "records = st.get_array(run_id, 'raw_records', time_range=(t0, t0 + int(1e10)))"
    ]
   },
   {
@@ -383,60 +401,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def plot_peak(p):\n",
-    "    # It's better to plot amplitude /time than per bin, since\n",
-    "    # sampling times are now variable\n",
-    "    y = p['data'][:p['length']] / p['dt']\n",
-    "    t_edges = np.arange(p['length'] + 1, dtype=np.int64)\n",
-    "    t_edges = t_edges * p['dt'] + p['time']\n",
-    "    t_edges = normalize_time(t_edges)\n",
-    "    \n",
-    "    # Correct step plotting from Knut\n",
-    "    t_ = np.zeros(2 * len(y))\n",
-    "    y_ = np.zeros(2 * len(y))\n",
-    "    t_[0::2] = t_edges[0:-1]\n",
-    "    t_[1::2] = t_edges[1::]\n",
-    "    y_[0::2] = y\n",
-    "    y_[1::2] = y\n",
-    "    \n",
-    "    c = hv.Curve(dict(time=t_, amplitude=y_),\n",
-    "                 kdims=points.kdims[0], \n",
-    "                 vdims=hv.Dimension('amplitude', label='Amplitude', unit='PE/ns'),\n",
-    "                 group='PeakSumWaveform')\n",
-    "    return c.opts(plot=dict(#interpolation='steps-mid',\n",
-    "                            #default_tools=['save', 'pan', 'box_zoom', 'save', 'reset'],\n",
-    "                            #tools=[time_zoom, 'xpan'],\n",
-    "                            width=600,\n",
-    "                            shared_axes=False,\n",
-    "                            show_grid=True),\n",
-    "                  style=dict(color='b')\n",
-    "                  #norm=dict(framewise=True)\n",
-    "                 )\n",
-    "\n",
-    "def peaks_in(t_0, t_1):\n",
-    "    return peaks[(normalize_time(peaks['time'] + peaks['length'] * peaks['dt']) > t_0)\n",
-    "                 & (normalize_time(peaks['time']) < t_1)]    \n",
-    "\n",
-    "def plot_peaks(t_0, t_1, n_max=10):\n",
-    "    # Find peaks in this range\n",
-    "    ps = peaks_in(t_0, t_1)\n",
-    "    print(len(ps))\n",
-    "    # Show only the largest n_max peaks\n",
-    "    if len(ps) > n_max:\n",
-    "        areas = ps['area']\n",
-    "        max_area = np.sort(areas)[-n_max]\n",
-    "        ps = ps[areas >= max_area]\n",
-    "        \n",
-    "    print(len(ps))\n",
-    "    \n",
-    "    return hv.Overlay(items=[plot_peak(p) for p in ps])\n",
-    "\n",
-    "\n",
-    "def plot_peak_range(x_range, **kwargs):\n",
-    "    # For use in dynamicmap with streams\n",
-    "    if x_range is None:\n",
-    "        x_range = (0, 10)\n",
-    "    return plot_peaks(x_range[0], x_range[1], **kwargs)"
+    " "
    ]
   },
   {
@@ -454,6 +419,13 @@
    "source": [
     "# Combine"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -567,7 +539,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   },
   "toc": {
    "nav_menu": {},

--- a/strax/context.py
+++ b/strax/context.py
@@ -159,6 +159,10 @@ class Context:
         for opt in self.takes_config.values():
             opt.validate(new_config, set_defaults=True)
 
+        for k in new_config:
+            if k not in self.takes_config:
+                warnings.warn(f"Unknown config option {k}; will do nothing.")
+
         self.context_config = new_config
 
         for k in self.context_config:

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -46,7 +46,6 @@ class Plugin:
 
     save_when = SaveWhen.ALWAYS
     parallel = False    # If True, compute() work is submitted to pool
-    save_meta_only = False
 
     # These are set on plugin initialization, which is done in the core
     run_id: str
@@ -314,6 +313,8 @@ class ParallelSourcePlugin(Plugin):
                     self.outputs_to_send.add(d)
                 else:
                     self.sub_savers[d] = savers[d]
+                    for x in self.sub_savers[d]:
+                        x.is_forked = True
                     del savers[d]
 
         mailboxes[self.provides].add_sender(self.iter(

--- a/strax/processor.py
+++ b/strax/processor.py
@@ -25,7 +25,10 @@ class MailboxDict(dict):
 class ThreadedMailboxProcessor:
     mailboxes: ty.Dict[str, strax.Mailbox]
 
-    def __init__(self, components: ProcessorComponents, max_workers=None):
+    def __init__(self,
+                 components: ProcessorComponents,
+                 allow_rechunk=True,
+                 max_workers=None):
         self.log = logging.getLogger(self.__class__.__name__)
         self.components = components
         self.mailboxes = MailboxDict()
@@ -82,6 +85,8 @@ class ThreadedMailboxProcessor:
                     # This is storage conversion mode
                     # TODO: Don't know how to get this info, for now,
                     # be conservative and don't rechunk
+                    rechunk = False
+                if not allow_rechunk:
                     rechunk = False
 
                 from functools import partial

--- a/strax/storage/zipfiles.py
+++ b/strax/storage/zipfiles.py
@@ -30,8 +30,8 @@ class ZipDirectory(strax.StorageFrontend):
         if not osp.exists(path):
             os.makedirs(path)
 
-    def _find(self, key,
-              write, ignore_versions, ignore_config):
+    def _find(self, key, write,
+              allow_incomplete, fuzzy_for, fuzzy_for_options):
         assert not write
 
         # Check exact match / write case
@@ -45,7 +45,7 @@ class ZipDirectory(strax.StorageFrontend):
             except KeyError:
                 pass
 
-            if not ignore_versions and not ignore_config:
+            if not len(fuzzy_for) and not len(fuzzy_for_options):
                 raise strax.DataNotAvailable
 
         raise NotImplementedError("Fuzzy matching within zipfiles not yet "

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -188,7 +188,9 @@ def to_str_tuple(x) -> typing.Tuple[str]:
         return x,
     elif isinstance(x, list):
         return tuple(x)
-    return x
+    elif isinstance(x, tuple):
+        return x
+    raise TypeError(f"Expected string or tuple of strings, got {type(x)}")
 
 
 @export

--- a/strax/xenon/cut_plugins.py
+++ b/strax/xenon/cut_plugins.py
@@ -48,3 +48,15 @@ class S1LowEnergyRange(strax.Plugin):
 class SR1Cuts(strax.MergeOnlyPlugin):
     depends_on = ['fiducial_cylinder_1t', 's1_max_pmt', 's1_low_energy_range']
     save_when = strax.SaveWhen.ALWAYS
+
+
+class FiducialEvents(strax.Plugin):
+    depends_on = ['event_info', 'fiducial_cylinder_1t']
+    data_kind = 'fiducial_events'
+
+    def infer_dtype(self):
+        return strax.merged_dtype([self.deps[d].dtype
+                                   for d in self.depends_on])
+
+    def compute(self, events):
+        return events[events['cut_fiducial_cylinder']]


### PR DESCRIPTION
This includes the strax changes and notebooks used for the demonstration I gave at Coimbra. Specifically:

* A new context option `allow_incomplete`. If set, and the storage backend supports it, it will allow users to load data that has not yet been completely written. When set, all saving is blocked and generates a warning instead, just like for the fuzzy and time range options.
* Support for `allow_incomplete` in the files backend. To enable this, the files backend now writes metadata to disk every chunk, which may cause a tiny slowdown. If a forked saver is used to save the data (e.g. raw_records during DAQ reading) `allow_incomplete` will not work yet.
* Some extra validation of context options: you now get a warning if you specify an unknown option.
* Protection against a common error: trying to set new options by passing a positional-arg dict to get_xxx will now result in an error. The correct way of setting new config options is passing config=dict(...), see the tutorial in the docs.
* Silence numerical warnings in the high-level XENON plugins around the statements where NaNs are known occurrences. These come from design choices like using NaN for cs1 when the event has no valid s1-s2 pair.
* Updated notebooks used in the demo.