### PR TITLE
Superruns, LZ4, pulse processing fixes

### DIFF
--- a/docs/source/advanced/superrun.rst
+++ b/docs/source/advanced/superrun.rst
@@ -1,0 +1,53 @@
+Superruns
+=========
+
+Overview and motivation
+------------------------
+A superrun is a run defined by (parts of) other runs, which are called 'subruns'. Superrun names start with an underscore. Regular run names cannot start with an underscore.
+
+Strax builds data for a superrun by loading (and potentially building) each of the subruns, then slicing and concatenating them as necessary.
+
+Superruns are useful to track common groupings of data. For example:
+
+* 'Minimum bias' runs, consisting only of low-energy events, events passing some cuts, DM-candidates, PMT flashes, or other thing of interest. The low-level data of these is much smaller than that of all the full runs, and can be brought to a local analysis facility, enabling on-site low-level waveform watching.
+* Grouping similar runs. For example, shifters might group good runs from a week of calibration data with some source under a single name, e.g. `_kr_feb2019`.
+
+
+
+Superruns can be built from other superruns. Thus, _sr1_v0.2 could be built from _background_january, _background_february, etc.
+
+
+Defining superruns
+-------------------
+Use the `define_run` context method to define a new superrun. There are three ways to do this.
+
+From a list of runids::
+
+    st.define_run('_awesome_superrun', ['123', '124'])
+
+From a dictionary of time range tuples. The times must be 64-bit integer UTC timestamps since the unix epoch::
+
+    st.define_run('_awesome_superrun', {
+        '123': [(start, stop), (start, stop), ...],
+        '124': [(start, stop), (start, stop), ...],})
+
+From a dataframe (or record array) with strax data::
+
+    st.define_run('_awesome_superrun', events_df)
+    st.define_run('_awesome_superrun', events_df, from_run='123')
+
+In this case, the run will be made of the time ranges that correspond exactly to `events_df`. If `events_df` already has a `run_id` field (e.g. because it consists of data from multiple runs), you do not need to pass `from_run`, it will be read off from the data.
+
+It is up to the storage frontent to process your request for defining a run. As a normal user, you generally only have permissions to create a new run in the `DataDirectory` (local files) storage frontend, where runs are recorded in json files.
+
+
+How superruns work
+--------------------
+
+As mentioned above, strax builds data for superruns by slicing data of the subruns. Thus, peaks from a superrun come from the peaks of the subruns, which are built from their own records as usual.
+
+Defaults for settings can be runid-dependent in strax. If an option specifies `default_per_run=[(run, setting), (run2, setting2)]`, then runs in between run and run2 will use setting, and runs after run2 `setting2`. Superruns store a deterministic hash of this `default_per_run` specification for tracking purposes.
+
+You cannot currently go directly from the superrun's records to the superrun's peaks. This would be tricky to implement, since (1) (2) even with the same settings, many plugins choose to do something different depending on the runid. For example, in straxen the gain model is specified by a file, but which gains from the file are actually used is dependent on the runid.
+
+Thus, superruns won't help build data faster, but they will speed up loading data after it has been built. This is important, because strax' overhead for loading a run is larger than hax, due to its version and option tracking.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,6 +31,7 @@ You might also find these presentations useful:
     :caption: Advanced usage
 
     advanced/overview
+    advanced/superrun
     advanced/plugin_dev
 
 .. toctree::

--- a/docs/source/reference/strax.processing.rst
+++ b/docs/source/reference/strax.processing.rst
@@ -8,55 +8,55 @@ strax.processing.data\_reduction module
 ---------------------------------------
 
 .. automodule:: strax.processing.data_reduction
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.processing.general module
 -------------------------------
 
 .. automodule:: strax.processing.general
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.processing.peak\_building module
 --------------------------------------
 
 .. automodule:: strax.processing.peak_building
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.processing.peak\_properties module
 ----------------------------------------
 
 .. automodule:: strax.processing.peak_properties
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.processing.peak\_splitting module
 ---------------------------------------
 
 .. automodule:: strax.processing.peak_splitting
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.processing.pulse\_processing module
 -----------------------------------------
 
 .. automodule:: strax.processing.pulse_processing
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: strax.processing
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/reference/strax.rst
+++ b/docs/source/reference/strax.rst
@@ -6,8 +6,8 @@ Subpackages
 
 .. toctree::
 
