### PR TITLE
CutPlugin class for cuts in straxen

### DIFF
--- a/docs/source/advanced/plugin_dev.rst
+++ b/docs/source/advanced/plugin_dev.rst
@@ -43,3 +43,13 @@ You can specify defaults in several ways:
 - ``default_per_run``: Specify a list of 2-tuples: ``(start_run, default)``. Here start_run is a numerized run name (e.g 170118_1327; note the underscore is valid in integers since python 3.6) and ``default`` the option that applies from that run onwards.
 - The ``strax_defaults`` dictionary in the run metadata. This overrides any defaults specified in the plugin code, but take care -- if you change a value here, there will be no record anywhere of what value was used previously, so you cannot reproduce your results anymore!
 
+Plugin types
+----------------------
+
+There are several plugin types:
+   * `Plugin`: The general type of plugin. Should contain at least `depends_on = <datakind>`, `provides = <datatype>`, `def compute(self, <datakind>)`, and `dtype = <dtype> ` or `def infer_dtype(): <>`.
+   * `OverlapWindowPlugin`: Allows a plugin to only
+   * `LoopPlugin`: Allows user to loop over a given datakind and find the corresponding data of a lower datakind using for example `def compute_loop(self, events, peaks)` where we loop over events and get the corresponding peaks that are within the time range of the event. Currently the second argument (`peaks`) must be fully contained in the first argument (`events` ).
+   * `CutPlugin`: Plugin type where using `def cut_by(self, <datakind>)` inside the plugin a user can return a boolean array that can be used to select data.
+   * `MergeOnlyPlugin`: This is for internal use and only merges two plugins into a new one. See as an example in straxen the `EventInfo` plugin where the following datatypes are merged `'events', 'event_basics', 'event_positions', 'corrected_areas', 'energy_estimates'`.
+   * `ParallelSourcePlugin`: For internal use only to parallelize the processing of low level plugins. This can be activated using stating `parallel = 'process'` in a plugin.

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -692,6 +692,7 @@ class CutPlugin(Plugin):
         # This should be provided by the user making a CutPlugin
         raise NotImplementedError()
 
+
 ##
 # "Plugins" for internal use
 # These do not actually do computations, but do other tasks

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -847,3 +847,50 @@ class ParallelSourcePlugin(Plugin):
             for s in savers:
                 s.close(wait_for=wait_for)
         super().cleanup(iters, wait_for)
+
+
+@export
+class CutPlugin(Plugin):
+    """Generate a plugin that provides a boolean for a given cut specified by 'cut_by'"""
+    save_when = SaveWhen.NEVER
+
+    def __init__(self):
+        super().__init__()
+
+        _name = strax.camel_to_snake(self.__class__.__name__)
+        if not hasattr(self, 'provides'):
+            self.provides = _name
+        if not hasattr(self, 'cut_name'):
+            self.cut_name = _name
+        if not hasattr(self, 'cut_description'):
+            _description = _name
+            if 'cut_' not in _description:
+                _description = 'Cut by ' + _description
+            else:
+                _description = " ".join(_description.split("_"))
+            self.cut_description = _description
+
+    def infer_dtype(self):
+        dtype = [(self.cut_name, np.bool, self.cut_description)]
+        dtype = dtype + strax.time_fields
+        return dtype
+
+    def compute(self, **kwargs):
+        if hasattr(self, 'cut_by'):
+            cut_by = self.cut_by
+        else:
+            raise NotImplementedError(f"{self.cut_name} does not have attribute 'cut_by'")
+
+        # Take shape of the first data_type like in strax.plugin
+        buff = list(kwargs.values())[0]
+
+        # Generate result buffer
+        r = np.zeros(len(buff), self.dtype)
+        r['time'] = buff['time']
+        r['endtime'] = buff['endtime']
+        r[self.cut_name] = cut_by(**kwargs)
+        return r
+
+    def cut_by(self, **kwargs):
+        # This should be provided by the user making a CutPlugin
+        raise NotImplementedError()

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -871,7 +871,7 @@ class CutPlugin(Plugin):
             self.cut_description = _description
 
     def infer_dtype(self):
-        dtype = [(self.cut_name, np.bool, self.cut_description)]
+        dtype = [(self.cut_name, np.bool_, self.cut_description)]
         dtype = dtype + strax.time_fields
         return dtype
 
@@ -887,7 +887,7 @@ class CutPlugin(Plugin):
         # Generate result buffer
         r = np.zeros(len(buff), self.dtype)
         r['time'] = buff['time']
-        r['endtime'] = buff['endtime']
+        r['endtime'] = strax.endtime(buff)
         r[self.cut_name] = cut_by(**kwargs)
         return r
 

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -872,6 +872,8 @@ class CutPlugin(Plugin):
 
     def infer_dtype(self):
         dtype = [(self.cut_name, np.bool_, self.cut_description)]
+        # TODO
+        #  Alternatively one can use time_dt_fields for low level plugins
         dtype = dtype + strax.time_fields
         return dtype
 

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -645,6 +645,53 @@ class LoopPlugin(Plugin):
         raise NotImplementedError
 
 
