### PR TITLE
Run selection and run-level metadata handling, multi-run loading

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ psutil==5.4.8
 numexpr==2.6.9
 boto3==1.9.78
 npshmex==0.1.2
+pymongo

--- a/strax/context.py
+++ b/strax/context.py
@@ -829,21 +829,23 @@ class Context:
                                         for t in doc.get('tags', [])])
 
                 _temp_docs.append(doc)
+                
+            if len(_temp_docs):
+                new_docs = pd.DataFrame(_temp_docs)
+            else:
+                new_docs = pd.DataFrame([], columns=store_fields)
 
-            new_docs = pd.DataFrame(_temp_docs)
             if docs is None:
                 docs = new_docs
             else:
                 # Keep only new runs (not found by earlier frontends)
-                docs = pd.merge(
+                docs = pd.concat([
                     docs,
-                     new_docs[
-                         ~np.in1d(new_docs['name'], docs['name'])])
+                    new_docs[
+                        ~np.in1d(new_docs['name'], docs['name'])]],
+                    sort=False)
 
-        if len(docs):
-            self.runs = pd.DataFrame(docs)
-        else:
-            self.runs = pd.DataFrame([], columns=['name'])
+        self.runs = docs
 
         for d in tqdm(check_available,
                       desc='Checking data availability'):

--- a/strax/context.py
+++ b/strax/context.py
@@ -573,7 +573,7 @@ class Context:
 
     def get_iter(self, run_id: str,
                  targets, save=tuple(), max_workers=None,
-                 time_range=None, 
+                 time_range=None,
                  seconds_range=None,
                  selection=None,
                  **kwargs) -> ty.Iterator[np.ndarray]:
@@ -591,7 +591,7 @@ class Context:
 
         if isinstance(selection, (list, tuple)):
             selection = ' & '.join(f'({x})' for x in selection)
-            
+
         # Convert relative to absolute time range
         if seconds_range is not None:
             try:
@@ -803,7 +803,8 @@ class Context:
         """
         store_fields = tuple(set(
             list(store_fields)
-            + [self.context_config['run_mode_field'], 'tags']
+            + [self.context_config['run_mode_field'],
+               'name', 'number', 'tags']
             + list(self.context_config['store_run_fields'])))
         check_available = tuple(set(
             list(check_available)
@@ -814,12 +815,16 @@ class Context:
             _temp_docs = []
             for doc in sf._scan_runs(store_fields=store_fields):
                 # If there is no number, make one from the name
-                if 'number' not in doc and 'name' in doc:
+                if 'number' not in doc:
+                    if 'name' not in doc:
+                        raise ValueError(f"Invalid run doc {doc}, contains "
+                                         f"neither name nor number.")
                     doc['number'] = int(doc['name'])
+
 
                 # If there is no name, make one from the number
                 doc.setdefault('name', str(doc['number']))
-                
+
                 # Set run mode to empty string if unknown
                 doc.setdefault(self.context_config['run_mode_field'],
                                '')
@@ -829,7 +834,7 @@ class Context:
                                         for t in doc.get('tags', [])])
 
                 _temp_docs.append(doc)
-                
+
             if len(_temp_docs):
                 new_docs = pd.DataFrame(_temp_docs)
             else:

--- a/strax/context.py
+++ b/strax/context.py
@@ -1,15 +1,18 @@
+from concurrent.futures import ProcessPoolExecutor, as_completed
 import collections
 import logging
-from functools import partial
 import fnmatch
+from functools import partial
+import random
+import re
+import string
 import typing as ty
 import warnings
-import random
-import string
 
+import numexpr
 import numpy as np
 import pandas as pd
-import numexpr
+from tqdm import tqdm
 
 import strax
 export, __all__ = strax.exporter()
@@ -36,8 +39,16 @@ export, __all__ = strax.exporter()
     strax.Option(name='forbid_creation_of', default=tuple(),
                  help="If any of the following datatypes is requested to be "
                       "created, throw an error instead. Useful to limit "
-                      "descending too far into the dependency graph.")
-)
+                      "descending too far into the dependency graph."),
+    strax.Option(name='store_run_fields', default=tuple(),
+                 help="Tuple of run document fields to store "
+                      "during scan_run."),
+    strax.Option(name='check_available', default=tuple(),
+                 help="Tuple of data types to scan availability for "
+                      "during scan_run."),
+    strax.Option(name='run_mode_field', default='mode',
+                 help="Name of the field in the run doc that describes the"
+                      '"mode" of the run (used in run selection)'))
 @export
 class Context:
     """Context for strax analysis.
