### PR TITLE
Change the default compressor to LZ4

### DIFF
--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -48,7 +48,7 @@ class Plugin:
     depends_on: tuple
     provides: tuple
 
-    compressor = 'blosc'
+    compressor = 'lz4'
 
     rechunk_on_save = True    # Saver is allowed to rechunk
 


### PR DESCRIPTION
For very large datafiles, ``blosc`` fails since the input buffer becomes larger than ~2 GB. Changing to LZ4 as default compressor allows to safely safe these larges chunks.