-    strax.processing
-    strax.storage
+   strax.processing
+   strax.storage
 
 Submodules
 ----------
@@ -16,79 +16,87 @@ strax.chunk\_arrays module
 --------------------------
 
 .. automodule:: strax.chunk_arrays
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.config module
 -------------------
 
 .. automodule:: strax.config
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.context module
 --------------------
 
 .. automodule:: strax.context
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.dtypes module
 -------------------
 
 .. automodule:: strax.dtypes
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.io module
 ---------------
 
 .. automodule:: strax.io
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.mailbox module
 --------------------
 
 .. automodule:: strax.mailbox
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.plugin module
 -------------------
 
 .. automodule:: strax.plugin
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.processor module
 ----------------------
 
 .. automodule:: strax.processor
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+strax.run\_selection module
+---------------------------
+
+.. automodule:: strax.run_selection
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.utils module
 ------------------
 
 .. automodule:: strax.utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: strax
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/reference/strax.storage.rst
+++ b/docs/source/reference/strax.storage.rst
@@ -8,47 +8,47 @@ strax.storage.common module
 ---------------------------
 
 .. automodule:: strax.storage.common
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.storage.files module
 --------------------------
 
 .. automodule:: strax.storage.files
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.storage.mongo module
 --------------------------
 
 .. automodule:: strax.storage.mongo
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.storage.s3 module
 -----------------------
 
 .. automodule:: strax.storage.s3
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 strax.storage.zipfiles module
 -----------------------------
 
 .. automodule:: strax.storage.zipfiles
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: strax.storage
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ numexpr==2.6.9
 boto3==1.9.174
 scipy==1.3.0
 pymongo==3.8.0
+lz4

--- a/strax/context.py
+++ b/strax/context.py
@@ -830,6 +830,7 @@ class Context:
 
     def make(self, run_id: ty.Union[str, tuple, list],
              targets, save=tuple(), max_workers=None,
+             _skip_if_built=True,
              **kwargs) -> None:
         """Compute target for run_id. Returns nothing (None).
         {get_docs}
@@ -841,7 +842,7 @@ class Context:
                 self.make, run_ids, targets=targets,
                 save=save, max_workers=max_workers, **kwargs)
 
-        if self.is_stored(run_id, targets):
+        if _skip_if_built and self.is_stored(run_id, targets):
             return
 
         for _ in self.get_iter(run_ids[0], targets,

--- a/strax/context.py
+++ b/strax/context.py
@@ -837,9 +837,12 @@ class Context:
         """
         # Multi-run support
         run_ids = strax.to_str_tuple(run_id)
+        if len(run_ids) == 0:
+            raise ValueError("Cannot build empty list of runs")
         if len(run_ids) > 1:
             return strax.multi_run(
-                self.make, run_ids, targets=targets,
+                self.get_array, run_ids, targets=targets,
+                throw_away_result=True,
                 save=save, max_workers=max_workers, **kwargs)
 
         if _skip_if_built and self.is_stored(run_id, targets):

--- a/strax/io.py
+++ b/strax/io.py
@@ -7,6 +7,7 @@ import os
 import numpy as np
 import blosc
 import zstd
+import lz4.frame as lz4
 
 import strax
 export, __all__ = strax.exporter()
@@ -24,6 +25,7 @@ COMPRESSORS = dict(
     blosc=dict(
         compress=partial(blosc.compress, shuffle=False),
         decompress=blosc.decompress),
+    lz4=dict(compress=lz4.compress, decompress=lz4.decompress)
 )
 
 

--- a/strax/processing/data_reduction.py
+++ b/strax/processing/data_reduction.py
@@ -43,8 +43,7 @@ def cut_baseline(records, n_before=48, n_after=30):
         clear_from = max(0, clear_from)
         if clear_from < samples_per_record:
             d.data[clear_from:] = 0
-
-    records.reduction_level[:] = ReductionLevel.BASELINE_CUT
+        d['reduction_level'] = ReductionLevel.BASELINE_CUT
 
 
 @export

