### PR TITLE
Specify defaults via run metadata / run doc

### DIFF
--- a/docs/source/advanced/plugin_dev.rst
+++ b/docs/source/advanced/plugin_dev.rst
@@ -41,4 +41,5 @@ You can specify defaults in several ways:
 - ``default``: Use the given value as default.
 - ``default_factory``: Call the given function (with no arguments) to produce a default. Use for mutable values such as lists.
 - ``default_per_run``: Specify a list of 2-tuples: ``(start_run, default)``. Here start_run is a numerized run name (e.g 170118_1327; note the underscore is valid in integers since python 3.6) and ``default`` the option that applies from that run onwards.
+- The ``strax_defaults`` dictionary in the run metadata. This overrides any defaults specified in the plugin code, but take care -- if you change a value here, there will be no record anywhere of what value was used previously, so you cannot reproduce your results anymore!
 

--- a/strax/__init__.py
+++ b/strax/__init__.py
@@ -20,10 +20,7 @@ from .plugin import *
 from .mailbox import *
 from .processor import *
 from .context import *
-
-# Just run this file, it will add new methods to Context
-from . import run_selection
-del run_selection
+from .run_selection import *
 
 from .io import *
 

--- a/strax/config.py
+++ b/strax/config.py
@@ -81,10 +81,10 @@ class Option:
         self.track = track
         self.help = help
 
