### PR TITLE
Fix time range finding issues

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -65,6 +65,8 @@ class Context:
     runs: ty.Union[pd.DataFrame, type(None)] = None
     _run_defaults_cache: dict = None
 
+    storage: ty.List[strax.StorageFrontend]
+
     def __init__(self,
                  storage=None,
                  config=None,
@@ -425,7 +427,7 @@ class Context:
                     fuzzy_for_options=self.context_config['fuzzy_for_options'],
                     allow_incomplete=self.context_config['allow_incomplete'])
 
-    def _get_partial_loader_for(self, key, n_range=None):
+    def _get_partial_loader_for(self, key, row_range=None, chunk_number=None):
         for sb_i, sf in enumerate(self.storage):
             try:
                 # Partial is clunky... but allows specifying executor later
@@ -434,53 +436,71 @@ class Context:
                 sf.find(key, **self._find_options)
                 return partial(sf.loader,
                                key,
-                               n_range=n_range,
+                               row_range=row_range,
+                               chunk_number=chunk_number,
                                **self._find_options)
             except strax.DataNotAvailable:
                 continue
         return False
 
-    def _time_range_to_n_range(self, run_id: str,
-                               time_range: ty.Tuple[int],
-                               d_with_time: str):
-        """Return range of chunk numbers that include time_range
+    def _time_range_to_row_range(self,
+                                 run_id: str,
+                                 time_range: ty.Tuple[int],
+                                 d_with_time: str):
+        """Return range of row numbers (with exclusive stop) of data
+        that intersect with time_range.
         :param run_id: Run name
         :param time_range: (start, stop) ns since unix epoch
-        :param d_with_time: Name of data type
-
-        With 'includes', we here mean that includes at least one piece of data
-        that intersects the time range.
+        :param d_with_time: Data type to derive mapping from
         """
-        # Find a range of row numbers that contains the time range
-        # It's a bit too large: to
-        # Get the n <-> time mapping in needed chunks
         if not self.is_stored(run_id, d_with_time):
             raise strax.DataNotAvailable(
-                "Time range selection needs time info from "
-                f"{d_with_time}, but this data is not yet available")
+                f"{d_with_time} from {run_id} is not available, so you cannot " 
+                "select a time slice from it.")
 
         meta = self.get_meta(run_id, d_with_time)
         if not len(meta['chunks']):
             raise ValueError("Data has no chunks??")
 
-        result = [0, -1]
+        n_start, n_stop = None, None
         chunk_info = dict()  # Otherwise pycharm complains later
-        prev_endtime = 0
-        for i, chunk_info in enumerate(strax.iter_chunk_meta(meta)):
-            n_range = [chunk_info['n_from'], chunk_info['n_to']]
-            for j, t in enumerate(time_range):
-                if prev_endtime < t <= chunk_info['last_endtime']:
-                    result[j] = n_range[j]
-            prev_endtime = chunk_info['last_endtime']
+        for chunk_i, chunk_info in enumerate(strax.iter_chunk_meta(meta)):
 
-        if result[1] == -1:
-            result[1] = chunk_info['n_to']
-        return result
+            has_start = (
+                n_start is None
+                and time_range[0] < chunk_info['last_endtime'])
+            has_end = (
+                n_stop is None
+                and time_range[1] < chunk_info['last_endtime'])
+
+            df = None
+            if has_start or has_end:
+                # Load data to get exact row number mapping
+                df = self.get_array(run_id, d_with_time, _chunk_number=chunk_i)
+
+            # np.argmax on a boolean array gives the first index where it is
+            # True (or 0 if the entire array is False)
+            if has_start:
+                n_start = chunk_info['n_from'] + \
+                          np.argmax(strax.endtime(df) > time_range[0])
+            if has_end:
+                n_stop = chunk_info['n_from'] \
+                         + np.argmax(df['time'] >= time_range[1])
+
+        if n_stop is None:
+            # Time range extends beyond the final chunk
+            n_stop = chunk_info['n_to'] + 1
+
+        if not (0 <= n_start <= n_stop <= chunk_info['n_to'] + 1):
+            raise RuntimeError(
+                f"Time range {time_range} for {d_with_time} "
+                f"mapped to invalid row range {n_start}-{n_stop}.")
+        return n_start, n_stop
 
     def get_components(self, run_id: str,
                        targets=tuple(), save=tuple(),
-                       time_range=None,
-                      ) -> strax.ProcessorComponents:
+                       time_range=None, chunk_number=None
+                       ) -> strax.ProcessorComponents:
         """Return components for setting up a processor
         {get_docs}
         """
@@ -500,7 +520,7 @@ class Context:
         targetp = plugins[target]
 
         if time_range is None:
-            n_range_for = dict()
+            row_range_for = dict()
         else:
             if 'time' not in targetp.dtype_for(target).names:
                 raise ValueError(
@@ -510,7 +530,7 @@ class Context:
             time_mappers = dict()
             if targetp.save_when == strax.SaveWhen.NEVER:
                 # The target is never saved, it's likely just some merging.
-                # But that means we have to load the dependencies,
+                # That means we have to load the dependencies,
                 # which might have different kinds, or be themselves never saved
                 for kind, deps in strax.group_by_kind(targetp.depends_on, plugins).items():
                     for d in deps:
@@ -524,14 +544,11 @@ class Context:
                             f"{target}, since it isn't saved itself "
                             f"and none of the dependencies {deps} of kind "
                             f" {kind} provide time information.")
-
-                    # ???
-                    # d_with_time = plugins[d_with_time].provides[0]
             else:
                 time_mappers[targetp.data_kind_for(target)] = target
 
-            n_range_for = {
-                kind: self._time_range_to_n_range(run_id, time_range, d)
+            row_range_for = {
+                kind: self._time_range_to_row_range(run_id, time_range, d)
                 for kind, d in time_mappers.items()}
 
         # Get savers/loaders, and meanwhile filter out plugins that do not
@@ -554,7 +571,8 @@ class Context:
             key = strax.DataKey(run_id, d, p.lineage)
             ldr = self._get_partial_loader_for(
                 key,
-                n_range=n_range_for.get(p.data_kind_for(d)))
+                chunk_number=chunk_number,
+                row_range=row_range_for.get(p.data_kind_for(d)))
 
             if not ldr and run_id.startswith('_'):
                 if time_range is not None:
@@ -575,10 +593,12 @@ class Context:
                         sub_n_range = None
                     else:
                         # TODO: this currently fails for data without time
-                        sub_n_range = self._time_range_to_n_range(
+                        sub_n_range = self._time_range_to_row_range(
                             subrun, sub_run_spec[subrun], d)
                     ldr = self._get_partial_loader_for(
-                        sub_key, n_range=sub_n_range)
+                        sub_key,
+                        row_range=sub_n_range,
+                        chunk_number=chunk_number)
                     if not ldr:
                         raise RuntimeError(
                             f"Could not load {d} for subrun {subrun} "
@@ -770,6 +790,7 @@ class Context:
                  time_within=None,
                  time_selection='fully_contained',
                  selection_str=None,
+                 _chunk_number=None,
                  **kwargs) -> ty.Iterator[np.ndarray]:
         """Compute target for run_id and iterate over results.
 
