### PR TITLE
Make exception work for incomplete matadata too

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -647,7 +647,7 @@ class Context:
             # the run start time (floored to seconds)
             t0 = self.run_metadata(run_id, 'start')['start']
             t0 = int(t0.timestamp()) * int(1e9)
-        except strax.RunMetadataNotAvailable:
+        except (strax.RunMetadataNotAvailable, KeyError):
             if not targets:
                 warnings.warn(
                     "Could not estimate run start time from "


### PR DESCRIPTION
This is a great feature of strax that is needed if one e.g. wants to load only a small part of the data. The exception is also gread in case the RunMetaData is not available. 

However in case of incomplete RunMetaData the error is not a `strax.RunMetadataNotAvailable` but a `KeyError` since `'start'` is not in the RunMetaData. Hence I'd propose to also accept the `KeyError` as an exception.

I've tested in on eb0 for run 7157 and 7158 while loading raw_records with incomplete RunMetaData:
`` 
  rr = st.get_array('007158', targets = ['raw_records'], seconds_range = (0,5))
`` 