@@ -50,6 +61,8 @@ class Context:
     """
     config: dict
     context_config: dict
+
+    runs: ty.Union[pd.DataFrame, type(None)] = None
 
     def __init__(self,
                  storage=None,
@@ -636,7 +649,8 @@ class Context:
             return np.concatenate(results)
         raise ValueError("Not a single chunk returned?")
 
-    def get_df(self, run_id: str, targets, save=tuple(), max_workers=None,
+    def get_df(self, run_id: ty.Union[str, tuple],
+               targets, save=tuple(), max_workers=None,
                **kwargs) -> pd.DataFrame:
         """Compute target for run_id and return as pandas DataFrame
         {get_docs}
@@ -692,26 +706,6 @@ class Context:
         raise strax.DataNotAvailable(f"No run-level metadata available "
                                      f"for {run_id}")
 
-    def list_available(self, target, **kwargs):
-        """Return sorted list of run_id's for which target is available
-        """
-        # TODO duplicated code with with get_iter
-        if len(kwargs):
-            # noinspection PyMethodFirstArgAssignment
-            self = self.new_context(**kwargs)
-
-        # The run_id is ignored in list_available, but we still use it for
-        # passing data type and lineage to the search functions.
-        # We choose 0 as placeholder since as of this writing strax
-        # requires run_ids to be int-able strings...
-        # TODO: this should change soon
-        key = self._key_for('0', target)
-
-        found_runs = []
-        for sf in self.storage:
-            found_runs += sf.list_available(key, **self._find_options)
-        return sorted(list(set(found_runs)))
-
     def is_stored(self, run_id, target, **kwargs):
         """Return whether data type target has been saved for run_id
         through any of the registered storage frontends.
@@ -735,6 +729,163 @@ class Context:
                 continue
         return False
 
+    def list_available(self, target, **kwargs):
+        """Return sorted list of run_id's for which target is available
+        """
+        # TODO duplicated code with with get_iter
+        if len(kwargs):
+            # noinspection PyMethodFirstArgAssignment
+            self = self.new_context(**kwargs)
+
+        # The run_id is ignored in list_available, but we still use it for
+        # passing data type and lineage to the search functions.
+        # We choose 0 as placeholder since as of this writing strax
+        # requires run_ids to be int-able strings...
+        # TODO: this should change soon
+        key = self._key_for('0', target)
+
+        found_runs = []
+        for sf in self.storage:
+            found_runs += sf.list_available(key, **self._find_options)
+        return sorted(list(set(found_runs)))
+
+    def scan_runs(self,
+                  check_available=tuple(),
+                  store_fields=tuple()):
+        """Update and return self.runs with runs currently available
+        in all storage frontends.
+        :param check_available: Check whether these data types are available
+        Availability of xxx is stored as a boolean in the xxx_available
+        column.
+        :param store_fields: Additional fields from run doc to include
+        as rows in the dataframe.
+
+        The context options scan_availability and store_run_fields list
+        data types and run fields, respectively, that will always be scanned.
+        """
+        store_fields = tuple(list(store_fields)
+                             + list(self.context_config['store_run_fields']))
+        check_available = tuple(list(check_available)
+                             + list(self.context_config['check_available']))
+
+        docs = None
+        for sf in self.storage:
+            _temp_docs = []
+            for doc in sf._scan_runs(store_fields=store_fields):
+                # If there is no number, make one from the name
+                if 'number' not in doc and 'name' in doc:
+                    doc['number'] = int(doc['name'])
+
+                # If there is no name, make one from the number
+                doc.setdefault('name', str(doc['number']))
+
+                # Flatten the tags fields, if it exists
+                if 'tags' in doc:
+                    doc['tags'] = ','.join([t['name']
+                                            for t in doc.get('tags', [])])
+                    doc = strax.flatten_dict(doc, separator='__')
+
+                _temp_docs.append(doc)
+
+            new_docs = pd.DataFrame(_temp_docs)
+            if docs is None:
+                docs = new_docs
+            else:
+                # Keep only new runs (not found by earlier frontends)
+                docs = pd.merge(
+                    docs,
+                     new_docs[
+                         ~np.in1d(new_docs['name'], docs['name'])])
+
+        self.runs = pd.DataFrame(docs)
+
+        # Set some fields we need later, in case they are not present
+        for fn in ['tags', 'run_mode_field']:
+            if fn not in self.runs.columns:
+                self.runs[fn] = ''
+
+        for d in tqdm(check_available,
+                      desc='Checking data availability'):
+            self.runs[d + '_available'] |= np.in1d(
+                self.runs.name.values,
+                self.list_available(d))
+
+        return self.runs
+
+    def run_selection(self, run_mode=None,
+                      include_tags=None, exclude_tags=None,
+                      available=tuple(),
+                      pattern_type='fnmatch', ignore_underscore=True):
+        """Return pandas.DataFrame with basic info from runs
+        that match selection criteria.
+        :param run_mode: Pattern to match run modes (reader.ini.name)
+        :param available: str or tuple of strs of data types for which data
+        must be available according to the runs DB.
+
+        :param include_tags: String or list of strings of patterns
+            for required tags
+        :param exclude_tags: String / list of strings of patterns
+            for forbidden tags.
+            Exclusion criteria  have higher priority than inclusion criteria.
+        :param pattern_type: Type of pattern matching to use.
+            Defaults to 'fnmatch', which means you can use
+            unix shell-style wildcards (`?`, `*`).
+            The alternative is 're', which means you can use
+            full python regular expressions.
+        :param ignore_underscore: Ignore the underscore at the start of tags
+            (indicating some degree of officialness or automation).
+
+        Examples:
+         - `run_selection(include_tags='blinded')`
+            select all datasets with a blinded or _blinded tag.
+         - `run_selection(include_tags='*blinded')`
+            ... with blinded or _blinded, unblinded, blablinded, etc.
+         - `run_selection(include_tags=['blinded', 'unblinded'])`
+            ... with blinded OR unblinded, but not blablinded.
+         - `run_selection(include_tags='blinded', exclude_tags=['bad', 'messy'])`
+           select blinded dsatasets that aren't bad or messy
+        """
+        if self.runs is None:
+            self.scan_runs()
+        dsets = self.runs.copy()
+
+        if pattern_type not in ('re', 'fnmatch'):
+            raise ValueError("Pattern type must be 're' or 'fnmatch'")
+
+        if run_mode is not None:
+            modes = dsets[self.context_config['run_mode_field']].values
+            mask = np.zeros(len(modes), dtype=np.bool_)
+            if pattern_type == 'fnmatch':
+                for i, x in enumerate(modes):
+                    mask[i] = fnmatch.fnmatch(x, run_mode)
+            elif pattern_type == 're':
+                for i, x in enumerate(modes):
+                    mask[i] = bool(re.match(run_mode, x))
+            dsets = dsets[mask]
+
+        if include_tags is not None:
+            dsets = dsets[_tags_match(dsets,
+                                      include_tags,
+                                      pattern_type,
+                                      ignore_underscore)]
+
+        if exclude_tags is not None:
+            dsets = dsets[True ^ _tags_match(dsets,
+                                             exclude_tags,
+                                             pattern_type,
+                                             ignore_underscore)]
+
+        have_available = strax.to_str_tuple(available)
+        for d in have_available:
+            if not d + '_available' in dsets.columns:
+                # Get extra availability info from the run db
+                self.runs[d + '_available'] = np.in1d(
+                    self.runs.name.values,
+                    self.list_available(d))
+            dsets = dsets[dsets[d + '_available']]
+
+        return dsets
+
 
 get_docs = """
 :param run_id: run id to get
