### PR TITLE
Protect OverlapWindowPlugin against empty chunks

### DIFF
--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -145,43 +145,18 @@ class Plugin:
             lineage=self.lineage)
 
     def dependencies_by_kind(self, require_time=None):
+        """Return dependencies grouped by data kind
+        i.e. {kind1: [dep0, dep1], kind2: [dep, dep]}
+        :param require_time: If True, one dependency of each kind
+        must provide time information. It will be put first in the list.
+
+        If require_time is omitted, we will require time only if there is
+        more than one data kind in the dependencies.
+        """
         return strax.group_by_kind(
             self.depends_on,
             plugins=self.deps,
             require_time=require_time)
-        # """Return dependencies grouped by data kind
-        # i.e. {kind1: [dep0, dep1], kind2: [dep, dep]}
-        # :param require_time: If True, one dependency of each kind
-        # must provide time information. It will be put first in the list.
-        #
-        # If require_time is omitted, we will require time only if there is
-        # more than one data kind in the dependencies.
-        # """
-        # if require_time is None:
-        #     require_time = \
-        #         len(self.dependencies_by_kind(require_time=False)) > 1
-        #
-        # deps_by_kind = dict()
-        # key_deps = []
-        # for d in self.depends_on:
-        #     k = self.deps[d].data_kind_for(d)
-        #     deps_by_kind.setdefault(k, [])
-        #
-        #     # If this has time information, put it first in the list
-        #     if (require_time
-        #             and 'time' in self.deps[d].dtype.names):
-        #         key_deps.append(d)
-        #         deps_by_kind[k].insert(0, d)
-        #     else:
-        #         deps_by_kind[k].append(d)
-        #
-        # if require_time:
-        #     for k, d in deps_by_kind.items():
-        #         if not d[0] in key_deps:
-        #             raise ValueError(f"For {self.__class__.__name__}, no "
-        #                              f"dependency of data kind {k} "
-        #                              "has time information!")
-        #return deps_by_kind
 
     def is_ready(self, chunk_i):
         """Return whether the chunk chunk_i is ready for reading.

--- a/strax/processor.py
+++ b/strax/processor.py
@@ -51,6 +51,11 @@ class ThreadedMailboxProcessor:
 
         self.log.debug("Processor components are: " + str(components))
 
+        if allow_multiprocess and os.name == 'nt':
+            print("You're on Windows! "
+                  "Multiprocessing disabled, here be dragons.")
+            allow_multiprocess = False
+
         if max_workers in [None, 1]:
             # Disable the executors: work in one process.
             # Each plugin works completely in its own thread.

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -185,7 +185,7 @@ class DataDirectory(StorageFrontend):
 @export
 def dirname_to_prefix(dirname):
     """Return filename prefix from dirname"""
-    return os.path.basename(dirname.strip('/')).split("-", maxsplit=1)[1]
+    return os.path.basename(dirname.strip('/').rstrip('\\')).split("-", maxsplit=1)[1]
 
 
 @export

--- a/tests/test_overlap_plugin.py
+++ b/tests/test_overlap_plugin.py
@@ -32,7 +32,7 @@ def test_overlap_plugin(input_peaks, split_i):
     chunked.
     """
     chunks = np.split(input_peaks, [split_i])
-    chunks = [c for c in chunks if len(c)]
+    chunks = [c for c in chunks]
 
     class Peaks(strax.Plugin):
         depends_on = tuple()


### PR DESCRIPTION
As discovered by @jorana, strax's OverlapWindowPlugin crashes with an IndexError if an empty chunk is found in the data stream. In general strax is not very robust against this case (see #162), but we are improving.

You can read how OverlapWindowPlugin works [here](https://strax.readthedocs.io/en/latest/developer/overlaps.html#overlap-window-plugins). For an empty chunk, this PR changes strax to simply not send or discard any data; the input/output caches remain the same. The case of the last chunk (after which you must send everything even it if is empty) is already handled by the `iter` method. 

This escaped the property-based testing due to a spurious condition in the test (I guess I just didn't consider empty chunks would be possible) that is now removed.

(This also removes some old but totally unrelated commented code)