### PR TITLE
Fix endtimes in peaks merging

### DIFF
--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -73,7 +73,11 @@ def merge_peaks(peaks, start_merge_at, end_merge_at,
         # Use the tight coincidence of the peak with the highest amplitude
         new_p['tight_coincidence'] = old_peaks['tight_coincidence'][
             old_peaks['data'].max(axis=1).argmax()]
-
+        
+        # If the endtime was in the peaks we have to recompute it here 
+        # because otherwise it will stay set to zero due to the buffer
+        if 'endtime' in new_p.dtype.names:
+            new_p['endtime'] = strax.endtime(last_peak)
     return new_peaks
 
 


### PR DESCRIPTION
For peaks with an endtime we need to recompute those numbers as otherwise we end up with a 0 as an `endtime `and `strax.endtime(peak)` will simply compute the endtime.

For example I tried merging peaks like these:
![afbeelding](https://user-images.githubusercontent.com/22295914/87445850-dd162a00-c5f8-11ea-8e95-6fd463cde181.png)

Which gave me this obviously wrong peak:
![afbeelding](https://user-images.githubusercontent.com/22295914/87445919-f15a2700-c5f8-11ea-9399-2903040dae70.png)

Maybe we should also change `strax.endtime `to not return `0`'s unless we consider going back in time to the 70s.

**Why haven't we seen this before**
Endtime is a field for peaks and higher while this code is only used for `peaklets`. Therefore we haven't run into this before but I foresee that solving issues that might arise might appear very strange if we want to remerge peaks at some point with strax.