+@export
+class CutPlugin(Plugin):
+    """Generate a plugin that provides a boolean for a given cut specified by 'cut_by'"""
+    save_when = SaveWhen.NEVER
+
+    def __init__(self):
+        super().__init__()
+
+        _name = strax.camel_to_snake(self.__class__.__name__)
+        if not hasattr(self, 'provides'):
+            self.provides = _name
+        if not hasattr(self, 'cut_name'):
+            self.cut_name = _name
+        if not hasattr(self, 'cut_description'):
+            _description = _name
+            if 'cut_' not in _description:
+                _description = 'Cut by ' + _description
+            else:
+                _description = " ".join(_description.split("_"))
+            self.cut_description = _description
+
+    def infer_dtype(self):
+        dtype = [(self.cut_name, np.bool_, self.cut_description)]
+        # Alternatively one could use time_dt_fields for low level plugins.
+        dtype = dtype + strax.time_fields
+        return dtype
+
+    def compute(self, **kwargs):
+        if hasattr(self, 'cut_by'):
+            cut_by = self.cut_by
+        else:
+            raise NotImplementedError(f"{self.cut_name} does not have attribute 'cut_by'")
+
+        # Take shape of the first data_type like in strax.plugin
+        buff = list(kwargs.values())[0]
+
+        # Generate result buffer
+        r = np.zeros(len(buff), self.dtype)
+        r['time'] = buff['time']
+        r['endtime'] = strax.endtime(buff)
+        r[self.cut_name] = cut_by(**kwargs)
+        return r
+
+    def cut_by(self, **kwargs):
+        # This should be provided by the user making a CutPlugin
+        raise NotImplementedError()
+
 ##
 # "Plugins" for internal use
 # These do not actually do computations, but do other tasks
@@ -847,51 +894,3 @@ class ParallelSourcePlugin(Plugin):
             for s in savers:
                 s.close(wait_for=wait_for)
         super().cleanup(iters, wait_for)
-
-
-@export
-class CutPlugin(Plugin):
-    """Generate a plugin that provides a boolean for a given cut specified by 'cut_by'"""
-    save_when = SaveWhen.NEVER
-
-    def __init__(self):
-        super().__init__()
-
-        _name = strax.camel_to_snake(self.__class__.__name__)
-        if not hasattr(self, 'provides'):
-            self.provides = _name
-        if not hasattr(self, 'cut_name'):
-            self.cut_name = _name
-        if not hasattr(self, 'cut_description'):
-            _description = _name
-            if 'cut_' not in _description:
-                _description = 'Cut by ' + _description
-            else:
-                _description = " ".join(_description.split("_"))
-            self.cut_description = _description
-
-    def infer_dtype(self):
-        dtype = [(self.cut_name, np.bool_, self.cut_description)]
-        # Alternatively one could use time_dt_fields for low level plugins.
-        dtype = dtype + strax.time_fields
-        return dtype
-
-    def compute(self, **kwargs):
-        if hasattr(self, 'cut_by'):
-            cut_by = self.cut_by
-        else:
-            raise NotImplementedError(f"{self.cut_name} does not have attribute 'cut_by'")
-
-        # Take shape of the first data_type like in strax.plugin
-        buff = list(kwargs.values())[0]
-
-        # Generate result buffer
-        r = np.zeros(len(buff), self.dtype)
-        r['time'] = buff['time']
-        r['endtime'] = strax.endtime(buff)
-        r[self.cut_name] = cut_by(**kwargs)
-        return r
-
-    def cut_by(self, **kwargs):
-        # This should be provided by the user making a CutPlugin
-        raise NotImplementedError()

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -872,8 +872,7 @@ class CutPlugin(Plugin):
 
     def infer_dtype(self):
         dtype = [(self.cut_name, np.bool_, self.cut_description)]
-        # TODO
-        #  Alternatively one can use time_dt_fields for low level plugins
+        # Alternatively one could use time_dt_fields for low level plugins.
         dtype = dtype + strax.time_fields
         return dtype
 

