### PR TITLE
Fix error in forbid_creation_of

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -564,6 +564,7 @@ class Context:
                 del plugins[d]
             else:
                 # Data not found anywhere. We will be computing it.
+                self._check_forbidden()
                 if (time_range is not None
                         and plugins[d].save_when != strax.SaveWhen.NEVER):
                     # While the data type providing the time information is
@@ -1151,7 +1152,17 @@ class Context:
             except strax.DataNotAvailable:
                 continue
         return False
-
+    
+    def _check_forbidden(self):
+        """Check that the forbid_creaction_of config is of tuple type.
+        Otherwise, try to make it a tuple"""
+        forbid_creation_of = self.context_config['forbid_creation_of']
+        if not type(forbid_creation_of) == tuple:
+            if not type(forbid_creation_of) == str:
+                raise ValueError(f'forbid_creation_of should be of type tuple not'
+                                 f'{type(forbid_creation_of)}')
+            self.context_config['forbid_creation_of'] = ((forbid_creation_of), )
+            
     @classmethod
     def add_method(cls, f):
         """Add f as a new Context method"""

--- a/strax/context.py
+++ b/strax/context.py
@@ -1157,8 +1157,8 @@ class Context:
         """Check that the forbid_creaction_of config is of tuple type.
         Otherwise, try to make it a tuple"""
         forbid_creation_of = self.context_config['forbid_creation_of']
-        if not type(forbid_creation_of) is tuple:
-            if not type(forbid_creation_of) is str:
+        if not isinstance(forbid_creation_of, tuple):
+            if not isinstance(forbid_creation_of, str):
                 raise ValueError(f'forbid_creation_of should be of type tuple not'
                                  f'{type(forbid_creation_of)}')
             self.context_config['forbid_creation_of'] = ((forbid_creation_of), )

--- a/strax/context.py
+++ b/strax/context.py
@@ -1152,17 +1152,17 @@ class Context:
             except strax.DataNotAvailable:
                 continue
         return False
-    
+
     def _check_forbidden(self):
         """Check that the forbid_creaction_of config is of tuple type.
         Otherwise, try to make it a tuple"""
         forbid_creation_of = self.context_config['forbid_creation_of']
-        if not type(forbid_creation_of) == tuple:
-            if not type(forbid_creation_of) == str:
+        if not type(forbid_creation_of) is tuple:
+            if not type(forbid_creation_of) is str:
                 raise ValueError(f'forbid_creation_of should be of type tuple not'
                                  f'{type(forbid_creation_of)}')
             self.context_config['forbid_creation_of'] = ((forbid_creation_of), )
-            
+
     @classmethod
     def add_method(cls, f):
         """Add f as a new Context method"""

--- a/strax/context.py
+++ b/strax/context.py
@@ -1154,14 +1154,10 @@ class Context:
         return False
 
     def _check_forbidden(self):
-        """Check that the forbid_creaction_of config is of tuple type.
+        """Check that the forbid_creation_of config is of tuple type.
         Otherwise, try to make it a tuple"""
-        forbid_creation_of = self.context_config['forbid_creation_of']
-        if not isinstance(forbid_creation_of, tuple):
-            if not isinstance(forbid_creation_of, str):
-                raise ValueError(f'forbid_creation_of should be of type tuple not'
-                                 f'{type(forbid_creation_of)}')
-            self.context_config['forbid_creation_of'] = ((forbid_creation_of), )
+        self.context_config['forbid_creation_of'] = strax.to_str_tuple(
+            self.context_config['forbid_creation_of'])
 
     @classmethod
     def add_method(cls, f):


### PR DESCRIPTION
**Problem**
We forbid the creation of records if only raw_records is in the forbid_creation of. If we compare stings, 'records' is in 'raw_records'. 

![afbeelding](https://user-images.githubusercontent.com/22295914/87933446-8e034580-ca8d-11ea-9cc5-d01d8dabcbd2.png)
yields the following error: 
![afbeelding](https://user-images.githubusercontent.com/22295914/87933473-99ef0780-ca8d-11ea-9b74-ec4a09acb1d7.png)
This is not entirely correct, we just specified we couldn't create raw_records. 

**Solution/test**
![afbeelding](https://user-images.githubusercontent.com/22295914/87933520-b2f7b880-ca8d-11ea-8cb9-bd05f88e5943.png)
This starts making 'records'

**Additional**
I don't think we want to allow users to create 'records' in straxen. As such I think we should specify that we forbid creation of ('raw_records', 'records') on line https://github.com/XENONnT/straxen/blob/master/straxen/contexts.py#L68.