@@ -753,3 +904,29 @@ for attr in dir(Context):
         doc = attr_val.__doc__
         if doc is not None and '{get_docs}' in doc:
             attr_val.__doc__ = doc.format(get_docs=get_docs)
+
+
+def _tags_match(dsets, patterns, pattern_type, ignore_underscore):
+    result = np.zeros(len(dsets), dtype=np.bool)
+
+    if isinstance(patterns, str):
+        patterns = [patterns]
+
+    for i, tags in enumerate(dsets.tags):
+        result[i] = any([any([_tag_match(tag, pattern,
+                                         pattern_type,
+                                         ignore_underscore)
+                              for tag in tags.split(',')
+                              for pattern in patterns])])
+
+    return result
+
+
+def _tag_match(tag, pattern, pattern_type, ignore_underscore):
+    if ignore_underscore and tag.startswith('_'):
+        tag = tag[1:]
+    if pattern_type == 'fnmatch':
+        return fnmatch.fnmatch(tag, pattern)
+    elif pattern_type == 're':
+        return bool(re.match(pattern, tag))
+    raise NotImplementedError

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -278,6 +278,11 @@ class StorageFrontend:
     # Abstract methods (to override in child)
     ##
 
+    def _scan_runs(self, store_fields):
+        """Iterable of run document / metadata dictionaries
+        """
+        yield from tuple()
+
     def _list_available(self, key: DataKey,
                         allow_incomplete, fuzzy_for, fuzzy_for_options):
         """Return list of available runs whose data matches key.

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -84,11 +84,14 @@ class StorageFrontend:
     """
     backends: list
     can_define_runs = False
