### PR TITLE
Check for presence of 0th fragment while baselining

### DIFF
--- a/strax/processing/pulse_processing.py
+++ b/strax/processing/pulse_processing.py
@@ -43,8 +43,7 @@ def baseline(records, baseline_samples=40, flip=True,
     # We only care about the channels in this set of records; a single .max()
     # is worth avoiding the hassle of passing n_channels around
     n_channels = records['channel'].max() + 1
-    last_bl_in = (
-        16000 * np.ones((n_channels, 2), dtype=np.int16))
+    last_bl_in = np.zeros((n_channels, 2), dtype=np.int16)
     seen_first = np.zeros(n_channels, dtype=np.bool_)
 
     for d_i, d in enumerate(records):

--- a/strax/processing/pulse_processing.py
+++ b/strax/processing/pulse_processing.py
@@ -17,7 +17,8 @@ NO_RECORD_LINK = -1
 
 @export
 @numba.jit(nopython=True, nogil=True, cache=True)
-def baseline(records, baseline_samples=40, flip=True):
+def baseline(records, baseline_samples=40, flip=True,
+             allow_sloppy_chunking=False, fallback_baseline=16000):
     """Determine baseline as the average of the first baseline_samples
     of each pulse. Subtract the pulse data from int(baseline),
     and store the baseline mean and rms.
@@ -25,6 +26,9 @@ def baseline(records, baseline_samples=40, flip=True):
     :param baseline_samples: number of samples at start of pulse to average
     to determine the baseline.
     :param flip: If true, flip sign of data
+    :param allow_sloppy_chunking: Allow use of the fallback_baseline in case
+    the 0th fragment of a pulse is missing
+    :param fallback_baseline: Fallback baseline (ADC counts)
 
     Assumes records are sorted in time (or at least by channel, then time).
 
@@ -38,17 +42,27 @@ def baseline(records, baseline_samples=40, flip=True):
     # Array for looking up last baseline (mean, rms) seen in channel
     # We only care about the channels in this set of records; a single .max()
     # is worth avoiding the hassle of passing n_channels around
-    last_bl_in = np.zeros((records['channel'].max() + 1, 2), dtype=np.int16)
+    n_channels = records['channel'].max() + 1
+    last_bl_in = (
+        16000 * np.ones((n_channels, 2), dtype=np.int16))
+    seen_first = np.zeros(n_channels, dtype=np.bool_)
 
     for d_i, d in enumerate(records):
 
         # Compute the baseline if we're the first record of the pulse,
         # otherwise take the last baseline we've seen in the channel
         if d.record_i == 0:
+            seen_first[d.channel] = True
             w = d.data[:baseline_samples]
             last_bl_in[d.channel] = bl, rms = w.mean(), w.std()
         else:
             bl, rms = last_bl_in[d.channel]
+            if not seen_first[d.channel]:
+                if not allow_sloppy_chunking:
+                    print(d.time, d.channel, d.record_i)
+                    raise RuntimeError("Cannot baseline, missing 0th fragment!")
+                bl = last_bl_in[d.channel] = fallback_baseline
+                rms = np.nan
 
         # Subtract baseline from all data samples in the record
         # (any additional zeros should be kept at zero)


### PR DESCRIPTION
If input data to strax is sufficiently bad, we could miss the 0th record but have a later record of a pulse in a chunk. If this happens, and it is the first pulse in that channel, we currently accidentally assume a baseline of 0. This is bad since baselines are usually around 16000.

This makes strax throw an error instead in this situation. To allow processing of data that has been improperly chunked, `strax.baseline` gets the extra options `allow_sloppy_chunking` (default False) and `fallback_baseline` (default 16000). If `allow_sloppy_chunking=True`, we will use the `fallback_baseline` instead of throwing an error in the situation mentioned above.