### PR TITLE
Natural breaks splitting

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -714,8 +714,12 @@ class Context:
             t0 = self.run_metadata(run_id, 'start')['start']
             t0 = int(t0.timestamp()) * int(1e9)
         except strax.RunMetadataNotAvailable:
-            if targets is None:
-                raise
+            if targets is None or not len(targets):
+                warnings.warn(
+                    "Could not estimate run start time from "
+                    "run metadata: assuming it is 0",
+                    UserWarning)
+                return 0
             # Get an approx start from the data itself,
             # then floor it to seconds for consistency
             t = strax.to_str_tuple(targets)[0]

--- a/strax/context.py
+++ b/strax/context.py
@@ -714,7 +714,7 @@ class Context:
             t0 = self.run_metadata(run_id, 'start')['start']
             t0 = int(t0.timestamp()) * int(1e9)
         except strax.RunMetadataNotAvailable:
-            if targets is None or not len(targets):
+            if not targets:
                 warnings.warn(
                     "Could not estimate run start time from "
                     "run metadata: assuming it is 0",

--- a/strax/dtypes.py
+++ b/strax/dtypes.py
@@ -76,27 +76,31 @@ def peak_dtype(n_channels=100, n_sum_wv_samples=200, n_widths=11):
         raise ValueError("Must have more than one channel")
         # Otherwise array changes shape?? badness ensues
     return interval_dtype + [
-        (('Integral across channels in photoelectrons',
-            'area'), np.float32),
+        (('Integral across channels [PE]',
+          'area'), np.float32),
         # Area per channel in ADC * samples
-        (('Integral per channel in PE',
-            'area_per_channel'), np.float32, n_channels),
+        (('Integral per channel [PE]',
+          'area_per_channel'), np.float32, n_channels),
         # Number of hits from which this peak was constructed
         # (zero if peak was split afterwards)
         (("Number of hits from which peak was constructed "
           "(currently zero if peak is split afterwards)",
-            'n_hits'), np.int32),
+          'n_hits'), np.int32),
         # Waveform data in PE/sample
         (('Waveform data in PE/sample (not PE/ns!)',
-            'data'), np.float32, n_sum_wv_samples),
-        (('Peak widths in ns: range of central area fraction',
-            'width'), np.float32, n_widths),
-        (('Peak widths in ns: area from midpoint',
-            'area_decile_from_midpoint'), np.float32, n_widths),
-        (('Check if channel is saturated',
-            'saturated_channel'), np.int16, n_channels),
+          'data'), np.float32, n_sum_wv_samples),
+        (('Peak widths in range of central area fraction [ns]',
+          'width'), np.float32, n_widths),
+        (('Peak widths: time between nth and 5th area decile [ns]',
+          'area_decile_from_midpoint'), np.float32, n_widths),
+        (('Does the channel reach ADC saturation?',
+          'saturated_channel'), np.int16, n_channels),
         (('Total number of saturated channels',
-            'n_saturated_channels'), np.int16),
-        (('Hits within tight range of mean',
-          'tight_coincidence'), np.int16)
+          'n_saturated_channels'), np.int16),
+        (('Number of hits within tight range of mean',
+          'tight_coincidence'), np.int32),
+        (('Largest gap between hits inside peak [ns]',
+          'max_gap'), np.int32),
+        (('Maximum interior goodness of split',
+          'max_goodness_of_split'), np.float32),
     ]

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -43,14 +43,17 @@ def find_peaks(hits, adc_to_pe,
 
     in_peak = False
     peak_endtime = 0
-
     for hit_i, hit in enumerate(hits):
         p = buffer[offset]
         t0 = hit['time']
         dt = hit['dt']
         t1 = hit['time'] + dt * hit['length']
 
-        if not in_peak:
+        if in_peak:
+            # This hit continues an existing peak
+            p['max_gap'] = max(p['max_gap'], t0 - peak_endtime)
+
+        else:
             # This hit starts a new peak candidate
             area_per_channel *= 0
             peak_endtime = t1
@@ -61,6 +64,7 @@ def find_peaks(hits, adc_to_pe,
             p['n_hits'] = 0
             p['area'] = 0
             in_peak = True
+            p['max_gap'] = 0
 
         # Add hit's properties to the current peak candidate
         p['n_hits'] += 1

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -1,11 +1,3 @@
-"""Peak splitting functions
-
-TODO: there is considerable duplication between the two algorithms
-implemented here. Be careful when editing: if you fix a bug, there is
-likely a mirrored but in the other algorithm.
-
-(if you fix the duplication, you will be rewarded generously in the afterlife.)
-"""
 import numpy as np
 import numba
 import strax
@@ -14,236 +6,263 @@ export, __all__ = strax.exporter()
 
 
 @export
-def split_peaks(peaks, records, to_pe, algorithm='local_minimum',
-                min_height=25, min_ratio=4,
-                threshold=0.4, min_area=40,
-                do_iterations=1):
-    """Return peaks after splitting .
-    :param peaks: peaks to split
-    :param records: records from which peaks were built; for building waveforms of
-    split peaks.
-    :param algorithm: 'local_minimum' (default, for backwards compatibility)
-    or 'natural_breaks' (should be better!)
-    :param do_iterations: Maximum number of iterations / recursive splits to do.
+def split_peaks(peaks, records, to_pe, algorithm='local_minimum', **kwargs):
+    """Return peaks split according to algorithm, with sum waveforms built.
 
-    Other options depend on the algorithm.
-        local_minimum: takes options min_height and min_ratio.
-            Splits peaks at prominent local minima.
-            On either side of a split point, local maxima are:
-                - larger than minimum + min_height, AND
-                - larger than minimum * min_ratio
-            (this is related to topographical prominence for mountains)
-            NB: Min_height is in pe/ns, NOT pe/bin!
+    :param peaks: Original peaks. Sum waveform must have been built.
+    :param records: Records from which peaks were built
+    :param to_pe: ADC to PE conversion factor array (of n_channels)
+    :param algorithm: 'local_minimum' or 'natural_breaks'.
 
-        natural_breaks: takes options threshold and min_area
-            Split peaks according to Jenks natural breaks algorithm,
-            until all fragments have GOF < threshold, or < area.
-            If threshold is a string, will be evaled with area = peak areas
+    Any other options are passed to the algorithm.
     """
-    if not len(records) or not len(peaks):
+    splitter = dict(local_minimum=LocalMinimumSplitter,
+                    natural_breaks=NaturalBreaksSplitter)[algorithm]()
+    return splitter(peaks, records, to_pe, **kwargs)
+
+
+class PeakSplitter:
+    find_split_args_defaults: tuple
+
+    def __call__(self, peaks, records, to_pe,
+                 do_iterations=1, min_area=0, **kwargs):
+        if not len(records) or not len(peaks):
+            return peaks
+
+        # Build the *args tuple for self.find_split_points from kwargs
+        args_options = tuple([
+            kwargs[k] if k in kwargs else default
+            for k, default in self.find_split_args_defaults])
+
+        # Check for spurious options
+        argnames = [k for k, _ in self.find_split_args_defaults]
+        for k in kwargs:
+            if k not in argnames:
+                raise TypeError(f"Unknown argument {k} for {self.__class__}")
+
+        while do_iterations > 0:
+            is_split = np.zeros(len(peaks), dtype=np.bool_)
+
+            # Support for both algorithms is a bit awkward since we rely on numba,
+            # so we can't use many of python's cool tricks to avoid duplication
+            # (there surely is a way, but I'm too lazy to find one right now)
+            new_peaks = self.split_peaks(
+                # Numba doesn't like self as argument, but it's ok with functions...
+                split_finder=self.find_split_points,
+                peaks=peaks,
+                is_split=is_split,
+                orig_dt=records[0]['dt'],
+                min_area=min_area,
+                args_options=args_options,
+                result_dtype=peaks.dtype)
+
+            if is_split.sum() == 0:
+                # Nothing was split -- end early
+                break
+
+            strax.sum_waveform(new_peaks, records, to_pe)
+            peaks = strax.sort_by_time(np.concatenate([peaks[~is_split], new_peaks]))
+            do_iterations -= 1
+
         return peaks
 
-    while do_iterations > 0:
-        is_split = np.zeros(len(peaks), dtype=np.bool_)
-
-        # Support for both algorithms is a bit awkward since we rely on numba,
-        # so we can't use many of python's cool tricks to avoid duplication
-        # (there surely is a way, but I'm too lazy to find one right now)
-        if algorithm == 'natural_breaks':
-            if isinstance(threshold, str):
-                thresholds = eval(threshold, dict(np=np, peaks=peaks))
-            else:
-                thresholds = np.ones(len(peaks), dtype=np.float32) * threshold
-
-            new_peaks = _split_peaks_nb(
-                peaks,
-                orig_dt=records[0]['dt'],
-                is_split=is_split,
-                thresholds=thresholds,
-                min_area=min_area,
-                result_dtype=peaks.dtype)
-        else:
-            new_peaks = _split_peaks(
-                peaks,
-                orig_dt=records[0]['dt'],
-                is_split=is_split,
-                min_height=min_height,
-                min_ratio=min_ratio,
-                result_dtype=peaks.dtype)
-
-        if is_split.sum() == 0:
-            # Nothing was split -- end early
-            break
-
-        strax.sum_waveform(new_peaks, records, to_pe)
-        peaks = strax.sort_by_time(np.concatenate([peaks[~is_split], new_peaks]))
-        do_iterations -= 1
-
-    return peaks
-
-
-
-##
-# Local minimum clustering
-##
-
-
-@strax.utils.growing_result(dtype=strax.peak_dtype(), chunk_size=int(1e4))
-@numba.jit(nopython=True, nogil=True, cache=True)
-def _split_peaks(peaks, orig_dt, is_split,
-                 min_height, min_ratio,
-                 _result_buffer=None, result_dtype=None):
-    # TODO NEEDS TESTS!
-    new_peaks = _result_buffer
-    offset = 0
-
-    for p_i, p in enumerate(peaks):
-        prev_split_i = 0
-
-        w = p['data'][:p['length']]
-
-        for split_i in find_split_points(
-                w,
-                min_height=min_height * p['dt'],
-                min_ratio=min_ratio):
-            is_split[p_i] = True
-            r = new_peaks[offset]
-            r['time'] = p['time'] + prev_split_i * p['dt']
-            r['channel'] = p['channel']
-            # Set the dt to the original (lowest) dt first;
-            # this may change when the sum waveform of the new peak is computed
-            r['dt'] = orig_dt
-            r['length'] = (split_i - prev_split_i) * p['dt'] / orig_dt
-
-            if r['length'] <= 0:
-                print(p['data'])
-                print(prev_split_i, split_i)
-                raise ValueError("Attempt to create invalid peak!")
-
-            offset += 1
-            if offset == len(new_peaks):
-                yield offset
-                offset = 0
-
-            prev_split_i = split_i
-
-    yield offset
-
-
-@numba.jit(nopython=True, nogil=True, cache=True)
-def find_split_points(w, min_height=0, min_ratio=0):
-    """"Yield indices of prominent local minima in w
-    If there was at least one index, yields len(w)-1 at the end
-    """
-    found_one = False
-    last_max = -99999999999999.9
-    min_since_max = 99999999999999.9
-    min_since_max_i = 0
-
-    for i, x in enumerate(w):
-        if x < min_since_max:
-            # New minimum since last max
-            min_since_max = x
-            min_since_max_i = i
-
-        if min(last_max, x) > max(min_since_max + min_height,
-                                  min_since_max * min_ratio):
-            # Significant local minimum: tell caller,
-            # reset both max and min finder
-            yield min_since_max_i
-            found_one = True
-            last_max = x
-            min_since_max = 99999999999999.9
-            min_since_max_i = i
-
-        if x > last_max:
-            # New max, reset minimum finder state
-            # Notice this is AFTER the split check,
-            # to accomodate very fast rising second peaks
-            last_max = x
-            min_since_max = 99999999999999.9
-            min_since_max_i = i
-
-    if found_one:
-        yield len(w)
-
-
-##
-# Natural breaks clustering
-##
-
-@strax.utils.growing_result(dtype=strax.peak_dtype(), chunk_size=int(1e4))
-@numba.jit(nopython=True, nogil=True, cache=True)
-def _split_peaks_nb(peaks, orig_dt, is_split,
-                    # For natural breaks
-                    thresholds, min_area,
+    @staticmethod
+    @strax.growing_result(dtype=strax.peak_dtype(), chunk_size=int(1e4))
+    @numba.jit(nopython=True, nogil=True, cache=True)
+    def split_peaks(split_finder, peaks, orig_dt, is_split, min_area,
+                    args_options,
                     _result_buffer=None, result_dtype=None):
-    # TODO NEEDS TESTS!
-    # TODO any way to avoid the code duplication that is compatible with numba?
-    new_peaks = _result_buffer
-    offset = 0
+        # TODO NEEDS TESTS!
+        new_peaks = _result_buffer
+        offset = 0
 
-    for p_i, p in enumerate(peaks):
-        if p['area'] < min_area:
-            continue
+        for p_i, p in enumerate(peaks):
+            if p['area'] < min_area:
+                continue
 
-        prev_split_i = 0
-        w = p['data'][:p['length']]
+            prev_split_i = 0
+            w = p['data'][:p['length']]
 
-        for split_i in find_split_points_nb(
-                w,
-                threshold=thresholds[p_i]):
-            is_split[p_i] = True
-            r = new_peaks[offset]
-            r['time'] = p['time'] + prev_split_i * p['dt']
-            r['channel'] = p['channel']
-            # Set the dt to the original (lowest) dt first;
-            # this may change when the sum waveform of the new peak is computed
-            r['dt'] = orig_dt
-            r['length'] = (split_i - prev_split_i) * p['dt'] / orig_dt
+            for split_i in split_finder(w, p['dt'], *args_options):
+                is_split[p_i] = True
+                r = new_peaks[offset]
+                r['time'] = p['time'] + prev_split_i * p['dt']
+                r['channel'] = p['channel']
+                # Set the dt to the original (lowest) dt first;
+                # this may change when the sum waveform of the new peak is computed
+                r['dt'] = orig_dt
+                r['length'] = (split_i - prev_split_i) * p['dt'] / orig_dt
 
-            if r['length'] <= 0:
-                print(p['data'])
-                print(prev_split_i, split_i)
-                raise ValueError("Attempt to create invalid peak!")
+                if r['length'] <= 0:
+                    print(p['data'])
+                    print(prev_split_i, split_i)
+                    raise ValueError("Attempt to create invalid peak!")
 
-            offset += 1
-            if offset == len(new_peaks):
-                yield offset
-                offset = 0
+                offset += 1
+                if offset == len(new_peaks):
+                    yield offset
+                    offset = 0
 
-            prev_split_i = split_i
+                prev_split_i = split_i
 
-    yield offset
+        yield offset
+
+    @staticmethod
+    def find_split_points(w, *args_options):
+        raise NotImplementedError
 
 
-@numba.njit(nogil=True, cache=True)
-def find_split_points_nb(w, threshold=0.4, _dummy=0.):
-    gofs = natural_breaks_gof(w)
-    i = np.argmax(gofs)
-    if gofs[i] > threshold:
-        yield i
-        yield len(w) - 1
+class LocalMinimumSplitter(PeakSplitter):
+    """Split peaks at significant local minima.
+
+    On either side of a split point, local maxima are required to be
+     - larger than minimum + min_height, AND
+     - larger than minimum * min_ratio
+    This is related to topographical prominence for mountains.
+    NB: Min_height is in pe/ns, NOT pe/bin!
+    """
+    find_split_args_defaults = (
+        ('min_height', 0),
+        ('min_ratio', 0),
+    )
+
+    @staticmethod
+    @numba.jit(nopython=True, nogil=True, cache=True)
+    def find_split_points(w, dt, min_height, min_ratio):
+        """"Yield indices of prominent local minima in w
+        If there was at least one index, yields len(w)-1 at the end
+        """
+        found_one = False
+        last_max = -99999999999999.9
+        min_since_max = 99999999999999.9
+        min_since_max_i = 0
+
+        for i, x in enumerate(w):
+            if x < min_since_max:
+                # New minimum since last max
+                min_since_max = x
+                min_since_max_i = i
+
+            if min(last_max, x) > max(min_since_max + min_height,
+                                      min_since_max * min_ratio):
+                # Significant local minimum: tell caller,
+                # reset both max and min finder
+                yield min_since_max_i
+                found_one = True
+                last_max = x
+                min_since_max = 99999999999999.9
+                min_since_max_i = i
+
+            if x > last_max:
+                # New max, reset minimum finder state
+                # Notice this is AFTER the split check,
+                # to accomodate very fast rising second peaks
+                last_max = x
+                min_since_max = 99999999999999.9
+                min_since_max_i = i
+
+        if found_one:
+            yield len(w)
+
+
+class NaturalBreaksSplitter(PeakSplitter):
+    """Split peaks according to (variations of) the natural breaks algorithm,
+    i.e. such that the sum squared difference from the mean is minimized.
+
+    Options:
+     - threshold: threshold to accept a split in the goodness of split value:
+       1 - (f(left) + f(right))/f(unsplit)
+     - normalize: if True, f is the variance. Otherwise, it is the
+       sum squared difference from the mean (i.e. unnormalized variance)
+     - split_low: if True, multiply the goodness of split value by the ratio
+       between the waveform at the split point and the maximum in the waveform.
+       This prevent splits at high density points.
+     - filter_wing_width: if > 0, do a moving average filter (without shift) on the
+       waveform before the split_low computation.
+       The window will include the sample itself, plus filter_wing_width (or as
+       close as we can get to it given the peaks sampling) on either side.
+    """
+    find_split_args_defaults = (
+        ('threshold', 0.4),
+        ('normalize', False),
+        ('split_low', False),
+        ('filter_wing_width', 0))
+
+    @staticmethod
+    @numba.njit(nogil=True, cache=True)
+    def find_split_points(w, dt, threshold, normalize, split_low, filter_wing_width):
+        gofs = natural_breaks_gof(w, dt,
+                                  normalize=normalize,
+                                  split_low=split_low,
+                                  filter_wing_width=filter_wing_width)
+        i = np.argmax(gofs)
+        if gofs[i] > threshold:
+            yield i
+            yield len(w) - 1
 
 
 @export
 @numba.njit(nogil=True, cache=True)
-def natural_breaks_gof(w):
+def natural_breaks_gof(w, dt, normalize=False, split_low=False, filter_wing_width=0):
     """Return natural breaks goodness of split/fit for the waveform w
     a sharp peak gives ~0, two widely separate peaks ~1.
     """
-    left = intraclass_variance(w)
-    right = intraclass_variance(w[::-1])[::-1]
+    left = sum_squared_deviations(w, normalize=normalize)
+    right = sum_squared_deviations(w[::-1], normalize=normalize)[::-1]
     gof = 1 - (left + right) / left[-1]
-    # Adjust to prevent splits at high density points
-    gof *= 1 - w / w.max()
+    if split_low:
+        # Adjust to prevent splits at high density points
+        filter_width = filter_wing_width
+        filter_n = filter_width // dt - 1
+        if filter_n > 0:
+            filtered_w = symmetric_moving_average(w, filter_n)
+        else:
+            filtered_w = w
+        gof *= 1 - filtered_w / filtered_w.max()
     return gof
 
 
+@export
 @numba.njit(nogil=True, cache=True)
-def intraclass_variance(waveform):
+def symmetric_moving_average(a, wing_width):
+    """Return the moving average of a, over windows
+    of length [2 * wing_width + 1] centered on each sample.
+
+    (i.e. the window covers each sample itself, plus a 'wing' of width
+     wing_width on either side)
+    """
+    if wing_width == 0:
+        return a
+    n = len(a)
+    out = np.empty(n, dtype=a.dtype)
+    asum = a[:wing_width].sum()
+    count = wing_width
+    for i in range(len(a)):
+        # Index of the sample that just disappeared
+        # from the window
+        just_out = i - wing_width - 1
+        if just_out > 0:
+            count -= 1
+            asum -= a[just_out]
+
+        # Index of the sample that just appeared
+        # in the window
+        just_in = i + wing_width
+        if just_in < n:
+            count += 1
+            asum += a[just_in]
+
+        out[i] = asum / count
+    return out
+
+
+@numba.njit(nogil=True, cache=True)
+def sum_squared_deviations(waveform, normalize=False):
     """Return left-to-right result of an online
     sum-intra-class variance computation on the waveform.
+
+    :param normalize: If True, divide by the total area,
+    i.e. produce ordinary variance.
     """
     mean = sum_weights = s = 0
     result = np.zeros(len(waveform))
@@ -259,5 +278,7 @@ def intraclass_variance(waveform):
         mean = mean_old + (w / sum_weights) * (i - mean_old)
         s += w * (i - mean_old) * (i - mean)
         result[i] = s
+        if normalize:
+            result[i] /= sum_weights
 
     return result

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -1,39 +1,91 @@
+"""Peak splitting functions
+
+TODO: there is considerable duplication between the two algorithms
+implemented here. Be careful when editing: if you fix a bug, there is
+likely a mirrored but in the other algorithm.
+
+(if you fix the duplication, you will be rewarded generously in the afterlife.)
+"""
+
+
 import numpy as np
 import numba
 import strax
 
 __all__ = 'split_peaks '.split()
 
+def split_peaks(peaks, records, to_pe, algorithm='local_minimum',
+                min_height=25, min_ratio=4,
+                threshold=0.4, min_area=40,
+                do_iterations=1):
+    """Return peaks after splitting .
+    :param peaks: peaks to split
+    :param records: records from which peaks were built; for building waveforms of
+    split peaks.
+    :param algorithm: 'local_minimum' (default, for backwards compatibility)
+    or 'natural_breaks' (should be better!)
+    :param do_iterations: Maximum number of iterations / recursive splits to do.
 
-def split_peaks(peaks, records, to_pe, min_height=25, min_ratio=4):
-    """Return peaks after splitting at prominent sum waveform minima
-    'Prominent' means: on either side of a split point, local maxima are:
-    - larger than minimum + min_height
-    - larger than minimum * min_ratio
-    (this is related to topographical prominence for mountains)
+    Other options depend on the algorithm.
+        local_minimum: takes options min_height and min_ratio.
+            Splits peaks at prominent local minima.
+            On either side of a split point, local maxima are:
+                - larger than minimum + min_height, AND
+                - larger than minimum * min_ratio
+            (this is related to topographical prominence for mountains)
+            NB: Min_height is in pe/ns, NOT pe/bin!
 
-    Min_height is in pe/ns (NOT pe/bin!)
+        natural_breaks: takes options threshold and min_area
+            Split peaks according to Jenks natural breaks algorithm,
+            until all fragments have GOF < threshold, or < area.
     """
     if not len(records) or not len(peaks):
-        # Empty chunk: cannot proceed
         return peaks
-    
-    is_split = np.zeros(len(peaks), dtype=np.bool_)
 
-    new_peaks = _split_peaks(peaks,
-                             min_height=min_height,
-                             min_ratio=min_ratio,
-                             orig_dt=records[0]['dt'],
-                             is_split=is_split,
-                             result_dtype=peaks.dtype)
-    strax.sum_waveform(new_peaks, records, to_pe)
-    return strax.sort_by_time(np.concatenate([peaks[~is_split],
-                                              new_peaks]))
+    while do_iterations > 0:
+        is_split = np.zeros(len(peaks), dtype=np.bool_)
+
+        # Support for both algorithms is a bit awkward since we rely on numba,
+        # so we can't use many of python's cool tricks to avoid duplication
+        # (there surely is a way, but I'm too lazy to find one right now)
+        if algorithm == 'natural_breaks':
+            new_peaks = _split_peaks_nb(
+                peaks,
+                orig_dt=records[0]['dt'],
+                is_split=is_split,
+                threshold=float(threshold),
+                min_area=float(min_area),
+                result_dtype=peaks.dtype)
+        else:
+            new_peaks = _split_peaks(
+                peaks,
+                orig_dt=records[0]['dt'],
+                is_split=is_split,
+                min_height=float(min_height),
+                min_ratio=float(min_ratio),
+                result_dtype=peaks.dtype)
+
+        if is_split.sum() == 0:
+            # Nothing was split -- end early
+            break
+
+        strax.sum_waveform(new_peaks, records, to_pe)
+        peaks = strax.sort_by_time(np.concatenate([peaks[~is_split], new_peaks]))
+        do_iterations -= 1
+
+    return peaks
+
+
+
+##
+# Local minimum clustering
+##
 
 
 @strax.utils.growing_result(dtype=strax.peak_dtype(), chunk_size=int(1e4))
 @numba.jit(nopython=True, nogil=True, cache=True)
-def _split_peaks(peaks, min_height, min_ratio, orig_dt, is_split,
+def _split_peaks(peaks, orig_dt, is_split,
+                 min_height, min_ratio,
                  _result_buffer=None, result_dtype=None):
     # TODO NEEDS TESTS!
     new_peaks = _result_buffer
@@ -42,11 +94,13 @@ def _split_peaks(peaks, min_height, min_ratio, orig_dt, is_split,
     for p_i, p in enumerate(peaks):
         prev_split_i = 0
 
-        for split_i in find_split_points(p['data'][:p['length']],
-                                         min_height=min_height * p['dt'],
-                                         min_ratio=min_ratio):
-            is_split[p_i] = True
+        w = p['data'][:p['length']]
 
+        for split_i in find_split_points(
+                w,
+                min_height=min_height * p['dt'],
+                min_ratio=min_ratio):
+            is_split[p_i] = True
             r = new_peaks[offset]
             r['time'] = p['time'] + prev_split_i * p['dt']
             r['channel'] = p['channel']
@@ -106,3 +160,92 @@ def find_split_points(w, min_height=0, min_ratio=0):
 
     if found_one:
         yield len(w)
+
+
+##
+# Natural breaks clustering
+##
+
+@strax.utils.growing_result(dtype=strax.peak_dtype(), chunk_size=int(1e4))
+@numba.jit(nopython=True, nogil=True, cache=True)
+def _split_peaks_nb(peaks, orig_dt, is_split,
+                    # For natural breaks
+                    threshold, min_area,
+                    _result_buffer=None, result_dtype=None):
+    # TODO NEEDS TESTS!
+    # TODO any way to avoid the code duplication that is compatible with numba?
+    new_peaks = _result_buffer
+    offset = 0
+
+    for p_i, p in enumerate(peaks):
+        if p['area'] < min_area:
+            continue
+
+        prev_split_i = 0
+        w = p['data'][:p['length']]
+
+        for split_i in find_split_points_nb(
+                w,
+                threshold=threshold):
+            is_split[p_i] = True
+            r = new_peaks[offset]
+            r['time'] = p['time'] + prev_split_i * p['dt']
+            r['channel'] = p['channel']
+            # Set the dt to the original (lowest) dt first;
+            # this may change when the sum waveform of the new peak is computed
+            r['dt'] = orig_dt
+            r['length'] = (split_i - prev_split_i) * p['dt'] / orig_dt
+
+            if r['length'] <= 0:
+                print(p['data'])
+                print(prev_split_i, split_i)
+                raise ValueError("Attempt to create invalid peak!")
+
+            offset += 1
+            if offset == len(new_peaks):
+                yield offset
+                offset = 0
+
+            prev_split_i = split_i
+
+    yield offset
+
+
+@numba.njit(nogil=True, cache=True)
+def find_split_points_nb(w, threshold=0.4, _dummy=0.):
+    gofs = _gof_array(w)
+    i = np.argmax(gofs)
+    if gofs[i] > threshold:
+        yield i
+        yield len(w) - 1
+
+
+@numba.njit(nogil=True, cache=True)
+def _gof_array(w):
+    """Return natural breaks goodness of split/fit for the waveform w
+    a sharp peak gives ~0, two widely separate peaks ~1.
+    """
+    left = weighted_var_online(w)
+    right = weighted_var_online(w[::-1])[::-1]
+    gof = 1 - (left + right) / left[-1]
+    return gof
+
+
+@numba.njit(nogil=True, cache=True)
+def weighted_var_online(waveform):
+    """Return left-to-right result of an online weighted variance computation
+    on the waveform.
+    """
+    mean = sum_weights = s = 0
+    result = np.zeros(len(waveform))
+    for i, w in enumerate(waveform):
+        sum_weights += w
+        if sum_weights == 0:
+            continue
+
+        mean_old = mean
+        mean = mean_old + (w / sum_weights) * (i - mean_old)
+        s += w * (i - mean_old) * (i - mean)
+        result[i] = s / sum_weights
+
+    return result

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -242,6 +242,9 @@ def weighted_var_online(waveform):
     mean = sum_weights = s = 0
     result = np.zeros(len(waveform))
     for i, w in enumerate(waveform):
+        # Negative weights can lead to odd results, so clip waveform
+        w = max(0, w)
+
         sum_weights += w
         if sum_weights == 0:
             continue

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -72,10 +72,11 @@ class PeakSplitter:
             strax.compute_widths(new_peaks)
 
             # ... and recurse (if needed)
-            self(new_peaks, records, to_pe,
-                 do_iterations=do_iterations - 1,
-                 min_area=min_area, **kwargs)
-            peaks = strax.sort_by_time(np.concatenate([peaks[~is_split], new_peaks]))
+            new_peaks = self(new_peaks, records, to_pe,
+                             do_iterations=do_iterations - 1,
+                             min_area=min_area, **kwargs)
+            peaks = strax.sort_by_time(np.concatenate([peaks[~is_split],
+                                                       new_peaks]))
 
         return peaks
 
@@ -96,7 +97,7 @@ class PeakSplitter:
             prev_split_i = 0
             w = p['data'][:p['length']]
 
-            for (split_i, bonus_output) in split_finder(w, p['dt'], p_i, *args_options):
+            for split_i, bonus_output in split_finder(w, p['dt'], p_i, *args_options):
                 if split_i == NO_MORE_SPLITS:
                     p['max_goodness_of_split'] = bonus_output
                     continue    # ... but the iteration will end anyway afterwards

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -225,8 +225,7 @@ def natural_breaks_gof(w, dt, normalize=False, split_low=False, filter_wing_widt
     gof = 1 - (left + right) / left[-1]
     if split_low:
         # Adjust to prevent splits at high density points
-        filter_width = filter_wing_width
-        filter_n = filter_width // dt - 1
+        filter_n = filter_wing_width // dt - 1
         if filter_n > 0:
             filtered_w = symmetric_moving_average(w, filter_n)
         else:

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -12,8 +12,10 @@ import numpy as np
 import numba
 import strax
 
-__all__ = 'split_peaks '.split()
+export, __all__ = strax.exporter()
 
+
+@export
 def split_peaks(peaks, records, to_pe, algorithm='local_minimum',
                 min_height=25, min_ratio=4,
                 threshold=0.4, min_area=40,
@@ -213,15 +215,16 @@ def _split_peaks_nb(peaks, orig_dt, is_split,
 
 @numba.njit(nogil=True, cache=True)
 def find_split_points_nb(w, threshold=0.4, _dummy=0.):
-    gofs = _gof_array(w)
+    gofs = natural_breaks_gof(w)
     i = np.argmax(gofs)
     if gofs[i] > threshold:
         yield i
         yield len(w) - 1
 
 
+@export
 @numba.njit(nogil=True, cache=True)
-def _gof_array(w):
+def natural_breaks_gof(w):
     """Return natural breaks goodness of split/fit for the waveform w
     a sharp peak gives ~0, two widely separate peaks ~1.
     """

--- a/tests/test_peak_processing.py
+++ b/tests/test_peak_processing.py
@@ -29,6 +29,7 @@ def test_find_peaks(hits, min_channels, min_area):
         assert np.all(peaks['area'] >= min_area)
     if min_channels != 1:
         assert np.all(peaks['n_hits'] >= min_channels)
+    assert np.all(peaks['max_gap'] < gap_threshold)
 
     # Without requirements, all hits must occur in a peak
     if min_area == 0 and min_channels == 1:


### PR DESCRIPTION
This adds support for variations of Jenks/Fischer natural breaks for splitting peaks, as an alternative to or replacement for the local minimum prominence finding algorithm method.

You can find some background info on [wikipedia](https://en.wikipedia.org/wiki/Jenks_natural_breaks_optimization) and [here](https://medium.com/analytics-vidhya/jenks-natural-breaks-best-range-finder-algorithm-8d1907192051). In computer vision, when used on an image intensity histogram, this is known as [Otsu's method](https://en.wikipedia.org/wiki/Otsu%27s_method). 

Natural breaks finds a point in the waveform that maximizes the 'goodness of split':

```
      s(left)  +  s(right)
1  -  --------------------
           s(original)     
```
Here s is the (weighted) sum squared deviation from the (weighted) mean, and 'left' and 'right' mean the left and right part of the waveform after the split. To be fully precise, for a waveform w(t), the (weighted) mean is `m = sum[t w(t)]/sum[w(t)]` and `s = sum[ w(t) (t - m)^2 ]`.

Values near 1 can be interpreted as a strong advice to split the peak; values near 0 as strong advice not to do so.

In this implementation, the user supplies a threshold function that depends on the peak area. The algorithm probes this to decide whether to actually accept the best split and split the peak in two halves. If we do, we recurse on the split halves, until they either drop below some minimum area, have no acceptable splits anymore, or we reach a configurable recursion limit.

The code also supports two modified goodness of split functions:
 - **Normalized variance**: This replaces s with the usual, i.e normalized, variance: `s = sum[ w(t) (t - m)^2 ] / sum[w(t)]`. This is a kind of [F-statistic](https://en.wikipedia.org/wiki/F-test), and has been proposed as a test for bimodality in the past ([Larkin, 1979](https://link.springer.com/content/pdf/10.3758%2FBF03205709.pdf)). 
 - **Low Split**: Supress splits at high parts of the waveform, by multipling the goodness of split by [the sum waveform value at sample where we split] divided by [the maximum sum waveform amplitude]. To make this work for jagged low-energy waveforms, we apply a ~150-ns square filter, i.e. a moving average, to the waveform.

Below you can see how these perform on a few prototypical peaks in XENON1T data at high-energies (so features are clear enough to see by eye). These were found with our current default local minimum clustering.

You can see ordinary natural breaks algorithm reaches quite high 'goodness of split' values in the middle of a normal Gaussian-ish peak. Low Split and Normalized Variance both show a much larger difference between good and bad cases (their values are just lower overall). Normalized Variance, however, has trouble recognizing long tails; Low Split again does quite well here. Thus I'd lean towards using Low Split for now.

Well-resolved peaks
----------------------------
![natbreaks_example_82](https://user-images.githubusercontent.com/4354311/71591319-32db2700-2b2c-11ea-9c46-b065b2ea0051.png)
![natbreaks_example_1794](https://user-images.githubusercontent.com/4354311/71591324-353d8100-2b2c-11ea-94c8-e1ca1251d060.png)

Sticky tails
----------------------------
![natbreaks_example_1910](https://user-images.githubusercontent.com/4354311/71591354-48e8e780-2b2c-11ea-8dfc-efa911caecc6.png)
![natbreaks_example_1096](https://user-images.githubusercontent.com/4354311/71591453-ab41e800-2b2c-11ea-96c6-99e1cd5b2ffc.png)

Multiple modes
----------------------------
![natbreaks_example_3756](https://user-images.githubusercontent.com/4354311/71591435-96fdeb00-2b2c-11ea-8734-11b3faeb42b1.png)
![natbreaks_example_381](https://user-images.githubusercontent.com/4354311/71591457-b0069c00-2b2c-11ea-8552-5fff4db7f722.png)

