### PR TITLE
Apply function to data

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -78,7 +78,8 @@ RUN_DEFAULTS_KEY = 'strax_defaults'
                       'even when no registered plugin takes them.'),
     strax.Option(name='apply_data_function', default=tuple(),
                  help='Apply a function to the data prior to returning the'
-                      'data.')
+                      'data. The function should take two positional arguments: '
+                      'func(<data>, <targets>).')
 )
 @export
 class Context:
@@ -1026,7 +1027,7 @@ class Context:
                                 f'{function} but expected callable function with')
             # Make sure that the function takes single argument data (or set other 
             # arguments as kwargs)
-            result = function(result)
+            result = function(result, targets)
         return result
 
     def accumulate(self,


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Apply a function in `get_array` just before returning the data.

This way, you can make a last-minute correction (or apply a blinding cut in the context).

**Can you briefly describe how it works?**
When one loads data you do either `st.get_array` or `st.get_df` (which then calls `st.get_array` for you). In the lines changed in this PR, you see that the results that is usually returned directly can now be changed by a function. Such a function should be a function that takes a single argument (the data) and does something to it. For example in https://github.com/XENONnT/straxen/pull/166 it remaps some channels but this could also be used to apply a blinding cut.

**Can you give a minimal working example (or illustrate with a figure)?**
As written in the Strax.Option a function should have the  form of:

```python
def function(data, targets):
    # Do something
    return data
```

See for example the MWE below.

```python
def set_time_from_start(data, targets, 
                        works_on_target='*records*', 
                        kwargs_are_fine=True):
     print('Time field is changed to start of run')
     
     # You can use kwargs as long as you obey the positional arguments 'data' and 'targets'
     if kwargs_are_fine:
          pass
    
     # Let's check in our function that we actually want to work on this kind of target(s)
     if np.any([fnmatch.fnmatch(t, works_on_target) for t in strax.to_str_tuple(targets)]):
          # At least one of the targets is of the kind we want to apply this function to
          data['time']=data['time'][0]
     else: 
          # Ok this some non (raw-)record like data. Let's not do anything to the data
          pass
     return data

#Initiate some context 
st = strax.Context(...) # such as st = straxen.contexts.xenonnt_online()

# Now wrap whatever function we have around the data
st.set_context_config({'apply_data_function': (set_time_from_start,)})

# When doing this we will get the print message and data where 'time' starts to count in ns
# since run
st.get_array(run_id='008657', targets = ('raw_records'), seconds_range = (0,1))
```

**What does it affect?**
`get_df`, `get_array` and `accumulate`. It does not affect `get_iter` (directly) otherwise also `st.make` would be affected which would be problematic as one might be applying corrections twice (which is fine if your cutting data but not fine if you switch channels).

After discussing the PR, `accumulate` is also affected to keep loading of data consistent across all methods.