### PR TITLE
Adjust file naming convention

### DIFF
--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -76,122 +76,6 @@ class DataCorrupted(Exception):
 class RunMetadataNotAvailable(Exception):
     pass
 
-@export
-class NameingFail(Exception):
-    """Raise a naming failure when keywords can not identified from a source"""
-    pass
-
-@export
-class NamingConvention():
-    """Semi hardcoded naming convention for the chunks files and metadata files"""
-
-    def __init__(self, keywords=[], filetype=None, seperator="-"):
-        """
-        :param keywords: Expect a list of strings to define a string
-        with 'empty keywords' which is ready for filling. For example:
-        keywords = ['a', 'b'] -> "{a}-{b}-"
-        :param filetype: Define which purpose the naming convention follows:
-          - filetype = None: Used for chunk name convention
-          - filetype = 'meta': Used to define the metadata file name
-        :param seperator: The standard seperator between keywords is '-'.
-        You might change it on purpose.
-        """
-        self.super_keyword_dict = {}
-        self.key_w = ""
-        self.gkeyword_definition = keywords
-        self.filetype = filetype
-        self.seperator = seperator
-        
-    def get_metadata_name(self, gkeyword_dict = []):
-        
-        self.create_name()
-        
-        if len(self.gkeyword_definition) == 0:
-            return self.key_w
-        
-        for idict in gkeyword_dict:
-            self.keyword_dict(idict)
-        
-        self.keyword_fill()
-        
-        return self.key_w
-        
-    def create_name(self):
-        #build the name convention:
-        for i, key_val in enumerate(self.gkeyword_definition):
-            if len(key_val) > 0:
-                self.key_w+= "{"+key_val+"}"
-            if i < len(self.gkeyword_definition)-1:
-                self.key_w+= self.seperator
-        #if the filetype is 'meta' we add a 'metadata.json' to point out that we store
-        #metadata here:
-        if self.filetype is 'meta':
-            self.key_w+=self.seperator+"metadata.json"
-
-    def keyword_dict(self, keydict):
-        """
-        This member function takes one dictionary of keywords. Call it
-        once more in a row will join the dictionaries. It allow you to
-        gather information from different sources (database, json file,...)
-        before you start to fill the keyword string.
-        """
-        
-        if not self.super_keyword_dict:
-            self.super_keyword_dict = keydict
-        else:
-            #works for python >=3.5
-            self.super_keyword_dict = {**self.super_keyword_dict, **keydict}
-
-    def keyword_fill(self):
-        """
-        Fill keyword string from given dictionaries. That is similar to 
-        the pre-defined function *.format() in Python with the difference
-        that it does not fill out missing keywords.
-        You can create strings like:
-          - keyword string: {a}-{b}-{c}
-          - dictionary information: {'a': 'a1', 'b':'b1'}
-        which results: a1-b1-{c}
-        """
-        
-        #identify the positions of the keyword locations in the string
-        dekbeg = [pos for pos, char in enumerate(self.key_w) if char == "{"]
-        dekend = [pos for pos, char in enumerate(self.key_w) if char == "}"]
-        
-        #loop over identified keywords to get the strings to replace them with:
-        identified_keywords = {}
-        for ibeg, iend in zip(dekbeg, dekend):
-            
-            i_key_w = self.key_w[ibeg+1:iend]
-            
-            i_key_value = ""
-            if i_key_w in self.super_keyword_dict:
-                i_key_value = self.super_keyword_dict[i_key_w]
-            
-            identified_keywords[i_key_w]=i_key_value
-        
-        #replace the identified keywords with the found strings:
-        for key, val in identified_keywords.items():
-            if len(val) > 0:
-                self.key_w=self.key_w.replace("{"+str(key)+"}", val)
-
-@export
-class MetaDataName(NamingConvention):
-    """
-    Define your metadata filename structure here and be ready
-    to fill it with information later
-    """
-    def Init(self):
-        self.nm = NamingConvention(keywords=["plugin_name", "hash_name"], filetype='meta')
-        return self.nm
-@export
-class FileDataName(NamingConvention):
-    """
-    Define your chunk filename structure here and be ready
-    to fill it with information later
-    """
-    def Init(self):
-        self.nm = NamingConvention(keywords=["plugin_name", "hash_name", "chunk_name"], filetype=None)
-        return self.nm
 
 @export
 class StorageFrontend:
