### PR TITLE
Three small fixes

### DIFF
--- a/strax/chunk_arrays.py
+++ b/strax/chunk_arrays.py
@@ -31,6 +31,7 @@ class ChunkPacer:
         except StopIteration:
             self._source_exhausted = True
             raise StopIteration
+        assert isinstance(x, np.ndarray), f"Got {type(x)} instead of ndarray"
         self.buffer.append(x)
         self.buffer_items += len(x)
 
@@ -60,8 +61,6 @@ class ChunkPacer:
     def get_n(self, n: int):
         """Return array of the next n elements produced by source,
         or (if this is less) as many as the source can still produce.
-        
-        raises 
         """
         try:
             while self.buffer_items < n:
@@ -103,7 +102,8 @@ class ChunkPacer:
 
     def peek(self, n=1):
         x = self.get_n(n)
-        self._put_back_at_start(x)
+        if len(x):
+            self._put_back_at_start(x)
         return x
 
     @property

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -177,15 +177,15 @@ def camel_to_snake(x):
 @contextlib.contextmanager
 def profile_threaded(filename):
     import yappi  # noqa   # yappi is not a dependency
-    import gil_load  # noqa   # same
     yappi.set_clock_type("cpu")
     try:
+        import gil_load  # noqa   # same
         gil_load.init()
         gil_load.start(av_sample_interval=0.1,
                        output_interval=3,
                        output=sys.stdout)
         monitoring_gil = True
-    except RuntimeError:
+    except (RuntimeError, ImportError):
         monitoring_gil = False
         pass
 


### PR DESCRIPTION
 * If an output of a multi-output plugin isn't saved or used anywhere in the processing, it is discarded. This situation used to crash strax with an error about starting a mailbox without a subscriber.
 * Fix to `chunk_arrays.py` to improve the behaviour for empty data (e.g. 'events' if the run has no events). I'm still not sure strax can fully handle this case, see #162.
 * The strax.profile_threaded function now works also if you don't have `gil_load` installed. This is useful since `gil_load` doesn't always compile, and it is not essential for profiling.