-        if self.default_by_run is not OMITTED:
-            warnings.warn(f"The {self.name} option uses default_by_run,"
-                          f" which will soon stop working!",
-                          DeprecationWarning)
+        # if self.default_by_run is not OMITTED:
+        #     warnings.warn(f"The {self.name} option uses default_by_run,"
+        #                   f" which will soon stop working!",
+        #                   DeprecationWarning)
 
         type = builtins.type
         if sum([self.default is not OMITTED,

--- a/strax/context.py
+++ b/strax/context.py
@@ -938,13 +938,6 @@ class Context:
         :param projection: Selection of fields to get, following MongoDB
         syntax. May not be supported by frontend.
         """
-        if self.runs is not None and projection in self.runs.columns:
-            # We already scanned for runs and just need one field. Maybe we
-            # have it already?
-            where = np.where(self.runs['name'].values == run_id)[0]
-            if len(where):
-                return {projection: self.runs.iloc[where[0]][projection]}
-
         for sf in self.storage:
             if not sf.provide_run_metadata:
                 continue

--- a/strax/context.py
+++ b/strax/context.py
@@ -943,7 +943,8 @@ class Context:
             # have it already?
             where = np.where(self.runs['name'].values == run_id)[0]
             if len(where):
-                return {projection: self.runs.iloc[where[0]]['projection']}
+                return {projection: self.runs.iloc[where[0]][projection]}
+
         for sf in self.storage:
             if not sf.provide_run_metadata:
                 continue

--- a/strax/run_selection.py
+++ b/strax/run_selection.py
@@ -37,7 +37,7 @@ def list_available(self, target, **kwargs):
 
 
 @strax.Context.add_method
-def scan_runs(self,
+def scan_runs(self: strax.Context,
               check_available=tuple(),
               store_fields=tuple()):
     """Update and return self.runs with runs currently available
@@ -53,7 +53,7 @@ def scan_runs(self,
     """
     store_fields = tuple(set(
         list(strax.to_str_tuple(store_fields))
-        + ['name', 'number', 'tags', 'mode', 'sub_run_spec',
+        + ['name', 'number', 'tags', 'mode',
            strax.RUN_DEFAULTS_KEY]
         + list(self.context_config['store_run_fields'])))
     check_available = tuple(set(
@@ -79,6 +79,12 @@ def scan_runs(self,
             # Convert tags list to a ,separated string
             doc['tags'] = ','.join([t['name']
                                    for t in doc.get('tags', [])])
+
+            # Put the strax defaults stuff into a different cache
+            if strax.RUN_DEFAULTS_KEY in doc:
+                self._run_defaults_cache[doc['name']] = \
+                    doc[strax.RUN_DEFAULTS_KEY]
+                del doc[strax.RUN_DEFAULTS_KEY]
 
             doc = flatten_run_metadata(doc)
 

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -54,13 +54,12 @@ class DataDirectory(StorageFrontend):
         with open(path, mode='r') as f:
             md = json.loads(f.read(),
                             object_hook=json_util.object_hook)
-        md = strax.flatten_dict(md, separator='.', keep='sub_run_spec')
+        md = strax.flatten_run_metadata(md)
         if projection is not None:
             md = {k: v
                   for k, v in md.items()
                   if k in projection}
         return md
-
 
     def write_run_metadata(self, run_id, metadata):
         with open(self._run_meta_path(run_id), mode='w') as f:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -269,6 +269,11 @@ def test_run_selection():
         st = strax.Context(storage=sf)
         assert len(st.scan_runs()) == len(mock_rundb)
         assert st.run_metadata('0') == mock_rundb[0]
+        assert st.run_metadata('0', projection='name') == {'name': '0'}
+
+        # Test caching of single-field projections
+        st.scan_runs()
+        assert st.run_metadata('0', projection='name') == {'name': '0'}
 
         assert len(st.select_runs(run_mode='nice')) == 2
         assert len(st.select_runs(include_tags='interesting')) == 2

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -271,10 +271,6 @@ def test_run_selection():
         assert st.run_metadata('0') == mock_rundb[0]
         assert st.run_metadata('0', projection='name') == {'name': '0'}
 
-        # Test caching of single-field projections
-        st.scan_runs()
-        assert st.run_metadata('0', projection='name') == {'name': '0'}
-
         assert len(st.select_runs(run_mode='nice')) == 2
         assert len(st.select_runs(include_tags='interesting')) == 2
         assert len(st.select_runs(include_tags='interesting',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,6 +8,7 @@ import pytest
 
 from strax.testutils import *
 
+
 def test_core():
     for allow_multiprocess in (False, True):
         for max_workers in [1, 2]:
@@ -279,6 +280,25 @@ def test_run_selection():
         assert len(st.select_runs(run_id='0')) == 1
         assert len(st.select_runs(run_id='*',
                                   exclude_tags='bad')) == 1
+
+
+def test_run_defaults():
+    mock_rundb = [{'name': '0', strax.RUN_DEFAULTS_KEY: dict(base_area=43)}]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        sf = strax.DataDirectory(path=temp_dir)
+        for d in mock_rundb:
+            sf.write_run_metadata(d['name'], d)
+        st = strax.Context(storage=sf, register=[Records, Peaks])
+
+        # The run defaults get used
+        peaks = st.get_array('0', 'peaks')
+        assert np.all(peaks['area'] == 43)
+
+        # ... but the user can still override them
+        peaks = st.get_array('0', 'peaks', config=dict(base_area=44))
+        assert np.all(peaks['area'] == 44)
+
 
 def test_dtype_mismatch():
     mystrax = strax.Context(storage=[],


### PR DESCRIPTION
This allows runs to specify default values for strax processing options via their metadata (run documents / database) using the `strax_defaults` field. This is very similar to the `processor...` field in XENON1T and will hopefully make correction handling a lot easier. Strax configruration priority is now as follows (high to low):
  * Context options (set by user)
  * Defaults specified in run metadata (i.e. run document/database)
  * Defaults specified with plugin definition, using `default`, `default_factory` or `default_per_run` (in that order of priority).

The `default_per_run` option will soon be deprecated/removed , now that this new way of specifying run-dependent defaults is available. Currently `default_per_run` forces strax runs to have names that are castable to integers, which breaks proper functioning of superruns (as @petergaemers noted) and is a pain more generally.

The original motivation behind `default_per_run` was that I liked to enable processing independent of a runs DB. Since run metadata can for some time already be provided by json files (as we currently do on dali), that motivation no longer applies.