### PR TITLE
Add info to ValueErrors for np.frombuffer

### DIFF
--- a/strax/io.py
+++ b/strax/io.py
@@ -52,8 +52,11 @@ def _load_file(f, compressor, dtype):
             return np.zeros(0, dtype=dtype)
 
         data = COMPRESSORS[compressor]['decompress'](data)
-        return np.frombuffer(data, dtype=dtype)
-
+        try:
+            return np.frombuffer(data, dtype=dtype)
+        except ValueError as e:
+            raise ValueError(f"ValueError while loading data with dtype =\n\t{dtype}") from e   
+            
     except Exception:
         raise strax.DataCorrupted(
             f"Fatal Error while reading file {f}: "


### PR DESCRIPTION
This could be a very small change to add some extra info in to a ValueError arising from np.frombuffer.

This has proven to be useful after the latest strax(en) format change and sorting out if redax-output and strax(en) input are in sync.