### PR TITLE
Saver exception handling

### DIFF
--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -432,16 +432,12 @@ class Saver:
         """Iterate over source and save the results under key
         along with metadata
         """
-        import logging
-        log = logging.getLogger('saver_temp')
-        log.debug("Saver started")
         if rechunk and self.prefer_rechunk:
             source = strax.fixed_size_chunks(source)
 
         pending = []
         try:
             for chunk_i, s in enumerate(source):
-                log.debug(f"Saving chunk {chunk_i}")
                 new_f = self.save(data=s, chunk_i=chunk_i, executor=executor)
                 if new_f is not None:
                     pending = [f for f in pending + [new_f]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -235,7 +235,10 @@ def test_exception():
             st.get_df(run_id=run_id, targets='peaks')
 
 
-def test_exception_in_saver():
+def test_exception_in_saver(caplog):
+    import logging
+    caplog.set_level(logging.DEBUG)
+
     with tempfile.TemporaryDirectory() as temp_dir:
         st = strax.Context(storage=strax.DataDirectory(temp_dir),
                            register=[Records, Peaks])
@@ -247,7 +250,7 @@ def test_exception_in_saver():
         try:
             strax.save_file = kaboom
             with pytest.raises(SomeCrash):
-                st.make(run_id=run_id, targets='peaks')
+                st.make(run_id=run_id, targets='records')
         finally:
             strax.save_file = old_save
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -235,6 +235,23 @@ def test_exception():
             st.get_df(run_id=run_id, targets='peaks')
 
 
+def test_exception_in_saver():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        st = strax.Context(storage=strax.DataDirectory(temp_dir),
+                           register=[Records, Peaks])
+
+        def kaboom(*args, **kwargs):
+            raise SomeCrash
+
+        old_save = strax.save_file
+        try:
+            strax.save_file = kaboom
+            with pytest.raises(SomeCrash):
+                st.make(run_id=run_id, targets='peaks')
+        finally:
+            strax.save_file = old_save
+
+
 def test_random_access():
     """Test basic random access
     TODO: test random access when time info is not provided directly


### PR DESCRIPTION
This makes strax crash if an exception occurs while saving data. Previously such exceptions could only be recovered from the metadata of the data type whose saver crashed, since the strax processing command itself just succeeded.
  * An exception in the saver now gets thrown inside the mailbox it is reading from. This will kill now the mailbox, which as before brings down the whole processing and reraises the original exception at the end.
  * When the exception occurs at the very end of processing, this isn't enough, since Mailbox._read passes beyond the logic capable of handling exceptions when the last message is delivered. Thus, we also store the exception in a new attribute `got_exception` of the saver. At the end of processing, we check if any of the savers have this attribute set, and if so, throw the original exception. This would have been sufficient on its own, but it's nicer to report the error and stop processing as soon as the first exception occurs, rather than at the very end.

This also adds a test to ensure this behaviour. For ParallelSourcePlugin-inlined savers, this exception handling likely does not work and will require more complicated logic.