### PR TITLE
Allows for plugin-specific chunks sizes

### DIFF
--- a/docs/source/advanced/chunking.rst
+++ b/docs/source/advanced/chunking.rst
@@ -39,6 +39,8 @@ Plugins can chunk their output as they wish, including withholding some data unt
 
 Savers, too, are free to chunk their data as they like; for example, to create files of convenient sizes. This affects the chunks you get when loading or reprocessing data. If you don't want this, e.g. if the next plugin in line assumes a particular kind of chunking you want to preserve, set the attribute `rechunk_on_save = False`.
 
+In cases where rechunking is permitted, a plugin can also specify a desired minimum uncompressed chunk size in bytes via the `chunk_target_size` attribute, with 200 MB as the default value. Chunks are concatenated until this desired size is exceeded, or all chunks have been combined, whereupon the data is compressed and written to disk.
+
 
 Sorted output requirement
 --------------------------

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -5,8 +5,9 @@ import numba
 
 import strax
 export, __all__ = strax.exporter()
+__all__ += ['default_chunk_size']
 
-@export
+
 default_chunk_size = int(2e8)
 
 @export

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -5,10 +5,10 @@ import numba
 
 import strax
 export, __all__ = strax.exporter()
-__all__ += ['default_chunk_size']
+__all__ += ['default_chunk_size_mb']
 
 
-default_chunk_size = int(2e8)
+default_chunk_size_mb = 200
 
 @export
 class Chunk:
@@ -25,7 +25,7 @@ class Chunk:
     end: int
 
     data: np.ndarray
-    target_size: int
+    target_size_mb: int
 
     def __init__(self,
                  *,
@@ -36,7 +36,7 @@ class Chunk:
                  start,
                  end,
                  data,
-                 target_size=default_chunk_size):
+                 target_size_mb=default_chunk_size_mb):
         self.data_type = data_type
         self.data_kind = data_kind
         self.dtype = np.dtype(dtype)
@@ -46,7 +46,7 @@ class Chunk:
         if data is None:
             data = np.empty(0, dtype)
         self.data = data
-        self.target_size = target_size
+        self.target_size_mb = target_size_mb
 
         if not (isinstance(self.start, (int, np.integer))
                 and isinstance(self.end, (int, np.integer))):
@@ -140,7 +140,7 @@ class Chunk:
             dtype=self.dtype,
             data_type=self.data_type,
             data_kind=self.data_kind,
-            target_size=self.target_size)
+            target_size_mb=self.target_size_mb)
 
         c1 = strax.Chunk(
             start=self.start,
@@ -207,7 +207,7 @@ class Chunk:
             data_kind=data_kind,
             run_id=run_id,
             data=data,
-            target_size=max([c.target_size for c in chunks]))
+            target_size_mb=max([c.target_size_mb for c in chunks]))
 
     @classmethod
     def concatenate(cls, chunks):
@@ -249,7 +249,7 @@ class Chunk:
             data_kind=chunks[0].data_kind,
             run_id=run_id,
             data=np.concatenate([c.data for c in chunks]),
-            target_size=max([c.target_size for c in chunks]))
+            target_size_mb=max([c.target_size_mb for c in chunks]))
 
 
 @export

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -6,6 +6,8 @@ import numba
 import strax
 export, __all__ = strax.exporter()
 
+@export
+default_chunk_size = int(2e8)
 
 @export
 class Chunk:
@@ -22,6 +24,7 @@ class Chunk:
     end: int
 
     data: np.ndarray
+    target_size: int
 
     def __init__(self,
                  *,
@@ -31,7 +34,8 @@ class Chunk:
                  run_id,
                  start,
                  end,
-                 data):
+                 data,
+                 target_size=default_chunk_size):
         self.data_type = data_type
         self.data_kind = data_kind
         self.dtype = np.dtype(dtype)
@@ -41,6 +45,7 @@ class Chunk:
         if data is None:
             data = np.empty(0, dtype)
         self.data = data
+        self.target_size = target_size
 
         if not (isinstance(self.start, (int, np.integer))
                 and isinstance(self.end, (int, np.integer))):
@@ -133,7 +138,8 @@ class Chunk:
             run_id=self.run_id,
             dtype=self.dtype,
             data_type=self.data_type,
-            data_kind=self.data_kind)
+            data_kind=self.data_kind,
+            target_size=self.target_size)
 
         c1 = strax.Chunk(
             start=self.start,
@@ -199,7 +205,8 @@ class Chunk:
             data_type=data_type,
             data_kind=data_kind,
             run_id=run_id,
-            data=data)
+            data=data
+            target_size=max([c.target_size for c in chunks]))
 
     @classmethod
     def concatenate(cls, chunks):
@@ -240,7 +247,8 @@ class Chunk:
             data_type=data_type,
             data_kind=chunks[0].data_kind,
             run_id=run_id,
-            data=np.concatenate([c.data for c in chunks]))
+            data=np.concatenate([c.data for c in chunks]),
+            target_size=max([c.target_size for c in chunks]))
 
 
 @export

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -206,7 +206,7 @@ class Chunk:
             data_type=data_type,
             data_kind=data_kind,
             run_id=run_id,
-            data=data
+            data=data,
             target_size=max([c.target_size for c in chunks]))
 
     @classmethod

