### PR TITLE
Fix memory leak.

### DIFF
--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -87,10 +87,10 @@ class PeakSplitter:
         is_split = np.zeros(len(peaks), dtype=np.bool_)
 
         # data_kind specific_outputs:
-        if data_type not in ('peaks', 'hitlets'):
-            raise TypeError(f'Unknown data_type. "{data_type}" is not supported.')
-        else:
+        if data_type in ('peaks', 'hitlets'):
             specific_output = SPECIFIC_OUTPUTS[data_type]
+        else:
+            raise TypeError(f'Unknown data_type. "{data_type}" is not supported.')
         new_peaks = self._split_peaks(
             # Numba doesn't like self as argument, but it's ok with functions...
             split_finder=self.find_split_points,


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
This PR is a different solution for the problem described in https://github.com/AxFoundation/strax/pull/309
**Can you briefly describe how it works?**
Inspired by the solution in https://github.com/AxFoundation/strax/pull/309. I moved the function `specific_output` into a dictionary outside of the PeakSplitter class which solved the problem
**Can you give a minimal working example (or illustrate with a figure)?**
run `python straxer 170206_1355 --target peaklets --context xenon1t_dali --build_lowlevel --profile_ram` 

Here are some example outputs:

Begining:
```
Got 1547 items. Now 1.1 sec / 0.0% into the run. Using 514.9 MB RAM.
Got 1901 items. Now 2.0 sec / 0.1% into the run. Using 676.9 MB RAM. ETA 2602.18 sec.
Got 1654 items. Now 3.2 sec / 0.1% into the run. Using 731.0 MB RAM. ETA 3094.93 sec.
Got 1666 items. Now 4.2 sec / 0.1% into the run. Using 722.3 MB RAM. ETA 3326.21 sec.
Got 1780 items. Now 5.6 sec / 0.2% into the run. Using 792.1 MB RAM. ETA 3514.53 sec.
```
20 % into the run:
```
Got 1666 items. Now 807.6 sec / 22.4% into the run. Using 1169.3 MB RAM. ETA 3263.64 sec.
Got 1652 items. Now 808.7 sec / 22.4% into the run. Using 1175.7 MB RAM. ETA 3262.02 sec.
Got 1812 items. Now 809.7 sec / 22.5% into the run. Using 1129.8 MB RAM. ETA 3261.01 sec.
Got 2186 items. Now 810.9 sec / 22.5% into the run. Using 1251.8 MB RAM. ETA 3259.96 sec.
```