### PR TITLE
Per-datatype rechunking control

### DIFF
--- a/strax/dtypes.py
+++ b/strax/dtypes.py
@@ -118,8 +118,7 @@ def peak_dtype(n_channels=100, n_sum_wv_samples=200, n_widths=11):
           'area'), np.float32),
         (('Integral per channel [PE]',
           'area_per_channel'), np.float32, n_channels),
-        (("Number of hits from which peak was constructed "
-          "(currently zero if peak is split afterwards)",
+        (("Number of hits contributing at least one sample to the peak ",
           'n_hits'), np.int32),
         (('Waveform data in PE/sample (not PE/ns!)',
           'data'), np.float32, n_sum_wv_samples),

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -177,6 +177,13 @@ class Plugin:
             return self.dtype[data_type]
         return self.dtype
 
+    def can_rechunk(self, data_type):
+        if isinstance(self.rechunk_on_save, bool):
+            return self.rechunk_on_save
+        if isinstance(self.rechunk_on_save, (dict, immutabledict)):
+            return self.rechunk_on_save[data_type]
+        raise ValueError("rechunk_on_save must be a bool or an immutabledict")
+
     def empty_result(self):
         if self.multi_output:
             return {d: np.empty(0, self.dtype_for(d))
@@ -726,7 +733,7 @@ class ParallelSourcePlugin(Plugin):
             for d in p.provides:
                 if d not in savers:
                     continue
-                if p.rechunk_on_save:
+                if p.can_rechunk(d):
                     # Case 3. has a saver we can't inline
                     outputs_to_send.add(d)
                     continue

--- a/strax/processor.py
+++ b/strax/processor.py
@@ -168,7 +168,7 @@ class ThreadedMailboxProcessor:
             for s_i, saver in enumerate(savers):
                 if d in dtypes_built:
                     can_drive = not lazy
-                    rechunk = (dtypes_built[d].rechunk_on_save
+                    rechunk = (dtypes_built[d].can_rechunk(d)
                                and allow_rechunk)
                 else:
                     # This is storage conversion mode


### PR DESCRIPTION
This allows a multi-output plugin to specify which of its output dtypes should be rechunked. You can set the `rechunk_on_save` attribute to:
  * True: rechunk all outputs
  * False: do not rechunk anything
  * (immutable)dict mapping dtypes -> True/False, per-datatype control.

The main use case is [PulseProcessing](https://github.com/XENONnT/straxen/blob/446c388eb8411cf87aa7d8e54cc8520c1a599cc0/straxen/plugins/pulse_processing.py#L81) in straxen, which outputs small monitoring datatypes (pulse_counts, veto_regions) besides the big records dtype. We can't rechunk records since that would make their expensive saving operation non-parallelizable, but we should rechunk pulse_counts and veto_regions to avoid saving many 3 kB files that give rucio a headache. 