### PR TITLE
Cleanup tests, make helpers accessible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,10 @@ deploy:
 matrix:
     include:
         - env: PYTHON=3.7 DEPLOY_ME=true
+        - env: PYTHON=3.7 NUMBA_DISABLE_JIT=true
         - env: PYTHON=3.6
         - os: osx
           env: PYTHON=3.7
-        - env: PYTHON=3.7
-          dist: trusty
         - env: PYTHON=3.8
 
 jobs:
@@ -68,5 +67,6 @@ script:
   - coverage run --source=strax setup.py test
 
 # Upload code coverage information
+# Only do this if not jitting, otherwise we miss those tests.
 after_success:
-  - coveralls
+  - if [ NUMBA_DISABLE_JIT ]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,17 @@ deploy:
 # The build matrix over all possible setups
 matrix:
     include:
-        - env: PYTHON=3.8 DEPLOY_ME=true
+        - env: PYTHON=3.7 DEPLOY_ME=true
         - env: PYTHON=3.6
         - os: osx
-          env: PYTHON=3.8
-        - env: PYTHON=3.8
+          env: PYTHON=3.7
+        - env: PYTHON=3.7
           dist: trusty
+        - env: PYTHON=3.8
+
+jobs:
+    allow_failures:
+        - env: PYTHON=3.8
 
 # Setup miniconda
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ deploy:
 # The build matrix over all possible setups
 matrix:
     include:
-        - env: PYTHON=3.7 DEPLOY_ME=true
+        - env: PYTHON=3.8 DEPLOY_ME=true
         - env: PYTHON=3.6
         - os: osx
-          env: PYTHON=3.7
-        - env: PYTHON=3.7
+          env: PYTHON=3.8
+        - env: PYTHON=3.8
           dist: trusty
 
 # Setup miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,4 +69,4 @@ script:
 # Upload code coverage information
 # Only do this if not jitting, otherwise we miss those tests.
 after_success:
-  - if [ NUMBA_DISABLE_JIT ]; then coveralls; fi
+  - if [ $NUMBA_DISABLE_JIT ]; then coveralls; fi

--- a/strax/testutils.py
+++ b/strax/testutils.py
@@ -1,36 +1,16 @@
-import tempfile     # noqa
+"""Utilities to help write strax tests.
+
+Not needed during strax operation, so this file is not imported in __init__.py
+"""
+
 from itertools import accumulate
 from functools import partial
 
 import numpy as np
 from boltons import iterutils
 from hypothesis import strategies
-import pytest     # noqa
 
-##
-# Hack to disable numba.jit
-# For the mini-examples run during testing numba actually causes a massive
-# performance drop. Moreover, if you make a buffer overrun bug, jitted fs
-# respond "slightly" less nice (giving you junk data or segfaulting)
-# Once in a while you should test without this...
-##
-def mock_numba():
-    from unittest.mock import MagicMock
-
-    class FakeNumba:
-
-        def jit(self, *args, **kwargs):
-            return lambda x: x
-
-    FakeNumba.caching = MagicMock()
-
-    import sys                                # noqa
-    sys.modules['numba'] = FakeNumba()
-
-
-# Mock numba before importing strax
-mock_numba()
-import strax    # noqa
+import strax
 
 
 # Since we use np.cumsum to get disjoint intervals, we don't want stuff

--- a/tests/test_chunk_arrays.py
+++ b/tests/test_chunk_arrays.py
@@ -1,5 +1,6 @@
+import pytest
 import itertools
-from .helpers import *
+from strax.testutils import *
 
 
 @pytest.fixture

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,10 +1,12 @@
-from .helpers import *
-
+import glob
 import shutil
+import tempfile
 import os
 import os.path as osp
-import glob
 
+import pytest
+
+from strax.testutils import *
 
 def test_core():
     for allow_multiprocess in (False, True):

--- a/tests/test_data_reduction.py
+++ b/tests/test_data_reduction.py
@@ -1,9 +1,10 @@
-from hypothesis import given
+from hypothesis import given, settings
 
-from .helpers import *
+from strax.testutils import *
 
 
 # TODO: test with multiple fake pulses and dt != 1
+@settings(deadline=None)
 @given(single_fake_pulse)
 def test_cut_outside_hits(records):
     hits = strax.find_hits(records, threshold=0)

--- a/tests/test_general_processing.py
+++ b/tests/test_general_processing.py
@@ -34,6 +34,7 @@ def test_fully_contained_in(things, containers):
             assert _is_contained(thing, containers[result[i]])
 
 
