### PR TITLE
Several bugfixes in peak processing

### DIFF
--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -164,7 +164,7 @@ def sum_waveform(peaks, records, adc_to_pe, n_channels=248):
             assert r_end > r_start
             
             max_in_record = r['data'][r_start:r_end].max()
-            p['saturated_channel'][ch] = int(max_in_record < r['baseline'])
+            p['saturated_channel'][ch] = int(max_in_record >= r['baseline'])
 
             # TODO Do we need .astype(np.int32).sum() ??
             p['area_per_channel'][ch] += r['data'][r_start:r_end].sum()

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -153,6 +153,11 @@ def sum_waveform(peaks, records, adc_to_pe, n_channels=248):
                 # we've seen all overlapping records
                 break
 
+            if n_r <= s:
+                # Only the zero-padded part of the record coincidentally
+                # overlaps with the peak, so this is not part of it
+                continue
+
             # Range of record that contributes to peak
             r_start = max(0, s)
             r_end = min(n_r, s + n_p)

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -75,4 +75,4 @@ def compute_widths(peaks):
     fr_times *= peaks['dt'].reshape(-1, 1)
 
     i = len(desired_fr) // 2
-    peaks['width'][:, 1:] = fr_times[:, i:] - fr_times[:, :i]
+    peaks['width'][:, 1:] = fr_times[:, i:] - fr_times[:, ::-1][:, i:]

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -243,3 +243,15 @@ def formatted_exception():
         # There was no relevant exception to record
         return ''
     return traceback.format_exc()
+
+def print_entry(d, n=0, show_data=False):
+    """ Print entry number n in human-readable format.
+    Default behavior is to skip the entry 'data' since it clutters output.
+    """
+    # Check what number of spaces required for nice alignment
+    max_len = np.max([len(key) for key in d.dtype.names])
+    el = d[n]
+    for key in d.dtype.names:
+        if (show_data or key != 'data'):
+            print(("{:<%d}: " % max_len).format(key), el[key])
+    return


### PR DESCRIPTION
Errors appeared in a rare situation where the zero-padded part of a record overlaps with a peak, causing a nonphysical selection range. 'Lucky'  enough this situation was not so rare in XAMS-type data :) I believe the right behavior is a ''continue'' meaning to skip this record in the peak consideration.