### PR TITLE
Checks for multioutput plugins and loop dependencies

### DIFF
--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -608,9 +608,9 @@ class LoopPlugin(Plugin):
             loop_over = self.loop_over
         else:
             loop_over = self.deps[self.depends_on[0]].data_kind
-            if not isinstance(loop_over, str):
-                raise TypeError("Please add \"loop_over = <base>\""
-                                " to your plugin definition")
+        if not isinstance(loop_over, str):
+            raise TypeError("Please add \"loop_over = <base>\""
+                            " to your plugin definition")
 
         # Group into lists of things (e.g. peaks)
         # contained in the base things (e.g. events)

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -608,6 +608,9 @@ class LoopPlugin(Plugin):
             loop_over = self.loop_over
         else:
             loop_over = self.deps[self.depends_on[0]].data_kind
+            if isinstance(loop_over, dict):
+                loop_over = loop_over[self.depends_on[0]]
+                # We can't have nested dictionaries here, can we?
 
         # Group into lists of things (e.g. peaks)
         # contained in the base things (e.g. events)

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -608,9 +608,9 @@ class LoopPlugin(Plugin):
             loop_over = self.loop_over
         else:
             loop_over = self.deps[self.depends_on[0]].data_kind
-            if isinstance(loop_over, dict):
-                loop_over = loop_over[self.depends_on[0]]
-                # We can't have nested dictionaries here, can we?
+            if not isinstance(loop_over, str):
+                raise TypeError("Please add \"loop_over = <base>\""
+                                " to your plugin definition")
 
         # Group into lists of things (e.g. peaks)
         # contained in the base things (e.g. events)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

If the first dependency of a loop plugin is produced by a multi-output plugin, the automatic determination of `loop_over` fails. During the automatic determination of loop order, `loop_over = self.deps[self.depends_on[0]].data_kind` ([plugin.py L610](https://github.com/AxFoundation/strax/blob/master/strax/plugin.py#L610)) evaluates to a dictionary rather than a string, and this fails 4 lines down when it dereferences `kwargs`.

**Can you briefly describe how it works?**

This PR checks to see if the `data_kind` of the plugin providing the first dependency is a multi-output plugin and asks the user to be more specific if it is. Fixes #311 .
