### PR TITLE
Stabilize and shorten lineage hash 

### DIFF
--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -108,6 +108,8 @@ class Plugin:
             data_type=self.provides,
             data_kind=self.data_kind,
             dtype=self.dtype,
+            lineage_hash=strax.DataKey(run_id, self.provides, self.lineage
+                                       ).lineage_hash,
             compressor=self.compressor,
             lineage=self.lineage)
 

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -1,11 +1,12 @@
+from base64 import b32encode
 import contextlib
 from functools import wraps
+import json
 import re
 import sys
 import traceback
 import typing
 from hashlib import sha1
-import pickle
 
 import numpy as np
 import numba
@@ -45,12 +46,6 @@ def inherit_docstring_from(cls):
         fn.__doc__ = getattr(cls, fn.__name__).__doc__
         return fn
     return docstring_inheriting_decorator
-
-
-@export
-def records_needed(pulse_length, samples_per_record):
-    """Return records needed to store pulse_length samples"""
-    return 1 + (pulse_length - 1) // samples_per_record
 
 
 @export
@@ -230,10 +225,12 @@ def hashablize(obj):
 
 
 @export
-def deterministic_hash(thing):
-    """Return a deterministic hash of a container hierarchy using hashablize,
-    pickle and sha1"""
-    return sha1(pickle.dumps(hashablize(thing))).hexdigest()
+def deterministic_hash(thing, length=10):
+    """Return a base32 lowercase string of length determined from hashing
+    a container hierarchy
+    """
+    digest = sha1(json.dumps(hashablize(thing)).encode('ascii')).digest()
+    return b32encode(digest)[:length].decode('ascii').lower()
 
 
 @export


### PR DESCRIPTION
This replaces the algorithm by which strax computes the hash of the data lineage. Since the hash is part of the key for looking up data, it has implications for previously produced strax data.


Changes to hash algorithm
-----------------------------
  1. Instead of ` pickle.dumps(x)`, `json.encode(x, sort_keys=True).encode('ascii')` is used to transform the lineage into bytes (after converting it to immutables, i.e. lists -> tuples). We found out pickle's output can depend on the reference counting of the objects to be hashed (see [here](https://stackoverflow.com/questions/45015180) and [here](http://www.aminus.org/blogs/index.php/2007/11/03/pickle_dumps_not_suitable_for_hashing?blog=2)). This would have meant, for example, that future strax versions might not have found data created by past strax versions, and that strax data would not be interchangeable between python versions that have a different pickle algorithm. Clearly this is unacceptable.
  2. Instead of 40 hexadecimal characters, we return the first 10 characters of the binary digest encoded in [base32](https://tools.ietf.org/html/rfc3548.html#section-5), lowercased. This results in much shorter filenames. Even if we process a run in 10^5 different ways, the probability of a collision is only ~4e-6 (using the formula [here](https://en.wikipedia.org/wiki/Birthday_problem#Cast_as_a_collision_problem) with n=1e5 and d=32**10), which seems acceptable.

Implications for old strax data
--------------------------------

Unfortunately any change in the hashing algorithm means **all strax data has to be renamed** in order to remain readable. To be specific, we have to recompute the hash according to the new algorithm, then rename at least the directory (and, for data produced after #143, the metadata.json file).

Here is some code that fixes all strax data in a directory (e.g. /dali/lgrandi/aalbers/strax_data_raw) to the new format. It should work on both pre-#143 and post-#143 data

```python
import glob
import json
import os
import os.path as osp

import strax

data_dir = '/dali/lgrandi/aalbers/strax_data'

for dirname in glob.glob(data_dir + '/*'):
    if not osp.isdir(dirname):
        continue
    
    # Load metadata
    md = glob.glob(dirname + '/*metadata*')
    if not len(md):
        print(f"Skipping dir {dirname}, "
               "didn't find metadata.json")
        continue
    md_filename = md[0]
    with open(md_filename) as f:
        md = json.load(f)
    
    key = strax.deterministic_hash(md['lineage'])
    dt = md['data_type']

    # Rename chunks
    for x in md['chunks']:
        new_fn = '-'.join([dt, key, '%06d' % x['chunk_i']])
        os.rename(
            osp.join(dirname, x['filename']),
            osp.join(dirname, new_fn))
        x['filename'] = new_fn
        
    # Write new metadata file
    md['lineage_hash'] = key
    new_mdfn = osp.join(dirname, 
                        '-'.join([dt, key, 'metadata.json']))
    with open(new_mdfn, mode='w') as f:
        json.dump(md, f)

    # If metadata filename changed, delete the old file
    if new_mdfn != md_filename:
        os.remove(md_filename)
        
    # Finally, rename the directory
    os.rename(dirname,
              osp.join(
                  osp.dirname(dirname), 
                  '-'.join([md['run_id'], dt, key])))
```

A typical strax filename will now be `180215_1035-raw_records-7k65yaooed/raw_records-7k65yaooed-000092`. Notice the data type and key are still included in the filename as well as the dirname, to ensure each file in a run has a unique name (see #143).
