### PR TITLE
Pulse processing upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Streaming analysis for xenon experiments
 [![Coverage Status](https://coveralls.io/repos/github/AxFoundation/strax/badge.svg?branch=master)](https://coveralls.io/github/AxFoundation/strax?branch=master)
 [![PyPI version shields.io](https://img.shields.io/pypi/v/strax.svg)](https://pypi.python.org/pypi/strax/)
 [![Join the chat at https://gitter.im/AxFoundation/strax](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/AxFoundation/strax?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/cc159474f2764d43b445d562a24ca245)](https://www.codacy.com/app/tunnell/strax?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=AxFoundation/strax&amp;utm_campaign=Badge_Grade)
 
 Strax is an analysis framework for pulse-only digitization data, specialized for live data reduction at speeds of 50-100 MB(raw) / core / sec. For more information, please see the [strax documentation](https://strax.readthedocs.io).
 

--- a/strax/context.py
+++ b/strax/context.py
@@ -600,6 +600,7 @@ class Context:
         for x in strax.ThreadedMailboxProcessor(
                 components,
                 max_workers=max_workers,
+                allow_shm=self.context_config['allow_shm'],
                 allow_rechunk=self.context_config['allow_rechunk']).iter():
             if selection is not None:
                 mask = numexpr.evaluate(selection, local_dict={

--- a/strax/processing/data_reduction.py
+++ b/strax/processing/data_reduction.py
@@ -50,7 +50,7 @@ def cut_baseline(records, n_before=48, n_after=30):
 
 
 def cut_outside_hits(records, hits, left_extension=2, right_extension=15):
-    """Return records with waveforms zerosed if not within
+    """Return records with waveforms zeroed if not within
     left_extension or right_extension of hits.
     These extensions properly account for breaking of pulses into records.
 

--- a/strax/processing/data_reduction.py
+++ b/strax/processing/data_reduction.py
@@ -3,7 +3,7 @@ import numpy as np
 import numba
 from enum import IntEnum
 
-from strax.processing.pulse_processing import NOT_APPLICABLE, record_links
+from strax.processing.pulse_processing import NO_RECORD_LINK, record_links
 from strax.processing.peak_building import find_peaks
 from .general import fully_contained_in
 from strax.dtypes import peak_dtype
@@ -106,7 +106,7 @@ def _cut_outside_hits(records, hits, new_recs,
         # Keep samples in previous record, if there was one
         if start_keep < 0:
             prev_ri = previous_record[rec_i]
-            if prev_ri != NOT_APPLICABLE:
+            if prev_ri != NO_RECORD_LINK:
                 # Note start_keep is negative, so this keeps the
                 # last few samples of the previous record
                 a = start_keep
@@ -116,7 +116,7 @@ def _cut_outside_hits(records, hits, new_recs,
         # Same for the next record
         if end_keep > samples_per_record:
             next_ri = next_record[rec_i]
-            if next_ri != NOT_APPLICABLE:
+            if next_ri != NO_RECORD_LINK:
                 b = end_keep - samples_per_record
                 new_recs[next_ri]['data'][:b] = records[next_ri]['data'][:b]
 

--- a/strax/processing/pulse_processing.py
+++ b/strax/processing/pulse_processing.py
@@ -144,11 +144,12 @@ def find_hits(records, threshold=15, _result_buffer=None):
         # print("Starting record ', record_i)
         in_interval = False
         hit_start = -1
+        area = 0
 
-        for i in range(samples_per_record):
+        for i, x in enumerate(r['data']):
             # We can't use enumerate over r['data'], numba gives error
             # TODO: file issue?
-            above_threshold = r['data'][i] > threshold
+            above_threshold = x > threshold
             # print(r['data'][i], above_threshold, in_interval, hit_start)
 
             if not in_interval and above_threshold:
@@ -166,7 +167,11 @@ def find_hits(records, threshold=15, _result_buffer=None):
                     # Hit ends at the *end* of this sample
                     # (because the record ends)
                     hit_end = i + 1
+                    area += x
                     in_interval = False
+
+                else:
+                    area += x
 
                 if not in_interval:
                     # print('saving hit')
@@ -184,6 +189,8 @@ def find_hits(records, threshold=15, _result_buffer=None):
                     res['dt'] = r['dt']
                     res['channel'] = r['channel']
                     res['record_i'] = record_i
+                    res['area'] = area
+                    area = 0
 
                     # Yield buffer to caller if needed
                     offset += 1
@@ -195,7 +202,6 @@ def find_hits(records, threshold=15, _result_buffer=None):
                     # hit_start = 0
                     # hit_end = 0
     yield offset
-
 
 def filter_records(r, ir):
     """Apply filter with impulse response ir over the records r.

--- a/tests/test_pulse_processing.py
+++ b/tests/test_pulse_processing.py
@@ -15,6 +15,9 @@ def _find_hits(r):
     # NB: exclusive right bound, no + 1 here
     np.testing.assert_equal(hits['length'],
                             hits['right'] - hits['left'])
+    for h in hits:
+        q = r[h['record_i']]
+        assert q['data'][h['left']:h['right']].sum() == h['area']
     return list(zip(hits['left'], hits['right']))
 
 

--- a/tests/test_pulse_processing.py
+++ b/tests/test_pulse_processing.py
@@ -72,6 +72,7 @@ def test_filter_waveforms():
     """
     wv = np.random.randn(300)
     ir = np.random.randn(41)
+    ir[10] += 10   # Because it crashes for max at edges
     origin = np.argmax(ir) - (len(ir)//2)
     wv_after = convolve1d(wv, ir,
                           mode='constant',

--- a/tests/test_pulse_processing.py
+++ b/tests/test_pulse_processing.py
@@ -1,9 +1,10 @@
+from .helpers import single_fake_pulse
+
 import numpy as np
 from hypothesis import given
 from scipy.ndimage import convolve1d
 
 import strax
-from .helpers import single_fake_pulse
 
 
 def _find_hits(r):
@@ -61,17 +62,20 @@ def test_find_hits_randomize(records):
         assert not np.any(w[l_:r_] == 1)
 
 
-def test_filter_records():
+def test_filter_waveforms():
     """Test that filter_records gives the same output
     as a simple convolution applied to the original pulse
     (before splitting into records)
     """
     wv = np.random.randn(300)
-    ir = np.random.randn(40)
-    wv_after = convolve1d(wv, ir, mode='constant')
+    ir = np.random.randn(41)
+    origin = np.argmax(ir) - (len(ir)//2)
+    wv_after = convolve1d(wv, ir,
+                          mode='constant',
+                          origin=origin)
 
     wvs = wv.reshape(3, 100)
-    wvs = strax.filter_records(
+    wvs = strax.filter_waveforms(
         wvs, ir,
         prev_r=np.array([strax.NO_RECORD_LINK, 0, 1]),
         next_r=np.array([1, 2, strax.NO_RECORD_LINK]))

--- a/tests/test_pulse_processing.py
+++ b/tests/test_pulse_processing.py
@@ -1,5 +1,6 @@
 import numpy as np
 from hypothesis import given
+from scipy.ndimage import convolve1d
 
 import strax
 from .helpers import single_fake_pulse
@@ -58,3 +59,22 @@ def test_find_hits_randomize(records):
         l_ = results[i][1]
         r_ = results[i + 1][0]
         assert not np.any(w[l_:r_] == 1)
+
+
+def test_filter_records():
+    """Test that filter_records gives the same output
+    as a simple convolution applied to the original pulse
+    (before splitting into records)
+    """
+    wv = np.random.randn(300)
+    ir = np.random.randn(40)
+    wv_after = convolve1d(wv, ir, mode='constant')
+
+    wvs = wv.reshape(3, 100)
+    wvs = strax.filter_records(
+        wvs, ir,
+        prev_r=np.array([strax.NO_RECORD_LINK, 0, 1]),
+        next_r=np.array([1, 2, strax.NO_RECORD_LINK]))
+    wv_after_2 = np.reshape(wvs, -1)
+
+    assert np.abs(wv_after - wv_after_2).sum() < 1e-9


### PR DESCRIPTION
  * Add `zero_outside_bounds`, which sets record waveforms to zero where they do not represent real data. For example, for 100-sample pulse stored in a 110-sample record, it will zero the final ten samples. Not doing this (and instead relying on the DAQ + `strax.baseline` to do it) may have contributed to some problems with the data reduction algorithms we saw during the latest DAQ test.
  * Add `filter_records`, which allows linear filtering of waveforms, e.g. to improve signal/noise or sharpen the pulses for better data reduction. It takes account of the fact that pulses are split over multiple records, by applying the convolution multiple times with different filter shifts (for the parts of the record for which this is needed). The convolutions is applied outside of numba, using `scipy.ndimage.convolve1d`, since I was too lazy to code up my own convolution loop + tests. Note at least one old version of scipy has a bug where this segfaults at extreme shifts of the filter (it works fine in v1.2.1, but I had to upgrade).
  * Replace `cut_outside_hits` with a somewhat faster version. The function remains without tests for the moment, unfortunately.