### PR TITLE
Workaround for fuzzy_for issue.

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -33,7 +33,7 @@ RUN_DEFAULTS_KEY = 'strax_defaults'
                  help='If True, save data that is loaded from one frontend '
                       'through all willing other storage frontends.'),
     strax.Option(name='fuzzy_for', default=tuple(),
-                 help='Tuple of plugin names for which no checks for version, '
+                 help='Tuple or string of plugin names for which no checks for version, '
                       'providing plugin, and config will be performed when '
                       'looking for data.'),
     strax.Option(name='fuzzy_for_options', default=tuple(),
@@ -525,7 +525,7 @@ class Context:
         fuzzy_for_keys = strax.to_str_tuple(self.context_config['fuzzy_for'])
         last_provides = []
         for key in fuzzy_for_keys:
-            last_provides.append(self._plugin_class_registry(key).provides[-1])
+            last_provides.append(self._plugin_class_registry[key].provides[-1])
         last_provides = tuple(last_provides)
 
         return dict(fuzzy_for=last_provides,

--- a/strax/context.py
+++ b/strax/context.py
@@ -516,7 +516,19 @@ class Context:
 
     @property
     def _find_options(self):
-        return dict(fuzzy_for=self.context_config['fuzzy_for'],
+
+        # The plugin settings in the lineage are stored with the last
+        # plugin provides name as a key. This can be quite confusing
+        # since e.g. to be fuzzy for the peaklets settings the user has
+        # to specify fuzzy_for=('lone_hits'). Here a small work around
+        # to change this and not to reprocess the entire data set.
+        fuzzy_for_keys = strax.to_str_tuple(self.context_config['fuzzy_for'])
+        last_provides = []
+        for key in fuzzy_for_keys:
+            last_provides.append(self._plugin_class_registry(key).provides[-1])
+        last_provides = tuple(last_provides)
+
+        return dict(fuzzy_for=last_provides,
                     fuzzy_for_options=self.context_config['fuzzy_for_options'],
                     allow_incomplete=self.context_config['allow_incomplete'])
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
The issue is elaborated in https://github.com/AxFoundation/strax/issues/285
**Can you briefly describe how it works?**
This PR is a small patch which will make the fuzzy_for option more flexible. The user can now specify any provides field in `fuzzy_for`. The user can now also just specify a string instead of a tuple.    
**Can you give a minimal working example (or illustrate with a figure)?**
`st.set_context_config({'fuzzy_for': 'peaklets'})`
