### PR TITLE
improve mongo-backend-loading

### DIFF
--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -57,9 +57,6 @@ class MongoBackend(StorageBackend):
         for i in range(chunk_len):
             for key in np.dtype(dtype).names:
                 result[i][key] = chunk_doc[i][key]
-
-        # We are done with this chunk.
-        del self.chunks_registry[chunk_i]
         return result
 
     def _saver(self, key, metadata):

--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -57,6 +57,9 @@ class MongoBackend(StorageBackend):
         for i in range(chunk_len):
             for key in np.dtype(dtype).names:
                 result[i][key] = chunk_doc[i][key]
+
+        # We are done with this chunk.
+        del self.chunks_registry[chunk_i]
         return result
 
     def _saver(self, key, metadata):


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Slightly tweak w.r.t. #335 (and #315). Only query the database for chunks once.

**Can you briefly describe how it works?**
Use `find` to find all chunks, save it in ram and load it from there instead of doing up to 600 queries.

**Performance**
Using 
```python
%%timeit
om = st.get_array('009524', 'online_peak_monitor', allow_incomplete=True) # 161 chunks
```
_Before_
23 s ± 175 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

_After_
1.91 s ± 70.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
