### PR TITLE
Add python3.8 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ jobs:
       env: PYTHON=3.7 NUMBA_DISABLE_JIT=1
     - name: "Python 3.6 (legacy)"
       env: PYTHON=3.6
+    - name: "Python 3.8 (beta)"
+      env: PYTHON=3.8  
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
     - name: "Python 3.6 (legacy)"
       env: PYTHON=3.6
     - name: "Python 3.8 (beta)"
-      env: PYTHON=3.8  
+      env: PYTHON=3.8
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
As illustrated in figure 4 of https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:daq:eb_speed_tests, python 3.8 showed an increased performance on the XENONnT eventbuilder machines. Therefore, we might want to test strax also for python 3.8.
