### PR TITLE
More memory optimizations

### DIFF
--- a/strax/mailbox.py
+++ b/strax/mailbox.py
@@ -357,8 +357,6 @@ class Mailbox:
                         raise MailboxReadTimeout(
                             f"{self.name} did not get {next_number} in time.")
                 self._subscriber_waiting_for[subscriber_i] = None
-                if self.lazy and self._can_fetch():
-                    self._fetch_new_condition.notify_all()
 
                 if self.killed:
                     self.log.debug(f"Reader finds {self.name} killed")
@@ -388,6 +386,9 @@ class Mailbox:
                        and (min(self._subscribers_have_read)
                             >= self._lowest_msg_number)):
                     heapq.heappop(self._mailbox)
+
+                if self.lazy and self._can_fetch():
+                    self._fetch_new_condition.notify_all()
                 self._write_condition.notify_all()
 
             for msg_number, msg in to_yield:

--- a/strax/mailbox.py
+++ b/strax/mailbox.py
@@ -447,7 +447,11 @@ class Mailbox:
 
 
 @export
-def divide_outputs(source, mailboxes, outputs=None):
+def divide_outputs(source,
+                   mailboxes: typing.Dict[str, Mailbox],
+                   lazy=False,
+                   flow_freely=tuple(),
+                   outputs=None):
     """This code is a 'mail sorter' which gets dicts of arrays from source
     and sends the right array to the right mailbox.
     """
@@ -457,10 +461,37 @@ def divide_outputs(source, mailboxes, outputs=None):
     mbs_to_kill = [mailboxes[d] for d in outputs]
     # TODO: this code duplicates exception handling and cleanup
     # from Mailbox.send_from! Can we avoid that somehow?
+    i = 0
     try:
-        for result in source:
+        while True:
+            for d in outputs:
+                if d in flow_freely:
+                    # Do not block on account of these guys
+                    continue
+
+                m = mailboxes[d]
+                if lazy:
+                    with m._lock:
+                        if not m._can_fetch():
+                            m.log.debug(f"Waiting to fetch {i}, "
+                                        f"{m._subscriber_waiting_for}, "
+                                        f"{m._subscriber_can_drive}")
+                            if not m._fetch_new_condition.wait_for(
+                                    m._can_fetch, timeout=m.timeout):
+                                raise MailboxReadTimeout(
+                                    f"{m} could not progress beyond {i}, "
+                                    f"no driving subscriber requested it.")
+
+            try:
+                result = next(source)
+            except StopIteration:
+                # No need to send this yet, close will do that
+                break
+
             for d, x in result.items():
                 mailboxes[d].send(x)
+            i += 1
+
     except Exception as e:
         for m in mbs_to_kill:
             m.kill_from_exception(e, reraise=False)

--- a/strax/mailbox.py
+++ b/strax/mailbox.py
@@ -424,8 +424,7 @@ class Mailbox:
         for msg_number, msg in self._mailbox:
             if msg_number == number:
                 return msg
-        else:
-            raise RuntimeError(f"Could not find message {number}")
+        raise RuntimeError(f"Could not find message {number}")
 
     def _has_msg(self, number):
         """Return if mailbox has message number.

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -511,18 +511,11 @@ class OverlapWindowPlugin(Plugin):
         raise NotImplementedError
 
     def iter(self, iters, executor=None):
-        # Keep one chunk in reserve, since we have to do something special
-        # if we see the last chunk.
-        last_result = None
-        for x in super().iter(iters, executor=executor):
-            if last_result is not None:
-                yield last_result
-            last_result = x
+        yield from super().iter(iters, executor=executor)
 
-        if self.cached_results is not None and last_result is not None:
-            # Note we do this even if the cached_result is only emptiness,
-            # to make sure our final result ends at the right time.
-            yield strax.Chunk.concatenate([last_result, self.cached_results])
+        # Yield final results, kept at bay in fear of a new chunk
+        if self.cached_results is not None:
+            yield self.cached_results
 
     def do_compute(self, chunk_i=None, **kwargs):
         if not len(kwargs):


### PR DESCRIPTION
This:
  * Makes multi-output plugins respect lazy mode (#241). Currently `divide_outputs` doesn't account for lazy mode, so a multi-output plugin could still run away and fetch as much as it likes (potentially blowing up since in lazy mode, the max_messages limits are removed)
  * For plugins with multiple inputs, the input controlling the chunk size ('pacemaker') is chosen to be the input that produces the smallest first chunk. Currently we just take the first dependency listed in depends_on.
  * OverlapWindowPlugin no longer keeps one chunk back, since it is now OK to yield empty chunks.

These together reduce strax's memory usage in single-core mode by about 15-20%, on top of the similar reduction from #241. Lazy mode now uses about ~30% less memory than non-lazy mode.

The only downside of lazy mode, as noted in #241, is that processing slows down significantly (up to 50% or so) when using single-core lazy mode on a multi-core job/machine. The lazy processing topology assumes you cannot do things in parallel, so when you actually can, it is less efficient. 

The multicore processing performance and memory use seem unaffected, although the last two changes listed above do affect multicore processing.