### PR TITLE
XENON RunDB Frontend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setuptools.setup(name='strax',
                               'graphviz'],
                      'xenon': ['keras',
                                'tensorflow',
-                               'scipy']
+                               'scipy',
+                               'pymongo',]
                  },
                  long_description_content_type="text/markdown",
                  packages=setuptools.find_packages(),

--- a/strax/storage/s3.py
+++ b/strax/storage/s3.py
@@ -73,7 +73,8 @@ class SimpleS3Store(StorageFrontend):
                                service_name='s3')
 
         # Create bucket (does nothing if exists)
-        self.s3.create_bucket(Bucket=BUCKET_NAME)
+        #self.s3.create_bucket(Bucket=BUCKET_NAME)
+        print(BUCKET_NAME)
 
         # Setup backends for reading
         self.backends = [S3Backend(aws_access_key_id=s3_access_key_id,
@@ -108,6 +109,7 @@ class SimpleS3Store(StorageFrontend):
                 raise strax.DataNotAvailable
 
     def backend_key(self, key_str):
+
         return self.backends[0].__class__.__name__, key_str
 
     def remove(self, key):
@@ -207,6 +209,7 @@ class S3Saver(strax.Saver):
         prefix = f'{self.strax_unique_key}/metadata_'
         objects_list = self.s3.list_objects(Bucket=BUCKET_NAME,
                                             Prefix=prefix)
+
         if 'Contents' in objects_list:
             for file in objects_list['Contents']:
                 # Grab chunk metadata as ASCIII

--- a/strax/xenon/__init__.py
+++ b/strax/xenon/__init__.py
@@ -1,1 +1,2 @@
 from . import common, plugins, cut_plugins, pax_interface       # noqa
+from .rundb import *

--- a/strax/xenon/rundb.py
+++ b/strax/xenon/rundb.py
@@ -68,7 +68,7 @@ class RunDB(strax.StorageFrontend):
                                                                 'meta.lineage': key.lineage}}
                                         })
 
-        if doc is None or len(doc['data']) == 0:
+        if (doc is None) or ('data' not in doc) or (len(doc['data']) == 0):
             if write:
                 return self.backends[-1].__class__.__name__, os.path.join(self.path, str(key))
             else:

--- a/strax/xenon/rundb.py
+++ b/strax/xenon/rundb.py
@@ -58,14 +58,14 @@ class RunDB(strax.StorageFrontend):
 
         query = {'name': key.run_id,
                  'data.type': key.data_type,
-                 '$or': [{'data.protocol': self.backends[0].__class__.__name__}]}
+                 '$or': [{'data.host': 'ceph-s3'}]}
 
         if self.dali:
             query['$or'].append({'data.host': 'dali'})
 
         doc = self.collection.find_one(query,
                                        {'data': {'$elemMatch': {'type': key.data_type,
-                                                                'lineage_hash': key.lineage}}
+                                                                'meta.lineage': key.lineage}}
                                         })
 
         if doc is None or len(doc['data']) == 0:

--- a/strax/xenon/rundb.py
+++ b/strax/xenon/rundb.py
@@ -1,0 +1,86 @@
+import os
+import re
+import socket
+
+import pymongo
+
+import strax
+
+export, __all__ = strax.exporter()
+
+
+@export
+class RunDB(strax.StorageFrontend):
+    """Frontend that searches RunDB MongoDB for data.
+
+    Loads appropriate backends ranging from Files to S3.
+    """
+
+    def __init__(self,
+                 mongo_url,
+                 path='.',
+                 s3_kwargs={},
+                 *args, **kwargs):
+        """
+        You must provide credentials to access your storage element.
+
+        :param s3_access_key_id: access key for S3-readable storage.
+        :param s3_secret_access_key: secret key for S3-readable storage.
+        :param endpoint_url: URL of S3-readable storage.
+
+        For other arguments, see DataRegistry base class.
+        """
+
+        super().__init__(*args, **kwargs)
+
+        self.client = pymongo.MongoClient(mongo_url)
+        self.collection = self.client['xenon1t']['runs']
+
+        self.path = path
+
+        # Setup backends for reading.  Don't change order!
+        self.backends = [
+            strax.S3Backend(**s3_kwargs),
+        ]
+
+        # This mess tries to identify the cluster
+        self.dali = True if re.match('^dali.*rcc.*', socket.getfqdn()) else False
+        if self.dali:
+            self.backends.append(strax.FileSytemBackend())
+
+    def _find(self, key: strax.DataKey, write, fuzzy_for, fuzzy_for_options):
+        """Determine if data exists
+
+        Search the S3 store to see if data is there.
+        """
+        if fuzzy_for or fuzzy_for_options:
+            raise NotImplementedError("Can't do fuzzy with S3")
+
+        query = {'name': key.run_id,
+                 'data.type': key.data_type,
+                 '$or': [{'data.protocol': self.backends[0].__class__.__name__}]}
+
+        if self.dali:
+            query['$or'].append({'data.host': 'dali'})
+
+        doc = self.collection.find_one(query,
+                                       {'data': {'$elemMatch': {'type': key.data_type,
+                                                                'lineage_hash': key.lineage}}
+                                        })
+
+        if doc is None or len(doc['data']) == 0:
+            if write:
+                return self.backends[-1].__class__.__name__, os.path.join(self.path, str(key))
+            else:
+                # If reading and no objects, then problem
+                raise strax.DataNotAvailable
+
+        datum = doc['data'][0]
+
+        if write and not self._can_overwrite(key):
+            raise strax.DataExistsError(at=datum['protocol'])
+
+        return datum['protocol'], datum['location']
+
+    def remove(self, key):
+        raise NotImplementedError()

--- a/strax/xenon/rundb.py
+++ b/strax/xenon/rundb.py
@@ -21,15 +21,6 @@ class RunDB(strax.StorageFrontend):
                  path='.',
                  s3_kwargs={},
                  *args, **kwargs):
-        """
-        You must provide credentials to access your storage element.
-
-        :param s3_access_key_id: access key for S3-readable storage.
-        :param s3_secret_access_key: secret key for S3-readable storage.
-        :param endpoint_url: URL of S3-readable storage.
-
-        For other arguments, see DataRegistry base class.
-        """
 
         super().__init__(*args, **kwargs)
 
@@ -49,12 +40,8 @@ class RunDB(strax.StorageFrontend):
             self.backends.append(strax.FileSytemBackend())
 
     def _find(self, key: strax.DataKey, write, fuzzy_for, fuzzy_for_options):
-        """Determine if data exists
-
-        Search the S3 store to see if data is there.
-        """
         if fuzzy_for or fuzzy_for_options:
-            raise NotImplementedError("Can't do fuzzy with S3")
+            raise NotImplementedError("Can't do fuzzy with RunDB yet.")
 
         query = {'name': key.run_id,
                  'data.type': key.data_type,


### PR DESCRIPTION
(This is XENON-specific, still need to do #48)

This addresses Issue #73.  There is a frontend that looks for data in a run database.  Currently, no default is given, so the MongoURL has to be fed in.  For example:

```
import strax

st = strax.Context(
    storage=strax.xenon.RunDB(mongo_url='mongodb://rundb-rw:XXXXX@rundbcluster-shard-00-00-cfaei.gcp.mongodb.net:27017,rundbcluster-shard-00-01-cfaei.gcp.mongodb.net:27017,rundbcluster-shard-00-02-cfaei.gcp.mongodb.net:27017/test?ssl=true&replicaSet=RunDBCluster-shard-0&authSource=admin&retryWrites=true'),
    register_all=strax.xenon.plugins,
    register=strax.xenon.pax_interface.RecordsFromPax
)

d = st.get_array('170321_0620', 'raw_records')
```

The way it works is by searching the RunDB for data of interest (this is the only RunDB call!).  If a run document exists, then it tries to determine if it knows how to read it.  S3 can be read anywhere.  A fuzzy hacky match is used (like in hax) to determine if you're running on `dali`, where other XENON data is.  At the moment, this interface cannot write RunDB aware.  This is reserved for snax.

This relies on a RunDB mirror hosted through MongoDB Atlas on Google Cloud Platform.  Which data is available can also be seen [here](https://snax-209012.appspot.com).
