### PR TITLE
ParallelSourcePlugin fixes and test

### DIFF
--- a/strax/processor.py
+++ b/strax/processor.py
@@ -121,3 +121,5 @@ class ThreadedMailboxProcessor:
         # which is printed for the user
         if traceback is not None:
             raise exc.with_traceback(traceback)
+
+        self.log.debug("Processing finished")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -77,7 +77,8 @@ def test_filestore():
 
         # The first dir contains peaks.
         # It should have one data chunk (rechunk is on) and a metadata file
-        assert os.listdir(data_dirs[0]) == ['000000', 'metadata.json']
+        assert sorted(os.listdir(data_dirs[0])) \
+               == ['000000', 'metadata.json']
 
         # Check metadata got written correctly.
         metadata = mystrax.get_meta(run_id, 'peaks')

--- a/tests/test_parallelsourceplugin.py
+++ b/tests/test_parallelsourceplugin.py
@@ -1,0 +1,77 @@
+import strax
+import numpy as np
+
+# TODO: these are small modifications of the test helpers in test_core.py
+# Can we avoid duplication somehow?
+n_chunks = 10
+recs_per_chunk = 10
+run_id = '0'
+
+
+class Records(strax.ParallelSourcePlugin):
+    provides = 'records'
+    depends_on = tuple()
+    dtype = strax.record_dtype()
+
+    def compute(self, chunk_i):
+        r = np.zeros(recs_per_chunk, self.dtype)
+        r['time'] = chunk_i
+        r['length'] = 1
+        r['dt'] = 1
+        r['channel'] = np.arange(len(r))
+        return r
+
+    def source_finished(self):
+        return True
+
+    def is_ready(self, chunk_i):
+        return chunk_i < n_chunks
+
+
+class Peaks(strax.Plugin):
+    parallel = True
+    provides = 'peaks'
+    depends_on = ('records',)
+    dtype = strax.peak_dtype()
+
+    def compute(self, records):
+        assert isinstance(records, np.ndarray), \
+            f"Recieved {type(records)} instead of numpy array!"
+        p = np.zeros(len(records), self.dtype)
+        p['time'] = records['time']
+        return p
+
+
+def test_processing():
+    """Test ParallelSource plugin under several conditions"""
+    # TODO: For some reason, with max_workers = 2,
+    # there is a hang at the end
+    # We haven't tested multiprocessing anywhere else,
+    # so we should do that first
+    max_workers = 1
+    for request_peaks in (True, False):
+        for peaks_parallel in (True, False):
+            # for max_workers in (1, 2):
+            Peaks.parallel = peaks_parallel
+            print(f"\nTesting with request_peaks {request_peaks}, "
+                  f"peaks_parallel {peaks_parallel}, "
+                  f"max_workers {max_workers}")
+
+            mystrax = strax.Context(storage=[],
+                                    register=[Records, Peaks])
+            bla = mystrax.get_array(
+                run_id=run_id,
+                targets='peaks' if request_peaks else 'records',
+                max_workers=max_workers)
+            assert len(bla) == recs_per_chunk * n_chunks
+            assert bla.dtype == (
+                strax.peak_dtype() if request_peaks else strax.record_dtype())
+
+
+if __name__ == '__main__':
+    import logging
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='{name} in {threadName} at {asctime}: {message}',
+        style='{')
+    test_processing()


### PR DESCRIPTION
This adds tests for the ParallelSourcePlugin, and should fix issue #97. I think @coderdj originally hit this  issue during the Stockholm strax workshop, and @tunnell has been seeing it during the SR1 conversion.

ParallelSourcePlugins (see docs: https://strax.readthedocs.io/en/latest/developer/parallel.html#parallelsourceplugin) inline other plugins, so they have multiple outputs. They need an intermediate mailbox to stage these outputs to. Unfortunately, this mailbox was named after the original plugin, which clashed with the mailbox used for outputting the data the original plugin produced (e.g. raw_records). If that data was needed anywhere else, e.g. as the final target, strange stuff would happen.

I could not get my test to run with multiprocessing activated. Since multiprocessing isn't tested anywhere else, and we know it has other issues anyway (#92), I've left this for later.