### PR TITLE
fix sum_waveform

### DIFF
--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -143,6 +143,8 @@ def sum_waveform(peaks, records, adc_to_pe, n_channels=248):
         for right_r_i in range(left_r_i, len(records)):
             r = records[right_r_i]
             ch = r['channel']
+            if ch >= n_channels:
+                continue
 
             s = int((p['time'] - r['time']) // dt)
             n_r = r['length']


### PR DESCRIPTION
Lets sum_waveform skip the channels not refering to pmts