### PR TITLE
Fix loading of incomplete data

### DIFF
--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -628,6 +628,13 @@ class Saver:
         if exc_info:
             self.md['exception'] = exc_info
 
+        if self.md['chunks']:
+            # Update to precise start and end values
+            self.md['start'] = self.md['chunks'][0]['start']
+            self.md['end'] = self.md['chunks'][-1]['end']
+        # If there were no chunks, we are certainly crashing.
+        # Don't throw another exception
+
         self.md['writing_ended'] = time.time()
 
         self._close()

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -101,7 +101,7 @@ class DataDirectory(StorageFrontend):
                 raise strax.DataExistsError(at=dirname)
             return bk
 
-        if allow_incomplete:
+        if allow_incomplete and not exists:
             # Check for incomplete data (only exact matching for now)
             if fuzzy_for or fuzzy_for_options:
                 raise NotImplementedError(

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -189,6 +189,7 @@ class DataDirectory(StorageFrontend):
 @export
 def dirname_to_prefix(dirname):
     """Return filename prefix from dirname"""
+    dirname = dirname.replace('_temp', '')
     return os.path.basename(dirname.strip('/').rstrip('\\')).split("-", maxsplit=1)[1]
 
 
@@ -291,14 +292,23 @@ class FileSaver(strax.Saver):
                 strax.save_file, fn, **kwargs)
 
     def _save_chunk_metadata(self, chunk_info):
-        if self.is_forked:
+        is_first = chunk_info['chunk_i'] == 0
+        if is_first:
+            self.md['start'] = chunk_info['start']
+
+        if self.is_forked and not is_first:
+            # Do not write to the main metadata file to avoid race conditions
+            # Instead, write a separate metadata.json file for this chunk,
+            # to be collected later.
+
             # We might not have a filename yet:
             # the chunk is not saved when it is empty
             filename = self._chunk_filename(chunk_info)
-            # Write a separate metadata.json file for each chunk
+
             fn = f'{self.tempdirname}/metadata_{filename}.json'
             with open(fn, mode='w') as f:
                 f.write(json.dumps(chunk_info, **self.json_options))
+
         else:
             # Just append and flush the metadata
             # (maybe not super-efficient to write the json everytime...
@@ -320,12 +330,6 @@ class FileSaver(strax.Saver):
             with open(fn, mode='r') as f:
                 self.md['chunks'].append(json.load(f))
             os.remove(fn)
-
-        if self.md['chunks']:
-            self.md['start'] = min([x['start'] for x in self.md['chunks']])
-            self.md['end'] = max([x['end'] for x in self.md['chunks']])
-        # If there were no chunks, we are certainly crashing.
-        # Don't throw another exception
 
         self._flush_metadata()
 


### PR DESCRIPTION
This restores the ability to load incomplete data -- i.e. data that is still being built or whose build has crashed in a bad way. A before, to use it, just set `allow_incomplete=True` in the context config. 

For most datatypes (peaks, pulse_counts, etc) we only needed small fixes:
  * Fix get_metadata to only look for the temporary (incomplete) metadata if the main file does not exist. Without this allow_incomplete would no longer allow you to load regular data.
  * Write the start time into the metadata as soon as the first chunk arrives.

For datatypes with forked savers, such as records and raw_records during multiprocessing, things were and still are slightly trickier. To avoid having to think about race conditions, we initially write the metadata of each chunk to its own separate json file. When the run finishes, these are all combined into the main metadata json. This makes loading incomplete data for such datatypes harder.

With this, the first chunk of such data _will_ write to the main json file, so that at least its data can be loaded while the run is in progress. You can't currently load any further data. This should be solvable by using atomic writes to the metadata json; not sure this is worth the potential complications though.