### PR TITLE
Lazy mailbox

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -39,6 +39,9 @@ RUN_DEFAULTS_KEY = 'strax_defaults'
                       "If False, will use multithreading only."),
     strax.Option(name='allow_shm', default=False,
                  help="Allow use of /dev/shm for interprocess communication."),
+    strax.Option(name='allow_lazy', default=True,
+                 help='Allow "lazy" processing. Saves memory, but incompatible '
+                      'with multiprocessing and perhaps slightly slower.'),
     strax.Option(name='forbid_creation_of', default=tuple(),
                  help="If any of the following datatypes is requested to be "
                       "created, throw an error instead. Useful to limit "
@@ -747,6 +750,7 @@ class Context:
                 allow_shm=self.context_config['allow_shm'],
                 allow_multiprocess=self.context_config['allow_multiprocess'],
                 allow_rechunk=self.context_config['allow_rechunk'],
+                allow_lazy=self.context_config['allow_lazy'],
                 max_messages=self.context_config['max_messages'],
                 timeout=self.context_config['timeout']).iter()):
             seen_a_chunk = True

--- a/strax/mailbox.py
+++ b/strax/mailbox.py
@@ -238,7 +238,8 @@ class Mailbox:
             if self.lazy:
                 def can_write():
                     return (
-                        (msg_number in self.subscriber_waiting_for
+                        (any([x is not None
+                              for x in self.subscriber_waiting_for])
                          and len(self._mailbox) < self.max_messages)
                         or self.killed)
             else:

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -288,6 +288,15 @@ class Plugin:
             else:
                 # Fetch the pacemaker, to figure out when this chunk ends
                 if not _fetch_chunk(pacemaker):
+                    # Source is exhausted. The other sources should also be
+                    # exhausted. This (a) checks this, and (b) ensures that
+                    # the content of all sources are requested all the way to
+                    # the end -- which lazy-mode processing requires
+                    for d in self.depends_on:
+                        if _fetch_chunk(d):
+                            raise RuntimeError(
+                                f"{self} sees that {pacemaker} is exhausted "
+                                f"before other dependency {d}!")
                     self.cleanup(wait_for=pending_futures)
                     return
                 this_chunk_end = self.input_buffer[pacemaker].end

--- a/strax/processor.py
+++ b/strax/processor.py
@@ -52,6 +52,7 @@ class ThreadedMailboxProcessor:
                  components: ProcessorComponents,
                  allow_rechunk=True, allow_shm=False,
                  allow_multiprocess=False,
+                 allow_lazy=True,
                  max_workers=None,
                  max_messages=4,
                  timeout=60):
@@ -69,7 +70,7 @@ class ThreadedMailboxProcessor:
             # Disable the executors: work in one process.
             # Each plugin works completely in its own thread.
             self.process_executor = self.thread_executor = None
-            lazy = True
+            lazy = allow_lazy
         else:
             lazy = False
             # Use executors for parallelization of computations.

--- a/tests/test_mailbox.py
+++ b/tests/test_mailbox.py
@@ -85,23 +85,16 @@ def test_result_timeout():
     """Test that our mailbox tester actually times out.
     (if not, the other tests might hang indefinitely if something is broken)
     """
-    for lazy in [False, True]:
-        print(f"Lazy mode: {lazy}")
-
-        with pytest.raises(concurrent.futures.TimeoutError):
-            mailbox_tester([0, 1],
-                           lazy=lazy,
-                           numbers=[1, 2],
-                           timeout=2 * LONG_TIMEOUT)
+    with pytest.raises(concurrent.futures.TimeoutError):
+        mailbox_tester([0, 1],
+                       numbers=[1, 2],
+                       timeout=2 * LONG_TIMEOUT)
 
 
 def test_read_timeout():
     """Subscribers time out if we cannot read for too long"""
-    for lazy in [False, True]:
-        print(f"Lazy mode: {lazy}")
-
-        with pytest.raises(strax.MailboxReadTimeout):
-            mailbox_tester([0, 1], numbers=[1, 2], lazy=lazy)
+    with pytest.raises(strax.MailboxReadTimeout):
+        mailbox_tester([0, 1], numbers=[1, 2])
 
 
 def test_write_timeout():

--- a/tests/test_mailbox.py
+++ b/tests/test_mailbox.py
@@ -62,10 +62,10 @@ def mailbox_tester(messages,
 def test_highlevel():
     """Test highlevel mailbox API"""
     for lazy in [False, True]:
-        print(f"Single mode: {lazy}")
+        print(f"Lazy mode: {lazy}")
 
         mb = strax.Mailbox(lazy=lazy)
-        mb.add_sender(range(10))
+        mb.add_sender(iter(list(range(10))))
 
         def test_reader(source):
             test_reader.got = r = []
@@ -99,14 +99,10 @@ def test_read_timeout():
 
 def test_write_timeout():
     """Writers time out if we cannot write for too long"""
-    for lazy in [False, True]:
-        print(f"Lazy mode: {lazy}")
-
-        with pytest.raises(strax.MailboxFullTimeout):
-            mailbox_tester([0, 1, 2, 3, 4],
-                           max_messages=1,
-                           lazy=lazy,
-                           reader_sleeps=LONG_TIMEOUT)
+    with pytest.raises(strax.MailboxFullTimeout):
+        mailbox_tester([0, 1, 2, 3, 4],
+                       max_messages=1,
+                       reader_sleeps=LONG_TIMEOUT)
 
 
 def test_reversed():


### PR DESCRIPTION
This makes strax's processing more robust and use 15-20% less memory when in single-core mode. Multicore processing is unchanged.

In the new mode, called 'lazy processing', a piece of data is only loaded or computed when it is requested by a higher-up plugin (or, ultimately, the user). Mailboxes now track who is waiting for what chunk. In lazy mode, they will:
  * Block fetching of new messages if any subscriber is 'waiting' for a message we already have. This just means the OS hasn't given its thread priority yet.
  * Fetch a new message only when a "driving" subscriber -- a plugins, not a saver -- is waiting for a new chunk we don't yet have.

This avoids loading chunks we do not need in memory, saving a bit of memory. More importantly, it means the buffers can be unbounded -- `max_messages` is ignored in lazy mode. This should prevent a lot of deadlock situations. Having unbounded buffers could cause an out-of-memory error, but since we fetch new messages only when necessary, this should only happen in cases where we would now get a deadlock (or an out-of-memory error, depending on `max_messages`).

Lazy mode is automatically activated for single-core processing. It can be turned off by setting the `allow_lazy` context option to False.

Lazy mode is always deactivated when multiprocessing. If you only load data that is requested, at most one computation per plugin will be running. But for online processing to be efficient, we must be able to run many forks of raw_records / DAQReader.

On my laptop I saw a very slight (~5-10%) slowdown in processing time. This is likely because my laptop has more than one core, so there is perhaps a (marginal) advantage to the ordinary processing scheme, even when max_workers = 1.