@@ -808,7 +829,8 @@ class Context:
         components = self.get_components(run_id,
                                          targets=targets,
                                          save=save,
-                                         time_range=time_range)
+                                         time_range=time_range,
+                                         chunk_number=_chunk_number)
 
         # Cleanup the temp plugins
         for k in list(self._plugin_class_registry.keys()):
@@ -1035,6 +1057,7 @@ the start of the run to load.
 - fully_contained: (default) select things fully contained in the range
 - touching: select things that (partially) overlap with the range
 - skip: Do not select a time range, even if other arguments say so
+:param _chunk_number: For internal use: return data from one chunk.
 """
 
 get_docs = """

--- a/strax/context.py
+++ b/strax/context.py
@@ -465,6 +465,10 @@ class Context:
         n_start, n_stop = None, None
         chunk_info = dict()  # Otherwise pycharm complains later
         for chunk_i, chunk_info in enumerate(strax.iter_chunk_meta(meta)):
+            if 'last_endtime' not in chunk_info:
+                raise ValueError(
+                    f"{d_with_time} does not have time information, "
+                    "cannot use it to convert time range to row numbers")
 
             has_start = (
                 n_start is None
@@ -577,8 +581,8 @@ class Context:
                 else:
                     # Fallback, can happen if target and one of its dependencies
                     # is not stored (e.g. merging peaks with something else)
-                    row_range = self._time_range_to_row_range(
-                        run_id, time_range, d)
+                    row_range = row_range_for[kind] = \
+                        self._time_range_to_row_range(run_id, time_range, d)
             else:
                 row_range = None
 

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -460,10 +460,12 @@ class LoopPlugin(Plugin):
                 kwargs[k] = r
 
         results = np.zeros(len(base), dtype=self.dtype)
+        deps_by_kind = self.dependencies_by_kind()
+
         for i in range(len(base)):
             r = self.compute_loop(base[i],
                                   **{k: kwargs[k][i]
-                                     for k in self.dependencies_by_kind()
+                                     for k in deps_by_kind
                                      if k != loop_over})
 
             # Convert from dict to array row:

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -374,7 +374,7 @@ class StorageBackend:
         for i, ci in enumerate(strax.iter_chunk_meta(metadata)):
 
             # Chunk number constraint
-            if chunk_number:
+            if chunk_number is not None:
                 if i != chunk_number:
                     continue
 

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -411,24 +411,21 @@ def multi_run(f, run_ids, *args, max_workers=None,
               throw_away_result=False,
               **kwargs):
     """Execute f(run_id, **kwargs) over multiple runs,
-    then return list of results.
+    then return list of result arrays, each with a run_id column added.
 
+    :param f: Function to run
     :param run_ids: list/tuple of runids
-    :param max_workers: number of worker threads/processes to spawn
+    :param max_workers: number of worker threads/processes to spawn.
+    If set to None, defaults to 1.
     :param throw_away_result: instead of collecting result, return None.
 
     Other (kw)args will be passed to f
     """
-    # Try to int all run_ids
+    if max_workers is None:
+        max_workers = 1
 
-    # Get a numpy array of run ids.
-    try:
-        run_id_numpy = np.array([int(x) for x in run_ids],
-                                dtype=np.int32)
-    except ValueError:
-        # If there are string id's among them,
-        # numpy will autocast all the run ids to Unicode fixed-width
-        run_id_numpy = np.array(run_ids)
+    # This will autocast all run ids to Unicode fixed-width
+    run_id_numpy = np.array(run_ids)
 
     # Probably we'll want to use dask for this in the future,
     # to enable cut history tracking and multiprocessing.
@@ -445,6 +442,7 @@ def multi_run(f, run_ids, *args, max_workers=None,
             r = f.result()
             if throw_away_result:
                 continue
+            # Append the run id column
             ids = np.array([run_id_numpy[i]] * len(r),
                            dtype=[('run_id', run_id_numpy.dtype)])
             r = merge_arrs([ids, r])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -31,7 +31,7 @@ def test_multirun():
         assert len(bla) == n * 2
         np.testing.assert_equal(
             bla['run_id'],
-            np.array([0] * n + [1] * n, dtype=np.int32))
+            np.array(['0'] * n + ['1'] * n))
 
 
 def test_filestore():


### PR DESCRIPTION
This is a fix for #230, i.e. the treatment of the time_range / seconds_range / time_within options.

Background info:
  * Strax supports (a) data without time information, such as `peaklet_classification` or `corrected_areas` and (b) data that is never stored, such as peaks, or the temporary datatypes that are made to merge e.g. `peaks` and `peak_basics` if you load them together.
  * Strax even allows time selection with a no-time datatype as long as you load it alongside data of the same kind that does have time info (like `peaks`). It will then use the latter to map the time range to row numbers, which can be selected in the no-time datatypes.

There were two bugs:
  * Strax was too coarse when converting time ranges to row numbers. We picked whichever time-bearing datatype was listed first, found out in which chunk the start and stop of the range were contained, then loaded the row numbers corresponding to those entire chunks. If this data type happened to be very slim (few columns), a chunk would correspond to way more time than you selected (since we try to save in fixed-size files), possibly the entire run. If the simultaneously loaded data types were not slim, your RAM might explode.
  * The time range argument and associated conversion to row ranges could be spuriously skipped. When loading a never-stored datatype such as `peaks` together with a time-bearing datatype of the same kind, such as `peak_basics`, `peaks` still has to be reconstructed from `peaklets` and `merged_s2s`. However, the time range was not passed on to the latter, so strax attempted to load the full data in the run, starting with the first chunk, which would usually cause a merge failure. (... but not always; due to the very coarse chunk mapping you were fine if the run only had one chunk or perhaps if you were just loading the first chunk.)

Now:
  * Strax actually loads data to find out the exact row numbers that correspond to the time range (only for chunks containing the start and stop time, so possibly just one chunk). This does mean that some data is loaded twice when doing time_range selections.
  * If a `time_range` is specified, it will apply to all data types that are loaded. There are likely still cases where the current logic fails, e.g. when you make some deep chain of no-time-bearing and never-stored plugins. Then you will get a neater error: it will say which data type it tried in vain to find time information for (rather than a weird merge failure or blowing up your memory).
  * `_time_range_to_n_range` has been renamed to `time_range_to_row_range` for clarify.
  * An additional option `_chunk_number` is added to `get_array`, `get_df`, etc, to load just a single chunk. This is used internally in `time_range_to_row_range`.

Taking a step back, this is all additional complexity that comes from supporting data types without time information (see also https://github.com/AxFoundation/strax/issues/79). If I knew how much trouble this would have brought I would never have supported it -- it saves a bit of space, but not so much. However, by now, it is probably too big of a downstream change to stop supporting this.