--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -159,3 +159,35 @@ def split_by_containment(things, containers):
         things_split.insert(c_i, things[:0])
 
     return things_split
+
+
+@export
+@numba.jit(nopython=True, nogil=True, cache=True)
+def overlap_indices(a1, n_a, b1, n_b):
+    """Given interval [a1, a1 + n_a), and [b1, b1 + n_b) of integers,
+    return indices [a_start, a_end), [b_start, b_end) of overlapping region.
+    """
+    if n_a < 0 or n_b < 0:
+        raise ValueError("Negative interval length passed to overlap test")
+
+    if n_a == 0 or n_b == 0:
+        return (0, 0), (0, 0)
+
+    # a: p, b: r
+    s = a1 - b1
+
+    if s <= -n_a:
+        # B is completely right of a
+        return (0, 0), (0, 0)
+
+    # Range in b that overlaps with a
+    b_start = max(0, s)
+    b_end = min(n_b, s + n_a)
+    if b_start >= b_end:
+        return (0, 0), (0, 0)
+
+    # Range of a that overlaps with b
+    a_start = max(0, -s)
+    a_end = min(n_a, -s + n_b)
+
+    return (a_start, a_end), (b_start, b_end)

--- a/strax/run_selection.py
+++ b/strax/run_selection.py
@@ -209,6 +209,10 @@ def define_run(self: strax.Context,
             return self.define_run(
                 name,
                 {from_run: np.transpose([start, end])})
+        elif not 'run_id' in data:
+            raise ValueError(
+                "Must provide from_run or data with a run_id column "
+                "to define a superrun")
         else:
             df = pd.DataFrame(dict(starts=start, ends=end,
                                    run_id=data['run_id']))

--- a/strax/run_selection.py
+++ b/strax/run_selection.py
@@ -198,7 +198,7 @@ def select_runs(self, run_mode=None, run_id=None,
 
 
 @strax.Context.add_method
-def define_run(self,
+def define_run(self: strax.Context,
                name: str,
                data: ty.Union[np.ndarray, pd.DataFrame, dict],
                from_run: ty.Union[str, None] = None):
@@ -212,7 +212,7 @@ def define_run(self,
         else:
             df = pd.DataFrame(dict(starts=start, ends=end,
                                    run_id=data['run_id']))
-            self.define_run(
+            return self.define_run(
                 name,
                 {run_id: rs[['start', 'stop']].values.transpose()
                  for run_id, rs in df.groupby('fromrun')})
@@ -220,17 +220,29 @@ def define_run(self,
     if isinstance(data, (list, tuple)):
         # list of runids
         data = strax.to_str_tuple(data)
-        self.define_run(
+        return self.define_run(
             name,
             {run_id: 'all' for run_id in data})
 
     if not isinstance(data, dict):
-        raise ValueError("Can't define run from {type(data)}")
+        raise ValueError(f"Can't define run from {type(data)}")
+
+    # Find start and end time of the new run = earliest start time of other runs
+    run_md = dict(start=float('inf'), end=0, livetime=0)
+    for _subrunid in data:
+        doc = self.run_metadata(_subrunid, ['start', 'end'])
+        run_md['start'] = min(run_md['start'], doc['start'])
+        run_md['end'] = max(run_md['end'], doc['end'])
+        run_md['livetime'] += doc['end'] - doc['start']
+
+    # Superrun names must start with an underscore
+    if not name.startswith('_'):
+        name = '_' + name
 
     # Dict mapping run_id: array of time ranges or all
     for sf in self.storage:
         if not sf.readonly and sf.can_define_runs:
-            sf.define_run(name, data)
+            sf.define_run(name, sub_run_spec=data, **run_md)
             break
     else:
         raise RuntimeError("No storage frontend registered that allows"

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -292,6 +292,11 @@ class StorageFrontend:
             result.append(r)
         return result
 
+    def define_run(self, name, sub_run_spec, **metadata):
+        self.write_run_metadata(name, dict(
+            sub_run_spec=sub_run_spec,
+            **metadata))
+
     ##
     # Abstract methods (to override in child)
     ##

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -52,12 +52,7 @@ class DataDirectory(StorageFrontend):
             with open(path, mode='r') as f:
                 md = json.loads(f.read(),
                                 object_hook=json_util.object_hook)
-            if not projection:
-                return md
-            md = strax.flatten_dict(md, separator='.')
-            return {k: v
-                    for k, v in md.items()
-                    if k in projection}
+            return md
         else:
             raise strax.RunMetadataNotAvailable(
                 f"No file at {path}, cannot find run metadata for {run_id}")

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -24,6 +24,7 @@ class DataDirectory(StorageFrontend):
     Run-level metadata is stored in loose json files in the directory.
     """
 
+    can_define_runs = True
     provide_run_metadata = True
 
     def __init__(self, path='.', *args, deep_scan=True, **kwargs):

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -377,12 +377,15 @@ def dict_to_rec(x, dtype=None):
 
 
 @export
-def multi_run(f, run_ids, *args, max_workers=None, **kwargs):
+def multi_run(f, run_ids, *args, max_workers=None,
+              throw_away_result=False,
+              **kwargs):
     """Execute f(run_id, **kwargs) over multiple runs,
     then return list of results.
 
     :param run_ids: list/tuple of runids
     :param max_workers: number of worker threads/processes to spawn
+    :param throw_away_result: instead of collecting result, return None.
 
     Other (kw)args will be passed to f
     """
@@ -410,10 +413,15 @@ def multi_run(f, run_ids, *args, max_workers=None, **kwargs):
         result = []
         for i, f in enumerate(futures):
             r = f.result()
+            if throw_away_result:
+                continue
             ids = np.array([run_id_numpy[i]] * len(r),
                            dtype=[('run_id', run_id_numpy.dtype)])
             r = merge_arrs([ids, r])
             result.append(r)
+
+        if throw_away_result:
+            return None
         return result
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -159,6 +159,7 @@ several_fake_records_one_channel = sorted_bounds(
 ##
 @strax.takes_config(
     strax.Option('crash', default=False),
+    strax.Option('secret_time_offset', default=0, track=False)
 )
 class Records(strax.Plugin):
     provides = 'records'
@@ -176,7 +177,7 @@ class Records(strax.Plugin):
         if self.config['crash']:
             raise SomeCrash("CRASH!!!!")
         r = np.zeros(recs_per_chunk, self.dtype)
-        r['time'] = chunk_i
+        r['time'] = chunk_i + self.config['secret_time_offset']
         r['length'] = 1
         r['dt'] = 1
         r['channel'] = np.arange(len(r))
@@ -188,9 +189,9 @@ class SomeCrash(Exception):
 
 
 @strax.takes_config(
-    strax.Option('some_option', default=0),
-    strax.Option('give_wrong_dtype', default=False)
-)
+    strax.Option('base_area', default=0),
+    strax.Option('give_wrong_dtype', default=False),
+    strax.Option('bonus_area', default_by_run=[(0, 0), (1, 1)]))
 class Peaks(strax.Plugin):
     provides = 'peaks'
     depends_on = ('records',)
@@ -202,8 +203,8 @@ class Peaks(strax.Plugin):
             return np.zeros(5, [('a', np.int), ('b', np.float)])
         p = np.zeros(len(records), self.dtype)
         p['time'] = records['time']
+        p['area'] = self.config['base_area'] + self.config['bonus_area']
         return p
-
 
 recs_per_chunk = 10
 n_chunks = 10

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -116,7 +116,7 @@ def test_fuzzy_matching():
         st.make(run_id=run_id, targets='peaks')
 
         # Changing option causes data not to match
-        st.set_config(dict(some_option=1))
+        st.set_config(dict(base_area=1))
         assert not st.is_stored(run_id, 'peaks')
         assert st.list_available('peaks') == []
 
@@ -130,7 +130,7 @@ def test_fuzzy_matching():
         st2.get_array(run_id, 'peaks')
 
         # Fuzzy for options also works
-        st3 = st.new_context(fuzzy_for_options=('some_option',))
+        st3 = st.new_context(fuzzy_for_options=('base_area',))
         assert st3.is_stored(run_id, 'peaks')
 
     # No saving occurs at all while fuzzy matching
@@ -292,7 +292,7 @@ def test_get_single_plugin():
     p = mystrax.get_single_plugin('0', 'peaks')
     assert isinstance(p, Peaks)
     assert len(p.config)
-    assert p.config['some_option'] == 0
+    assert p.config['base_area'] == 0
 
 
 def test_superrun():
@@ -303,16 +303,39 @@ def test_superrun():
     ]
 
     with tempfile.TemporaryDirectory() as temp_dir:
+        # Test run definition
         sf = strax.DataDirectory(path=temp_dir)
         for d in mock_rundb:
             sf.write_run_metadata(d['name'], d)
 
-        st = strax.Context(storage=sf)
+        st = strax.Context(storage=sf, register=[Records, Peaks])
         st.define_run('super', ['0', '1'])
 
         md = st.run_metadata('_super')
-        print(md)
         assert md['start'] == 0
         assert md['end'] == int(3e9)
         assert md['livetime'] == int(2e9)
         assert md['sub_run_spec'] == {'0': 'all', '1': 'all'}
+
+        # Test superrun loading
+        r1 = st.get_array('0', 'records')
+        r2 = st.get_array('1', 'records', config=dict(secret_time_offset=int(1e9)))
+        rs = st.get_array('_super', 'records')
+        np.testing.assert_array_equal(rs, np.concatenate([r1, r2]))
+
+        # Test that superrun loading triggers subrun processing
+        ps = st.get_array('_super', 'peaks')
+        p1 = st.get_array('0', 'peaks')
+        p2 = st.get_array('1', 'peaks')
+        np.testing.assert_array_equal(p1['area'], np.zeros(len(p1)))
+        np.testing.assert_array_equal(p2['area'], np.ones(len(p2)))
+        np.testing.assert_array_equal(ps, np.concatenate([p1, p2]))
+
+        # Test superrun processing can override run-dependent options
+        st.set_config(config=dict(bonus_area=0))
+        ps = st.get_array('_super', 'peaks')
+        p1 = st.get_array('0', 'peaks')
+        p2 = st.get_array('1', 'peaks')
+        np.testing.assert_array_equal(p1['area'], np.zeros(len(p1)))
+        np.testing.assert_array_equal(p2['area'], np.zeros(len(p2)))
+        np.testing.assert_array_equal(ps, np.concatenate([p1, p2]))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -163,7 +163,7 @@ def test_storage_converter():
             with pytest.raises(strax.DataNotAvailable):
                 store_2.find(key)
 
-            st.make(run_id, 'peaks')
+            st.make(run_id, 'peaks', _skip_if_built=False)
 
             # Data is now in both stores
             store_1.find(key)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -293,3 +293,26 @@ def test_get_single_plugin():
     assert isinstance(p, Peaks)
     assert len(p.config)
     assert p.config['some_option'] == 0
+
+
+def test_superrun():
+    # TODO: duplicated init with test_run_selection
+    mock_rundb = [
+        dict(name='0', start=0, end=int(1e9)),
+        dict(name='1', start=int(2e9), end=int(3e9))
+    ]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        sf = strax.DataDirectory(path=temp_dir)
+        for d in mock_rundb:
+            sf.write_run_metadata(d['name'], d)
+
+        st = strax.Context(storage=sf)
+        st.define_run('super', ['0', '1'])
+
+        md = st.run_metadata('_super')
+        print(md)
+        assert md['start'] == 0
+        assert md['end'] == int(3e9)
+        assert md['livetime'] == int(2e9)
+        assert md['sub_run_spec'] == {'0': 'all', '1': 'all'}

--- a/tests/test_data_reduction.py
+++ b/tests/test_data_reduction.py
@@ -1,0 +1,56 @@
+from hypothesis import given
+
+from .helpers import *
+
+
+# TODO: test with multiple fake pulses and dt != 1
+@given(single_fake_pulse)
+def test_cut_outside_hits(records):
+    hits = strax.find_hits(records, threshold=0)
+
+    # Set all record waveforms to 1 (still and 0 out of bounds)
+    for r in records:
+        r['data'] = 0
+        r['data'][:r['length']] = 1
+        assert np.all(np.in1d(r['data'], [0, 1]))
+
+    left_extension = 2
+    right_extension = 3
+
+    records_out = strax.cut_outside_hits(
+        records,
+        hits,
+        left_extension=left_extension,
+        right_extension=right_extension)
+
+    assert len(records_out) == len(records)
+    if len(records) == 0:
+        return
+
+    # All fields except data are unchanged
+    for x in records.dtype.names:
+        if x == 'data':
+            continue
+        if x == 'reduction_level':
+            np.testing.assert_array_equal(
+                records_out[x],
+                np.ones(len(records), dtype=np.int16)
+                * strax.ReductionLevel.HITS_ONLY)
+        else:
+            np.testing.assert_array_equal(records_out[x], records[x],
+                                          err_msg=f"Field {x} mangled!")
+
+    records = records_out
+
+    # Super-laborious dumb check
+    for r in records:
+        for i, w in enumerate(r['data'][:r['length']]):
+            t = r['time'] + i * r['dt']
+            for h in hits:
+                if (h['time'] - left_extension
+                        <= t <
+                        strax.endtime(h) + right_extension):
+                    assert w == 1, f"Position {i} should be preserved"
+                    break
+            else:
+                assert w == 0, f"Position {i} should be cut"

--- a/tests/test_general_processing.py
+++ b/tests/test_general_processing.py
@@ -51,7 +51,7 @@ def test_split_by_containment(things, containers):
                     == _is_contained(t, containers[container_i]))
 
     if len(result) and len(np.concatenate(result)) > 1:
-        assert np.diff(np.concatenate(result)['time']) >= 0, "Sorting broken"
+        assert np.diff(np.concatenate(result)['time']).min() >= 0, "Sorting bug"
 
 
 def _is_contained(_thing, _container):

--- a/tests/test_peak_processing.py
+++ b/tests/test_peak_processing.py
@@ -57,7 +57,7 @@ def test_sum_waveform(records, peak_left, peak_length):
     p = peaks[0]
     p['time'] = peak_left
     p['length'] = peak_length
-    p['dt'] = 0
+    p['dt'] = 1
 
     strax.sum_waveform(peaks, records, np.ones(n_ch))
 


### PR DESCRIPTION
Superruns
===============

A superrun is a run defined by (parts of) other runs, called 'subruns'. It is like a tag, but can be applied to parts of runs. Superruns can also be built from other superruns, enabling multiple levels of grouping. Details are in a new documentation page.

For example, `_rn_february`, `_sr1_background_v0.2`, or `_1234_lowenergyonly` might be superruns. Superrun ids start with an underscore. Regular run ids cannot start with an underscore from now on.

The two main uses are:
  * Grouping runs to load high-level data faster and easier. A high-level datafile (e.g. event_info) for a single one-hour run is often a sub-MB file. If we have O(10^4) runs, as in XENON1T, loading these over a network filesystem is very time-consuming. Strax's detailed configuration checking also introduces a substantial per-run loading-time overhead compared to hax.
  * Defining 'minimum bias' runs, e.g. with the high-energy events cut out, or just the DM candidates selected. The raw data for such runs could be kept at an analysis facility, enabling low-level waveform watching. High-level data for such runs replaces the untracked 'cache files' from hax. 

Strax builds data for superruns by slicing data of the subruns. Thus peaks from a superrun comes from the 'peaks' of the subruns, which are built from their own records as usual. Thus superruns won't help build data faster, but do help in loading data after it has been built.

LZ4
====
Support for LZ4 (de)compression is added. The performance is very similar to blosc, but unlike blosc, it does not have a 2GB/file limitation.

![compress_benchmark_load](https://user-images.githubusercontent.com/4354311/64704635-e4d3e200-d4ae-11e9-911e-ae36cb99d702.png)
![compress_benchmark_save](https://user-images.githubusercontent.com/4354311/64704636-e4d3e200-d4ae-11e9-9ed9-3e0ad1514df4.png)

Ignore the lz4_minhc point in the graphs above, just look at lz4. Snappy has apparently also upped its game and is now comparable to lz4/blosc too (unlike in previous tests).

Pulse processing fixes
===================
Added a test for `cut_outside_hits`, and fix a few edge cases. The interval-overlap-finding logic is factored out, tested, and reused in the sum waveform code.