### PR TITLE
Exception handling fixes

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -758,7 +758,7 @@ class Context:
                 del self._plugin_class_registry[k]
 
         seen_a_chunk = False
-        for result in strax.continuity_check(strax.ThreadedMailboxProcessor(
+        generator = strax.ThreadedMailboxProcessor(
                 components,
                 max_workers=max_workers,
                 allow_shm=self.context_config['allow_shm'],
@@ -766,14 +766,27 @@ class Context:
                 allow_rechunk=self.context_config['allow_rechunk'],
                 allow_lazy=self.context_config['allow_lazy'],
                 max_messages=self.context_config['max_messages'],
-                timeout=self.context_config['timeout']).iter()):
-            seen_a_chunk = True
-            if not isinstance(result, strax.Chunk):
-                raise ValueError(f"Got type {type(result)} rather than a strax "
-                                 f"Chunk from the processor!")
-            result.data = self.apply_selection(result.data, selection_str,
-                                               time_range, time_selection)
-            yield result
+                timeout=self.context_config['timeout']).iter()
+
+        try:
+            for result in strax.continuity_check(generator):
+                seen_a_chunk = True
+                if not isinstance(result, strax.Chunk):
+                    raise ValueError(f"Got type {type(result)} rather than "
+                                     f"a strax Chunk from the processor!")
+                result.data = self.apply_selection(result.data, selection_str,
+                                                   time_range, time_selection)
+                yield result
+
+        except GeneratorExit:
+            generator.throw(OutsideException(
+                "Terminating due to an exception originating from outside "
+                "strax's get_iter (which we cannot retrieve)."))
+
+        except Exception as e:
+            generator.throw(e)
+            raise
+
         if not seen_a_chunk:
             if time_range is None:
                 raise strax.DataCorrupted("No data returned!")
@@ -1012,3 +1025,8 @@ for attr in dir(Context):
         doc = attr_val.__doc__
         if doc is not None and '{get_docs}' in doc:
             attr_val.__doc__ = doc.format(get_docs=get_docs)
+
+
+@export
+class OutsideException(Exception):
+    pass


### PR DESCRIPTION
  *  When an exception inside `get_iter` occurs, it is now caught, submitted to the Processor (which kills all the mailboxes), and reraised. Currently these exceptions cause a hang instead (terminated by the mailbox timeout -- hopefully). After this, we will shut down cleanly and the proper exception will be recorded in the metadata.
  * When an exception in code calling `get_iter` occurs, e.g. in the body of a for loop over `get_iter` (such as in `get_array`, or less trivially, in `straxer`), we don't get a chance to catch the exception. Instead, we will write a custom `OutsideException` to the metadata, with a message saying the exception originated from beyond strax's get_iter.
    * If the for loop driving `get_iter` wants to do better than this, it would have to be wrapped in a try: except, and the except must `.throw` the exception back to the `get_iter` generator.
    * If it does not do this, get_iter still get notified that "something bad happened" by means of `GeneratorExit`, from the `.close()` called when the `get_iter` generator is garbage collected. We use this to trigger the `OutsideException`. See point 5 in [pep 342](https://www.python.org/dev/peps/pep-0342/#specification-summary), and for more fun with generator cleanups, read [this blog post](https://amir.rachum.com/blog/2017/03/03/generator-cleanup/).