+    provide_run_metadata = False
 
     def __init__(self,
                  readonly=False,
+                 provide_run_metadata=None,
                  overwrite='if_broken',
-                 take_only=tuple(), exclude=tuple()):
+                 take_only=tuple(), 
+                 exclude=tuple()):
         """
         :param readonly: If True, throws CannotWriteData whenever saving is
         attempted.
@@ -98,6 +101,8 @@ class StorageFrontend:
          - 'always': Always overwrite data. Use with caution!
         :param take_only: Provide/accept only these data types.
         :param exclude: Do NOT provide/accept these data types.
+        :param provide_run_metadata: Whether to provide run-level metadata
+        (run docs). If None, use class-specific default
 
         If take_only and exclude are both omitted, provide all data types.
         If a data type is listed in both, it will not be provided.
@@ -109,6 +114,8 @@ class StorageFrontend:
         self.take_only = strax.to_str_tuple(take_only)
         self.exclude = strax.to_str_tuple(exclude)
         self.overwrite = overwrite
+        if provide_run_metadata is not None:
+            self.provide_run_metadata = provide_run_metadata
         self.readonly = readonly
         self.log = logging.getLogger(self.__class__.__name__)
 

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -83,6 +83,7 @@ class StorageFrontend:
     For example, a runs database, or a data directory on the file system.
     """
     backends: list
