### PR TITLE
Add record amplitude bit shift

### DIFF
--- a/strax/dtypes.py
+++ b/strax/dtypes.py
@@ -75,6 +75,8 @@ def record_dtype(samples_per_record=DEFAULT_RECORD_LENGTH):
           'baseline'), np.float32),
         (('Baseline RMS in ADC counts. data = baseline - data_orig',
           'baseline_rms'), np.float32),
+        (('Multiply data by 2**(this number). Baseline is unaffected.',
+          'amplitude_bit_shift'), np.int16),
         (('Waveform data in raw counts above integer part of baseline',
           'data'), np.int16, samples_per_record),
     ]

--- a/strax/processing/pulse_processing.py
+++ b/strax/processing/pulse_processing.py
@@ -125,7 +125,7 @@ def integrate(records):
         return
     for i, r in enumerate(records):
         records[i]['area'] = (
-            r['data'].sum()
+            r['data'].sum() * 2**r['amplitude_bit_shift']
             # Add floating part of baseline * number of samples
             # int(round()) the result since the area field is an int
             + int(round((r['baseline'] % 1) * r['length'])))
@@ -249,6 +249,7 @@ def _find_hits(records, min_amplitude, min_height_over_noise,
             min_amplitude[r['channel']],
             r['baseline_rms'] * min_height_over_noise[r['channel']])
         n_samples = r['length']
+        multiplier = 2**r['amplitude_bit_shift']
 
         # If someone passes a length > n_samples record,
         # and we don't abort here, numba will happily overrun the buffer!
@@ -258,7 +259,7 @@ def _find_hits(records, min_amplitude, min_height_over_noise,
             # We can't use enumerate over r['data'],
             # numba gives errors if we do.
             # TODO: file issue?
-            x = r['data'][i]
+            x = r['data'][i] * multiplier
 
             satisfy_threshold = x >= threshold
             # print(x, satisfy_threshold, in_interval, hit_start)


### PR DESCRIPTION
This adds the field `amplitude_bit_shift` to records, as introduced by @zhut19 in https://github.com/XENONnT/straxen/pull/38.  This will help make desaturation corrections possible, e.g. based on pulse shape as in XENON1T or using the attenuated / high-energy channels (@ariannarocchetti @petergaemers).

Setting this field means the amplitude the data should be multiplied by `2**amplitude_bit_shift` before it is used. Currently, desaturation corrections cannot store amplitudes above `2**15 -1`, since strax uses signed 16-bit integers (np.int16) to represent waveforms. After this, a correction function could set amplitude_bit_shift = 1 (or 2, 3, etc) and divide the whole waveform by 2 (or 4, 8, etc), so it can store higher amplitudes while staying within the allowed integer range. Of course this loses some precision, but for a giant waveform that seems acceptable.

I went through the pulse processing / integration routines to change them were needed, but it would be great if someone could check if I did it correctly or missed some function. Even better would be to test this of course. 

The baseline field is assumed to be left unaffected by the multiplier. Thus, we do not use the multiplier when correcting integrals for the non-integer part of the baseline (see https://github.com/AxFoundation/strax/issues/2).

This also implements Tianyu's proposed fix in https://github.com/AxFoundation/strax/issues/256 for the saturated channel counting. The saturation check takes into account the multiplier, so a channel will still be flagged as saturated even after a desaturation correction is run on it.