### PR TITLE
Correctly check endtimes in chunk.py

### DIFF
--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -65,7 +65,7 @@ class Chunk:
 
         if len(self.data):
             data_starts_at = self.data[0]['time']
-            data_ends_at = strax.endtime(self.data[-1])
+            data_ends_at = strax.endtime(self.data).max()
 
             if data_starts_at < self.start:
                 raise ValueError(f"Attempt to create chunk {self} "

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -65,7 +65,7 @@ class Chunk:
 
         if len(self.data):
             data_starts_at = self.data[0]['time']
-            data_ends_at = strax.endtime(self.data).max()
+            data_ends_at = strax.endtime(self.data[-500:]).max()
 
             if data_starts_at < self.start:
                 raise ValueError(f"Attempt to create chunk {self} "

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -65,6 +65,7 @@ class Chunk:
 
         if len(self.data):
             data_starts_at = self.data[0]['time']
+            # Check the last 500 samples (arbitrary number) as sanity check
             data_ends_at = strax.endtime(self.data[-500:]).max()
 
             if data_starts_at < self.start:


### PR DESCRIPTION
**Problem**
We observed that although the data is always sorted by (start)time, this is not per se true for the endtime. Therefore the last record may not have the latest endtime. We need to check this and not proceed if we observe such a thing. 

**Example**
As Daniel illustrated nicely. Image we have to following data where `-` means data, `_` means no data, and `|` means start and stop.
```
ch0: |---|__
ch1: _|-|___
```
Here the signal in ch0 starts before the signal in ch1 while the end of ch0 is __later__ than ch1. Hence we need to check both channels.

**Solution**
We used to look only at the last sample only but we need to look into the endtimes better to assert that we are not having any data sticking out of the chunk. This is the safest way to get around this (that is look at all the data in the chunk).

**Alternative**
Depending on the datarate one might also argue that for example we look at the last 100 samples :
```
data_ends_at = strax.endtime(self.data[-100:]).max()
```

**Straxen**
A similar PR in straxen will actually fix the problem:
https://github.com/XENONnT/straxen/pull/146