### PR TITLE
Create seperate doc for new chunk

### DIFF
--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -188,11 +188,8 @@ class MongoSaver(Saver):
         """see strax.Saver"""
         # For the first chunk we get the run_start_time and update the run-metadata file
         if int(chunk_info['chunk_i']) == 0:
-            self.run_start = t0 = datetime.fromtimestamp(
+            self.run_start = datetime.fromtimestamp(
                 chunk_info['start']/1e9).replace(tzinfo=py_utc)
-            self.col.update_one({'_id': self.id_md},
-                                {'$set':
-                                     {'run_start_time': t0}})
 
         self.col.update_one({'_id': self.id_md},
                             {'$addToSet':


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
We experienced that some documents got bigger than the 16 MB limit imposed by mongo due to many chunks being written to the same document. This is solved in this PR by splitting out the chunks-data and the meta-data into separate documents.

**Can you give a minimal working example (or illustrate with a figure)?**
https://github.com/XENONnT/analysiscode/blob/master/StraxTests/add_mongo_saver_finetuning.ipynb

**Doc format**
See the gist below for an example. Here we uploaded three chunks with a length == 5 datafield (to keep it simple). This means we have four documents in total:
https://gist.github.com/jorana/c4fccefa1a152b403bace944a8993699
