### PR TITLE
Create templates for strax

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,12 @@
+**What is the problem / what does the code in this PR do**
+
+**Can you briefly describe how it works?**
+
+**Can you give an minimum working example (or illustrate with a figure)?**
+
+Please include the following if applicable:
+  - Update the docstring(s)
+  - Update the documentation
+  - Tests to check the (new) code is working as desired.
+  - Does it solve one of the open issues on github?
+    

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -2,11 +2,12 @@
 
 **Can you briefly describe how it works?**
 
-**Can you give an minimum working example (or illustrate with a figure)?**
+**Can you give a minimal working example (or illustrate with a figure)?**
 
 Please include the following if applicable:
   - Update the docstring(s)
   - Update the documentation
   - Tests to check the (new) code is working as desired.
   - Does it solve one of the open issues on github?
-    
+
+Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).


### PR DESCRIPTION
When writing PRs in strax it might be good to add a template for both filing issues and adding PR. This can help keeping the pull requests in a similar format. It might also help authors to include things (like tests, documentation, examples) that would probably be requested by the reviewers.
