### PR TITLE
Fix lineage hash caching

### DIFF
--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -51,7 +51,7 @@ class DataKey:
         # this property
         if self._lineage_hash == '':
             self._lineage_hash = strax.deterministic_hash(self.lineage)
-        return strax.deterministic_hash(self.lineage)
+        return self._lineage_hash
 
 
 @export


### PR DESCRIPTION
Strax was supposed to cache lineage hashes for data keys -- it didn't, now it does.