@@ -560,7 +444,7 @@ class Saver:
                     "complete in time!")
         else:
             pass
-                    
+
         self.closed = True
 
         exc_info = strax.formatted_exception()

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -147,6 +147,12 @@ class DataDirectory(StorageFrontend):
 
 
 @export
+def dirname_to_prefix(dirname):
+    """Return filename prefix from dirname"""
+    return os.path.basename(dirname.strip('/')).split("-", maxsplit=1)[1]
+
+
+@export
 class FileSytemBackend(strax.StorageBackend):
     """Store data locally in a directory of binary files.
 
@@ -155,7 +161,7 @@ class FileSytemBackend(strax.StorageBackend):
     """
 
     def get_metadata(self, dirname):
-        prefix =  os.path.basename(dirname).split("-", maxsplit=1)[1]
+        prefix = dirname_to_prefix(dirname)
         metadata_json = f'{prefix}-metadata.json'
         with open(osp.join(dirname, metadata_json), mode='r') as f:
             return json.loads(f.read())
@@ -199,9 +205,9 @@ class FileSaver(strax.Saver):
         super().__init__(metadata)
         self.dirname = dirname
         self.tempdirname = dirname + '_temp'
-        self.prefix = os.path.basename(dirname).split("-", maxsplit=1)[1]
+        self.prefix = dirname_to_prefix(dirname)
         self.metadata_json = f'{self.prefix}-metadata.json'
-        
+
         if os.path.exists(dirname):
             print(f"Removing data in {dirname} to overwrite")
             shutil.rmtree(dirname)
@@ -218,7 +224,6 @@ class FileSaver(strax.Saver):
     def _save_chunk(self, data, chunk_info):
         ichunk = '%06d' % chunk_info['chunk_i']
         filename = f'{self.prefix}-{ichunk}'
-        #filename = self.filedata.format(chunk_name = '%06d' % chunk_info['chunk_i'])
         filesize = strax.save_file(
             os.path.join(self.tempdirname, filename),
             data=data,

--- a/strax/storage/zipfiles.py
+++ b/strax/storage/zipfiles.py
@@ -38,7 +38,9 @@ class ZipDirectory(strax.StorageFrontend):
         bk = self._backend_key(key)
         with zipfile.ZipFile(self._zipname(key)) as zp:
             try:
-                zp.getinfo(str(key) + '/metadata.json')
+                dirname = str(key)
+                prefix = strax.dirname_to_prefix(dirname)
+                zp.getinfo(f'{dirname}/{prefix}-metadata.json')
                 return bk
             except KeyError:
                 pass
@@ -110,7 +112,8 @@ class ZipFileBackend(strax.StorageBackend):
     def get_metadata(self, zipn_and_dirn):
         zipn, dirn = zipn_and_dirn
         with zipfile.ZipFile(zipn) as zp:
-            with zp.open(dirn + '/metadata.json') as f:
+            prefix = strax.dirname_to_prefix(dirn)
+            with zp.open(f'{dirn}/{prefix}-metadata.json') as f:
                 return json.loads(f.read())
 
     def saver(self, *args, **kwargs):


### PR DESCRIPTION
My suggestion is to adjust the XENONnT naming convention to get unique file names. My implementation takes the information about the file name convention simply from directory (dirname) information at the level of the backend.
To get a clean solution we may improve later the frontend-backend communication to get all necessary from the database itself (or a similar interface).
I tested running a  simple STRAX script which processed several plugins on the fly to get a high-level dataframe back. The data structure looks good to me.

@JelleAalbers I choose to write the "more complicated" looking NameConvention class in order to be able to create a string from keywords with the freedom of simply handing dictionaries over to fill out such keywords (similar to *.format() in Python) but do not relay on the requirement of passing a full keyword list. Maybe over-archiving but quite handy.