+@settings(deadline=None)
 @given(sorted_intervals, disjoint_sorted_intervals)
 # Specific example to trigger issue #37
 @example(

--- a/tests/test_general_processing.py
+++ b/tests/test_general_processing.py
@@ -1,4 +1,4 @@
-from hypothesis import given, example
+from hypothesis import given, example, settings
 from hypothesis.strategies import integers
 from strax.testutils import sorted_intervals, disjoint_sorted_intervals
 from strax.testutils import several_fake_records
@@ -8,6 +8,7 @@ import strax
 
 
 @given(sorted_intervals, disjoint_sorted_intervals)
+@settings(deadline=None)
 # Tricky example: uncontained interval precedes contained interval
 # (this did not produce an issue, but good to show this is handled)
 @example(things=np.array([(0, 1, 0, 1),
@@ -62,6 +63,7 @@ def _is_contained(_thing, _container):
            <= _container['time'] + _container['length']
 
 
+@settings(deadline=None)
 @given(several_fake_records)
 def test_from_break(records):
     window = 5

--- a/tests/test_general_processing.py
+++ b/tests/test_general_processing.py
@@ -1,7 +1,7 @@
 from hypothesis import given, example
 from hypothesis.strategies import integers
-from .helpers import sorted_intervals, disjoint_sorted_intervals
-from .helpers import several_fake_records
+from strax.testutils import sorted_intervals, disjoint_sorted_intervals
+from strax.testutils import several_fake_records
 
 import numpy as np
 import strax

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,20 +1,20 @@
-from . import helpers
+from strax import testutils
 from hypothesis import given
 import strax
 
 
-@given(helpers.sorted_bounds())
+@given(testutils.sorted_bounds())
 def test_sorted_bounds(bs):
     assert is_sorted(bs)
 
 
-@given(helpers.sorted_bounds(disjoint=True))
+@given(testutils.sorted_bounds(disjoint=True))
 def test_disjoint_bounds(bs):
     assert is_sorted(bs)
     assert is_disjoint(bs)
 
 
-@given(helpers.disjoint_sorted_intervals)
+@given(testutils.disjoint_sorted_intervals)
 def test_dsi(intvs):
     bs = list(zip(intvs['time'].tolist(), strax.endtime(intvs).tolist()))
     assert is_sorted(bs)

--- a/tests/test_multi_output.py
+++ b/tests/test_multi_output.py
@@ -1,4 +1,6 @@
-from .helpers import *
+import tempfile
+
+from strax.testutils import *
 
 
 class EvenOddSplit(strax.Plugin):

--- a/tests/test_overlap_plugin.py
+++ b/tests/test_overlap_plugin.py
@@ -1,4 +1,4 @@
-from . import helpers   # Mocks numba    # noqa
+from strax import testutils
 
 import numpy as np
 
@@ -7,7 +7,7 @@ from hypothesis import given, strategies, example
 import strax
 
 
-@given(helpers.disjoint_sorted_intervals.filter(lambda x: len(x) > 0),
+@given(testutils.disjoint_sorted_intervals.filter(lambda x: len(x) > 0),
        strategies.integers(min_value=0, max_value=3))
 # Examples that trigger issue #49
 @example(

--- a/tests/test_peak_processing.py
+++ b/tests/test_peak_processing.py
@@ -1,7 +1,7 @@
-from .helpers import fake_hits, several_fake_records
+from strax.testutils import fake_hits, several_fake_records
 
 import numpy as np
-from hypothesis import given
+from hypothesis import given, settings
 import hypothesis.strategies as st
 
 import strax
@@ -10,6 +10,7 @@ import strax
 @given(fake_hits,
        st.one_of(st.just(1), st.just(3)),
        st.one_of(st.just(0), st.just(3)))
+@settings(deadline=None)
 def test_find_peaks(hits, min_channels, min_area):
     hits['area'] = 1
     gap_threshold = 10
@@ -46,6 +47,7 @@ def test_find_peaks(hits, min_channels, min_area):
     # TODO: add more tests, preferably test against a second algorithm
 
 
+@settings(deadline=None)
 @given(several_fake_records,
        st.integers(min_value=0, max_value=100),
        st.integers(min_value=1, max_value=100)

--- a/tests/test_pulse_processing.py
+++ b/tests/test_pulse_processing.py
@@ -1,7 +1,7 @@
-from .helpers import single_fake_pulse
+from strax.testutils import single_fake_pulse
 
 import numpy as np
-from hypothesis import given
+from hypothesis import given, settings
 from scipy.ndimage import convolve1d
 
 import strax
@@ -46,6 +46,8 @@ def test_find_hits():
         assert results == should_find_intervals
 
 
+
+@settings(deadline=None)
 @given(single_fake_pulse)
 def test_find_hits_randomize(records):
     """Tests the hitfinder with whatever hypothesis can throw at it

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
-from . import helpers   # noqa
 import numpy as np
+
 import strax
 
 


### PR DESCRIPTION
This cleans up strax' test helpers file, which contains mainly [hypothesis](https://hypothesis.works/) strategies for making random records and peaks for testing data processing routines.

There are now no side effects from importing it -- in particular, we no longer mock numba for performance during tests. This makes the tests take slightly longer, but only if the compilation cache is not present (e.g. on Travis or after changes). Since we use numba in production we should clearly also test with it. Also, since numba is considering using strax as an integration test (https://github.com/numba/numba-integration-testing/issues/29) I'm sure they would appreciate if we don't replace `sys.modules['numba']` with a MagicMock...

The test helpers file is made accessible as strax.testutils, since some of the functions defined in it could be useful in writing tests for straxen.