--- a/tests/test_cut_plugin.py
+++ b/tests/test_cut_plugin.py
@@ -1,0 +1,100 @@
+from strax import testutils
+import strax
+import numpy as np
+from hypothesis import given, strategies, example, settings
+
+# Initialize. We test both dt time-fields and time time-field
+_dtype_name = 'var'
+_cut_dtype = ('variable 0', _dtype_name)
+full_dt_dtype = [(_cut_dtype,  np.float64)] + strax.time_dt_fields
+full_time_dtype = [(_cut_dtype,  np.float64)] + strax.time_fields
+
+
+def get_some_array():
+    # Either 0 or 1
+    take_dt = np.random.choice(2)
+
+    # Stolen from testutils.bounds_to_intervals
+    def bounds_to_intervals(bs, dt=1):
+        x = np.zeros(len(bs), dtype=full_dt_dtype if take_dt else full_time_dtype)
+        x['time'] = [x[0] for x in bs]
+        # Remember: exclusive right bound...
+        if take_dt:
+            x['length'] = [x[1] - x[0] for x in bs]
+            x['dt'] = 1
+        else:
+            x['endtime'] = x['time'] + ([x[1] - x[0] for x in bs]) * dt
+        return x
+
+    # Randomly imput either of full_dt_dtype or full_time_dtype
+    sorted_intervals = testutils.sorted_bounds().map(bounds_to_intervals)
+    return sorted_intervals
+
+@given(get_some_array().filter(lambda x: len(x) > 0),
+       strategies.integers(min_value=-10, max_value=10))
+@settings(deadline=None)
+# Examples for readability
+@example(
+    input_peaks=np.array(
+        [(-11, 0, 1),
+         (0, 1, 3),
+         (-5, 3, 5),
+         (11, 5, 7),
+         (7, 7, 9)
+         ],
+        dtype=[(_cut_dtype,  np.float64)] + strax.time_fields),
+    cut_threshold=5)
+@example(
+    input_peaks=np.array(
+        [(0, 0, 1, 1),
+         (1, 1, 1, 1),
+         (5, 2, 2, 1),
+         (11, 4, 2, 4)
+         ],
+        dtype=[(_cut_dtype,  np.int16)] + strax.time_dt_fields),
+    cut_threshold=-1)
+def test_cut_plugin(input_peaks, cut_threshold):
+    """
+    """
+    # Just one chunk will do
+    chunks = [input_peaks]
+    _dtype = input_peaks.dtype
+
+    class ToBeCut(strax.Plugin):
+        """Data to be cut with strax.CutPlugin"""
+        depends_on = tuple()
+        dtype = _dtype
+        provides = 'to_be_cut'
+        data_kind = 'to_be_cut'  # match with depends_on below
+
+        def compute(self, chunk_i):
+            data = chunks[chunk_i]
+            return self.chunk(
+                data=data,
+                start=int(data[0]['time']),
+                end=int(strax.endtime(data[-1])))
+
+        # Hack to make peak output stop after a few chunks
+        def is_ready(self, chunk_i):
+            return chunk_i < len(chunks)
+
+        def source_finished(self):
+            return True
+
+    class CutSomething(strax.CutPlugin):
+        """Minimal working example of CutPlugin"""
+
+        depends_on = ('to_be_cut',)
+
+        def cut_by(self, to_be_cut):
+            return to_be_cut[_dtype_name] > cut_threshold
+
+    st = strax.Context(storage=[])
+    st.register(ToBeCut)
+    st.register(CutSomething)
+
+    result = st.get_array(run_id='some_run',
+                          targets=strax.camel_to_snake(CutSomething.__name__))
+    correct_answer = np.sum(input_peaks[_dtype_name] > cut_threshold)
+    assert len(result) == len(input_peaks), "WTF??"
+    assert correct_answer == np.sum(result['cut_something']), "Cut plugin does not give boolean arrays correctly"

--- a/tests/test_cut_plugin.py
+++ b/tests/test_cut_plugin.py
@@ -30,7 +30,7 @@ def get_some_array():
     sorted_intervals = testutils.sorted_bounds().map(bounds_to_intervals)
     return sorted_intervals
 
-@given(get_some_array().filter(lambda x: len(x) > 0),
+@given(get_some_array().filter(lambda x: len(x) >= 0),
        strategies.integers(min_value=-10, max_value=10))
 @settings(deadline=None)
 # Examples for readability
@@ -71,8 +71,8 @@ def test_cut_plugin(input_peaks, cut_threshold):
             data = chunks[chunk_i]
             return self.chunk(
                 data=data,
-                start=int(data[0]['time']),
-                end=int(strax.endtime(data[-1])))
+                start=int(data[0]['time']) if len(data) else np.arange(len(chunks))[chunk_i],
+                end=int(strax.endtime(data[-1])) if len(data) else np.arange(1, len(chunks)+1)[chunk_i])
 
         # Hack to make peak output stop after a few chunks
         def is_ready(self, chunk_i):


### PR DESCRIPTION
The cuts currently in straxen (https://github.com/XENONnT/straxen/blob/master/straxen/plugins/x1t_cuts.py ) have a quite lot of overlap with one another. Most of the time a simple Boolean array is all that is returned. However, we each time have to add the time fields et cetera which may somewhat obscure the functionality.
To simplify the cuts somewhat I've written a simple Plugin Class. In straxen it could be used as for example:
```
class CutS1s(CutPlugin):
    depends_on = ('events', 'corrected_areas')
    provides = 'cs1_cut'
    cut_description = "Remove cS1 above 100 PE"
    cut_name ='cut_high_cs1'
    __version__ = '0.0.0'
    
    def cut_by(self, events):
        return events['cs1'] > 100
```
```
class CutS2s(CutPlugin):
    depends_on = ('events', 'corrected_areas')
    cut_description = "Remove cS2s below 100 PE"
    
    def cut_by(self, events):
        return events['cs2'] < 100
```

```
class CutRecord0(CutPlugin):
    depends_on = ('records',)
    provides = 'is_not_record0_cut'
    cut_description = "is record 0"
    cut_name ='is_not_record0_cut'
    __version__ = '0.0.0'
    
    def cut_by(self, records):
        return records['record_i'] != 0
```