### PR TITLE
Area per channel in PE

### DIFF
--- a/docs/source/reference/strax.storage.rst
+++ b/docs/source/reference/strax.storage.rst
@@ -20,6 +20,14 @@ strax.storage.files module
     :undoc-members:
     :show-inheritance:
 
+strax.storage.mongo module
+--------------------------
+
+.. automodule:: strax.storage.mongo
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 strax.storage.s3 module
 -----------------------
 

--- a/strax/context.py
+++ b/strax/context.py
@@ -894,7 +894,8 @@ class Context:
             ... with blinded or _blinded, unblinded, blablinded, etc.
          - `run_selection(include_tags=['blinded', 'unblinded'])`
             ... with blinded OR unblinded, but not blablinded.
-         - `run_selection(include_tags='blinded', exclude_tags=['bad', 'messy'])`
+         - `run_selection(include_tags='blinded',
+                          exclude_tags=['bad', 'messy'])`
            select blinded dsatasets that aren't bad or messy
         """
         if self.runs is None:

--- a/strax/dtypes.py
+++ b/strax/dtypes.py
@@ -79,13 +79,13 @@ def peak_dtype(n_channels=100, n_sum_wv_samples=200, n_widths=11):
         (('Integral across channels in photoelectrons',
             'area'), np.float32),
         # Area per channel in ADC * samples
-        (('Integral per channel in ADX x samples (not PE!)',
-            'area_per_channel'), np.int32, n_channels),
+        (('Integral per channel in PE',
+            'area_per_channel'), np.float32, n_channels),
         # Number of hits from which this peak was constructed
         # (zero if peak was split afterwards)
         (("Number of hits from which peak was constructed "
           "(currently zero if peak is split afterwards)",
-            'n_hits'), np.int16),
+            'n_hits'), np.int32),
         # Waveform data in PE/sample
         (('Waveform data in PE/sample (not PE/ns!)',
             'data'), np.float32, n_sum_wv_samples),

--- a/strax/mailbox.py
+++ b/strax/mailbox.py
@@ -68,7 +68,7 @@ class Mailbox:
     """
 
     DEFAULT_TIMEOUT = 300
-    DEFAULT_MAX_MESSAGES = 20
+    DEFAULT_MAX_MESSAGES = 2
 
     def __init__(self,
                  name='mailbox',

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -152,7 +152,8 @@ class DataDirectory(StorageFrontend):
                 continue
             yield osp.join(self.path, dirname)
 
-    def _parse_folder_name(self, fn):
+    @staticmethod
+    def _parse_folder_name(fn):
         """Return (run_id, data_type, hash) if folder name matches
         DataDirectory convention, raise InvalidFolderNameFormat otherwise
         """
@@ -333,5 +334,6 @@ class FileSaver(strax.Saver):
         os.rename(self.tempdirname, self.dirname)
 
 
+@export
 class InvalidFolderNameFormat(Exception):
     pass

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -260,17 +260,27 @@ def formatted_exception():
 
 
 @export
-def print_entry(d, n=0, show_data=False):
-    """ Print entry number n in human-readable format.
-    Default behavior is to skip the entry 'data' since it clutters output.
+def print_record(x, skip_array=True):
+    """Print record(s) d in human-readable format
+    :param skip_array: Omit printing array fields
     """
+    if len(x.shape):
+        for q in x:
+            print_record(q)
+
     # Check what number of spaces required for nice alignment
-    max_len = np.max([len(key) for key in d.dtype.names])
-    el = d[n]
-    for key in d.dtype.names:
-        if (show_data or key != 'data'):
-            print(("{:<%d}: " % max_len).format(key), el[key])
-    return
+    max_len = np.max([len(key) for key in x.dtype.names])
+    for key in x.dtype.names:
+        try:
+            len(x[key])
+        except TypeError:
+            # Not an array field
+            pass
+        else:
+            if skip_array:
+                continue
+
+        print(("{:<%d}: " % max_len).format(key), x[key])
 
 
 @export

--- a/tests/test_peak_processing.py
+++ b/tests/test_peak_processing.py
@@ -10,13 +10,14 @@ import strax
 @given(fake_hits,
        st.one_of(st.just(1), st.just(3)),
        st.one_of(st.just(0), st.just(3)))
-def test_find_peaks(hits, min_hits, min_area):
+def test_find_peaks(hits, min_channels, min_area):
+    hits['area'] = 1
     gap_threshold = 10
     peaks = strax.find_peaks(hits,
-                             to_pe=np.ones(1),
+                             adc_to_pe=np.ones(1),
                              right_extension=0, left_extension=0,
                              gap_threshold=gap_threshold,
-                             min_hits=min_hits,
+                             min_channels=min_channels,
                              min_area=min_area)
     # Check sanity
     assert np.all(peaks['length'] > 0)
@@ -25,11 +26,11 @@ def test_find_peaks(hits, min_hits, min_area):
     # Check if requirements satisfied
     if min_area != 0:
         assert np.all(peaks['area'] >= min_area)
-    if min_hits != 1:
-        assert np.all(peaks['n_hits'] >= min_hits)
+    if min_channels != 1:
+        assert np.all(peaks['n_hits'] >= min_channels)
 
     # Without requirements, all hits must occur in a peak
-    if min_area == 0 and min_hits == 1:
+    if min_area == 0 and min_channels == 1:
         assert np.sum(peaks['n_hits']) == len(hits)
         assert np.all(strax.fully_contained_in(hits, peaks) > -1)
 


### PR DESCRIPTION
  * Change the area_per_channel field of peaks to be in PE, to ensure fewer plugins need to know about the PMT gains.
  * Replace `min_hits` with `min_channels` as an option to `find_peaks`. When set to 2 or higher numbers, this will help cuts down the amount of peaks.
  * Some misc reformatting / recommenting