### PR TITLE
fix flip boolean bug in pulse_processing

### DIFF
--- a/strax/processing/pulse_processing.py
+++ b/strax/processing/pulse_processing.py
@@ -37,7 +37,6 @@ def baseline(records, baseline_samples=40, flip=True,
     """
     if not len(records):
         return records
-    samples_per_record = len(records[0]['data'])
 
     # Array for looking up last baseline (mean, rms) seen in channel
     # We only care about the channels in this set of records; a single .max()

--- a/strax/processing/pulse_processing.py
+++ b/strax/processing/pulse_processing.py
@@ -66,7 +66,7 @@ def baseline(records, baseline_samples=40, flip=True,
         # Subtract baseline from all data samples in the record
         # (any additional zeros should be kept at zero)
         d['data'][:d['length']] = (
-            (-1 * flip) * (d['data'][:d['length']] - int(bl)))
+            np.where(flip, -1, 1) * (d['data'][:d['length']] - int(bl)))
         d['baseline'] = bl
         d['baseline_rms'] = rms
 

--- a/strax/processing/pulse_processing.py
+++ b/strax/processing/pulse_processing.py
@@ -65,7 +65,7 @@ def baseline(records, baseline_samples=40, flip=True,
         # Subtract baseline from all data samples in the record
         # (any additional zeros should be kept at zero)
         d['data'][:d['length']] = (
-            np.where(flip, -1, 1) * (d['data'][:d['length']] - int(bl)))
+            (-1 if flip else 1) * (d['data'][:d['length']] - int(bl)))
         d['baseline'] = bl
         d['baseline_rms'] = rms
 


### PR DESCRIPTION
Replaced (-1*flip) with np.where(flip, -1, 1) to fix flip=False bug in records flipping.
using np.where with flip as boolean, will return -1 if flip=True, else returns 1. 
Previously boolean meant if flip=False d['data'] will go to 0.

Also I believe that calculating https://github.com/AxFoundation/strax/blob/8e94cd95d823c1537cd49a568d8a3ee4e0204ea5/strax/processing/pulse_processing.py#L40
in baseline computation is unnecessary.