+    can_define_runs = False
 
     def __init__(self,
                  readonly=False,

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -23,7 +23,7 @@ class DataDirectory(StorageFrontend):
 
     Run-level metadata is stored in loose json files in the directory.
     """
-    
+
     provide_run_metadata = True
 
     def __init__(self, path='.', *args, deep_scan=True, **kwargs):
@@ -32,7 +32,7 @@ class DataDirectory(StorageFrontend):
         :param deep_scan: Let scan_runs scan over folders,
         so even data for which no run-level metadata is available
         is reported.
-        
+
         For other arguments, see DataRegistry base class.
         """
         super().__init__(*args, **kwargs)
@@ -49,7 +49,7 @@ class DataDirectory(StorageFrontend):
         path = self._run_meta_path(run_id)
         if osp.exists(path):
             with open(path, mode='r') as f:
-                md = json.loads(f.read(), 
+                md = json.loads(f.read(),
                                 object_hook=json_util.object_hook)
             if not projection:
                 return md
@@ -62,8 +62,6 @@ class DataDirectory(StorageFrontend):
                 f"No file at {path}, cannot find run metadata for {run_id}")
 
     def write_run_metadata(self, run_id, metadata):
-        final_path = self._run_meta_path(run_id)
-
         with open(self._run_meta_path(run_id), mode='w') as f:
             f.write(json.dumps(metadata, default=json_util.default))
 
@@ -72,12 +70,12 @@ class DataDirectory(StorageFrontend):
         These should be directly convertable to a pandas DataFrame.
         """
         found = set()
-        
+
         # Yield metadata for runs for which we actually have it
         for md_path in sorted(glob.glob(
                 osp.join(self.path,
                          RUN_METADATA_PATTERN.replace('%s', '*')))):
-            # Parse the run metadata filename pattern. 
+            # Parse the run metadata filename pattern.
             # (different from the folder pattern)
             run_id = osp.basename(md_path).split('-')[0]
             found.add(run_id)

--- a/strax/storage/zipfiles.py
+++ b/strax/storage/zipfiles.py
@@ -5,7 +5,7 @@ import shutil
 import zipfile
 
 import strax
-from .files import RUN_METADATA_FILENAME
+from .files import RUN_METADATA_PATTERN
 
 export, __all__ = strax.exporter()
 
@@ -54,7 +54,7 @@ class ZipDirectory(strax.StorageFrontend):
     def run_metadata(self, run_id):
         with zipfile.ZipFile(self._zipname(run_id)) as zp:
             try:
-                with zp.open(RUN_METADATA_FILENAME % run_id) as f:
+                with zp.open(RUN_METADATA_PATTERN % run_id) as f:
                     return json.loads(f.read())
             except KeyError:
                 raise strax.RunMetadataNotAvailable

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -1,3 +1,4 @@
+import collections
 import contextlib
 from functools import wraps
 import re
@@ -273,3 +274,32 @@ def print_entry(d, n=0, show_data=False):
         if (show_data or key != 'data'):
             print(("{:<%d}: " % max_len).format(key), el[key])
     return
+
+
+@export
+def count_tags(ds):
+    """Return how often each tag occurs in the datasets DataFrame ds"""
+    from collections import Counter
+    from itertools import chain
+    all_tags = chain(*[ts.split(',')
+                       for ts in ds['tags'].values])
+    return Counter(all_tags)
+
+
+@export
+def flatten_dict(d, separator=':', _parent_key=''):
+    """Flatten nested dictionaries into a single dictionary,
+    indicating levels by separator.
+    Don't set _parent_key argument, this is used for recursive calls.
+    Stolen from http://stackoverflow.com/questions/6027558
+    """
+    items = []
+    for k, v in d.items():
+        new_key = _parent_key + separator + k if _parent_key else k
+        if isinstance(v, collections.MutableMapping):
+            items.extend(flatten_dict(v,
+                                      separator=separator,
+                                      _parent_key=new_key).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,3 @@
-"""A very basic test for the strax core.
-Mostly tests if we don't crash immediately..
-"""
 import tempfile
 import shutil
 import os
@@ -77,6 +74,7 @@ def test_filestore():
 
         assert mystrax.is_stored(run_id, 'peaks')
         assert mystrax.list_available('peaks') == [run_id]
+        assert mystrax.scan_runs()['name'].values.tolist() == [run_id]
 
         # We should have two directories
         data_dirs = sorted(glob.glob(osp.join(temp_dir, '*/')))
@@ -249,3 +247,29 @@ def test_random_access():
         assert len(df) == 2 * recs_per_chunk
         assert df['time'].min() == 3
         assert df['time'].max() == 4
+
+
+def test_run_selection():
+    mock_rundb = [
+        dict(name='0', mode='funny', tags=[dict(name='bad')]),
+        dict(name='1', mode='nice', tags=[dict(name='interesting'),
+                                          dict(name='bad')]),
+        dict(name='2', mode='nice', tags=[dict(name='interesting')])]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        sf = strax.DataDirectory(path=temp_dir)
+
+        # Write mock runs db
+        for d in mock_rundb:
+            sf.write_run_metadata(d['name'], d)
+
+        st = strax.Context(storage=sf)
+        assert len(st.scan_runs()) == len(mock_rundb)
+        assert st.run_metadata('0') == mock_rundb[0]
+
+        assert len(st.run_selection(run_mode='nice') == 1)
+        assert len(st.run_selection(include_tags='interesting') == 2)
+        assert len(st.run_selection(include_tags='interesting',
+                                    exclude_tags='bad') == 1)
+        assert len(st.run_selection(include_tags='interesting',
+                                    run_mode='nice') == 1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -68,8 +68,11 @@ def test_multirun():
                                 register=[Records, Peaks],)
         bla = mystrax.get_array(run_id=['0', '1'], targets='peaks',
                                 max_workers=max_workers)
-        assert len(bla) == recs_per_chunk * n_chunks * 2
-        assert bla.dtype == strax.peak_dtype()
+        n = recs_per_chunk * n_chunks
+        assert len(bla) == n * 2
+        np.testing.assert_equal(
+            bla['run_id'],
+            np.array([0] * n + [1] * n, dtype=np.int32))
 
 
 def test_filestore():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -280,9 +280,9 @@ def test_run_selection():
         assert len(st.scan_runs()) == len(mock_rundb)
         assert st.run_metadata('0') == mock_rundb[0]
 
-        assert len(st.run_selection(run_mode='nice') == 1)
-        assert len(st.run_selection(include_tags='interesting') == 2)
-        assert len(st.run_selection(include_tags='interesting',
-                                    exclude_tags='bad') == 1)
-        assert len(st.run_selection(include_tags='interesting',
-                                    run_mode='nice') == 1)
+        assert len(st.select_runs(run_mode='nice') == 1)
+        assert len(st.select_runs(include_tags='interesting') == 2)
+        assert len(st.select_runs(include_tags='interesting',
+                                 exclude_tags='bad') == 1)
+        assert len(st.select_runs(include_tags='interesting',
+                                  run_mode='nice') == 1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,6 +62,16 @@ def test_core():
         assert bla.dtype == strax.peak_dtype()
 
 
+def test_multirun():
+    for max_workers in [1, 2]:
+        mystrax = strax.Context(storage=[],
+                                register=[Records, Peaks],)
+        bla = mystrax.get_array(run_id=['0', '1'], targets='peaks',
+                                max_workers=max_workers)
+        assert len(bla) == recs_per_chunk * n_chunks * 2
+        assert bla.dtype == strax.peak_dtype()
+
+
 def test_filestore():
     with tempfile.TemporaryDirectory() as temp_dir:
         mystrax = strax.Context(storage=strax.DataDirectory(temp_dir),


### PR DESCRIPTION
This generalizes and improves the run selection and multi-run loading support from straxen, and moves it to strax. Specifically:
  * Support for loading/creating data for multiple runs at a time with `get_df`, `get_array` and `make`: simply pass a list/tuple of runids. An extra `run_id` field will be added to the output dataframe/array so you can track which events came from which runs.
  * New `select_runs` and `scan_runs` context methods, ported from straxen. `scan_runs` is the important one: it populates a dataframe with basic run info, from run-level metadata (run docs) provided by the storage frontends (through their `_scan_runs` and `list_available` methods). `select_runs` just contains some helpers for making selections on this dataframe based on tags and run mode fields.
  * The `DataDirectory` storage frontend now supports these methods. This allows you to replace/mock a runs database by putting some jsons in a DataDirectory folder. If nothing else, this allows strax's run selection code to be tested without a connection to a runs db.


Also, this adds a new `seconds_range` argument to `get_df, `get_array` etc., to specify a time range in seconds since the beginning of the run to load. This is complementary time `time_range`, which specifies a time range to load in absolute epoch nanoseconds.

(And if you look very closely, you'll see a new `define_run` context method that doesn't connect to anything yet... more on this later)