--- a/strax/context.py
+++ b/strax/context.py
@@ -490,7 +490,7 @@ class Context:
         targets = strax.to_str_tuple(targets)
 
         # Although targets is a tuple, we only support one target at the moment
-        # TODO: just make it a string!
+        # we could just make it a string!
         assert len(targets) == 1, f"Found {len(targets)} instead of 1 target"
         if len(targets[0]) == 1:
             raise ValueError(

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -59,7 +59,7 @@ class Plugin:
     rechunk_on_save = True    # Saver is allowed to rechunk
     # How large (uncompressed) should re-chunked chunks be?
     # Meaningless if rechunk_on_save is False
-    chunk_target_size = int(2e8)
+    chunk_target_size = strax.default_chunk_size
 
 
     # For a source with online input (e.g. DAQ readers), crash if no new input

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -57,6 +57,10 @@ class Plugin:
     compressor = 'blosc'
 
     rechunk_on_save = True    # Saver is allowed to rechunk
+    # How large (uncompressed) should re-chunked chunks be?
+    # Meaningless if rechunk_on_save is False
+    chunk_target_size = int(2e8)
+
 
     # For a source with online input (e.g. DAQ readers), crash if no new input
     # has appeared for this many seconds
@@ -85,7 +89,7 @@ class Plugin:
     run_i: int
     config: typing.Dict
     deps: typing.Dict       # Dictionary of dependency plugin instances
-    
+
     compute_takes_chunk_i = False    # Autoinferred, no need to set yourself
     compute_takes_start_end = False
 
@@ -207,7 +211,8 @@ class Plugin:
             lineage_hash=strax.DataKey(
                 run_id, data_type, self.lineage).lineage_hash,
             compressor=self.compressor,
-            lineage=self.lineage)
+            lineage=self.lineage,
+            chunk_target_size=self.chunk_target_size)
 
     def dependencies_by_kind(self):
         """Return dependencies grouped by data kind
@@ -497,7 +502,8 @@ class Plugin:
             data_kind=self.data_kind_for(data_type),
             data_type=data_type,
             dtype=self.dtype_for(data_type),
-            data=data)
+            data=data,
+            target_size=self.chunk_target_size)
 
     def compute(self, **kwargs):
         raise NotImplementedError

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -59,7 +59,7 @@ class Plugin:
     rechunk_on_save = True    # Saver is allowed to rechunk
     # How large (uncompressed) should re-chunked chunks be?
     # Meaningless if rechunk_on_save is False
-    chunk_target_size = strax.default_chunk_size
+    chunk_target_size_mb = strax.default_chunk_size_mb
 
 
     # For a source with online input (e.g. DAQ readers), crash if no new input
@@ -212,7 +212,7 @@ class Plugin:
                 run_id, data_type, self.lineage).lineage_hash,
             compressor=self.compressor,
             lineage=self.lineage,
-            chunk_target_size=self.chunk_target_size)
+            chunk_target_size_mb=self.chunk_target_size_mb)
 
     def dependencies_by_kind(self):
         """Return dependencies grouped by data kind
@@ -503,7 +503,7 @@ class Plugin:
             data_type=data_type,
             dtype=self.dtype_for(data_type),
             data=data,
-            target_size=self.chunk_target_size)
+            target_size_mb=self.chunk_target_size_mb)
 
     def compute(self, **kwargs):
         raise NotImplementedError

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -405,8 +405,8 @@ class StorageBackend:
             data_type=metadata['data_type'],
             data_kind=metadata['data_kind'],
             dtype=dtype,
-            target_size=metadata.get('chunk_target_size',
-                                     strax.default_chunk_size))
+            target_size_mb=metadata.get('chunk_target_size_mb',
+                                        strax.default_chunk_size_mb))
 
         required_chunk_metadata_fields = 'start end run_id'.split()
 
@@ -543,7 +543,7 @@ class Saver:
                 try:
                     if rechunk and self.allow_rechunk:
                         while (chunk is None or
-                                chunk.data.nbytes < chunk.target_size):
+                                chunk.data.nbytes < chunk.target_size_mb*1e6):
                             chunk = strax.Chunk.concatenate(
                                 [chunk, next(source)])
                     else:

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -404,7 +404,9 @@ class StorageBackend:
         chunk_kwargs = dict(
             data_type=metadata['data_type'],
             data_kind=metadata['data_kind'],
-            dtype=dtype)
+            dtype=dtype,
+            target_size=metadata.get('chunk_target_size',
+                                     strax.default_chunk_size))
 
         required_chunk_metadata_fields = 'start end run_id'.split()
 
@@ -540,7 +542,8 @@ class Saver:
                 chunk = None
                 try:
                     if rechunk and self.allow_rechunk:
-                        while chunk is None or chunk.data.nbytes < 1e8:
+                        while (chunk is None or
+                                chunk.data.nbytes < chunk.target_size):
                             chunk = strax.Chunk.concatenate(
                                 [chunk, next(source)])
                     else:


### PR DESCRIPTION
This changes the default uncompressed chunk size from 100 MB (specified in an obscure, undocumented location) to a plugin-definable value, with new default 200 MB. This value gets stored with the metadata, but if it's missing the default is assumed. This should affect writing data much more than reading it, but the hope is that 200 MB uncompressed is a more acceptable trade between fewer, larger files (easier on the bookkeeping) and more, smaller files (easier on the end user).