### PR TITLE
Option to give range to sum_waveform

### DIFF
--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -137,12 +137,11 @@ def store_downsampled_waveform(p, wv_buffer):
 
 @export
 @numba.jit(nopython=True, nogil=True, cache=True)
-def sum_waveform(peaks, records, adc_to_pe,
-                 peak_list=np.array([-3, -14])):
+def sum_waveform(peaks, records, adc_to_pe, *arg):
     """Compute sum waveforms for all peaks in peaks
     Will downsample sum waveforms if they do not fit in per-peak buffer
 
-    :keyword peak_list: Indicies of the peaks for partial processing
+    :arg peak_list: Indicies of the peaks for partial processing
     In the form of np.array([np.int])
 
     Assumes all peaks AND pulses have the same dt!
@@ -151,6 +150,10 @@ def sum_waveform(peaks, records, adc_to_pe,
         return
     if not len(peaks):
         return
+    if len(arg):
+        peak_list = arg[0]
+    else:
+        peak_list = np.arange(len(peaks))
     if not len(peak_list):
         return
     dt = records[0]['dt']
@@ -165,11 +168,6 @@ def sum_waveform(peaks, records, adc_to_pe,
 
     n_channels = len(peaks[0]['area_per_channel'])
     area_per_channel = np.zeros(n_channels, dtype=np.float32)
-
-    # If peak list is the default fill it with all peak indicies
-    # Hope it never is [-3, -14] for real
-    if np.sum(peak_list) == -17 and np.prod(peak_list) == 42:
-        peak_list = np.arange(len(peaks))
 
     for peak_i in peak_list:
         p = peaks[peak_i]

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -153,7 +153,7 @@ def sum_waveform(peaks, records, adc_to_pe, select_peaks_indices=None):
         return
     if select_peaks_indices is None:
         select_peaks_indices = np.arange(len(peaks))
-    elif not len(select_peaks_indices):
+    if not len(select_peaks_indices):
         return
     dt = records[0]['dt']
 

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -154,8 +154,7 @@ def sum_waveform(peaks, records, adc_to_pe, select_peaks_indices=None):
     if select_peaks_indices is None:
         select_peaks_indices = np.arange(len(peaks))
     elif not len(select_peaks_indices):
-        raise ValueError('select_peaks_indices must either be None (for all '
-                         'indices) or array of indices to store.')
+        return
     dt = records[0]['dt']
 
     # Big buffer to hold even largest sum waveforms

--- a/tests/test_peak_processing.py
+++ b/tests/test_peak_processing.py
@@ -84,3 +84,6 @@ def test_sum_waveform(records, peak_left, peak_length):
 
     assert len(sum_wv) == peak_length
     assert np.all(p['data'][:peak_length] == sum_wv)
+
+    # Finally check that we also can use a selection of peaks to sum
+    strax.sum_waveform(peaks, records, np.ones(n_ch), select_peaks_indices=np.array([0]))


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

The desaturation requires re-calculating the sum waveform of only a small fraction of the peaklets (that are saturated), once the (temporary copy of) records are corrected. It is best to be able to do partial re-calculation.

**Can you briefly describe how it works?**

`func: sum_waveform` now takes a keyword argument `peak_list` of the type `numpy.array`. When not specified, default value would be converted into `np.arange(len(peaks))`
