### PR TITLE
Update files.py

### DIFF
--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -205,6 +205,11 @@ class FileSytemBackend(strax.StorageBackend):
         prefix = dirname_to_prefix(dirname)
         metadata_json = f'{prefix}-metadata.json'
         md_path = osp.join(dirname, metadata_json)
+        
+        if not osp.exists(md_path):
+            # Try to see if we are so fast that there exists a temp folder 
+            # with the metadata we need.
+            md_path = osp.join(dirname+'_temp', metadata_json)
 
         if not osp.exists(md_path):
             # Try old-format metadata


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Solves a very hairy bug I induced here https://github.com/XENONnT/straxen/pull/257

**Can you briefly describe how it works?**
So the eventbuilders are so freaking fast that we run into this issue. The metadata is still in a temp folder making the RunDBs frontend live hard. 

Traceback
```python
Traceback (most recent call last):
  File "/home/xedaq/software/straxen/bin/bootstrax", line 1142, in run_strax
    st_make()
  File "/home/xedaq/software/straxen/bin/bootstrax", line 1122, in st_make
    max_workers=process_mode['cores'])
  File "/home/xedaq/software/strax/strax/context.py", line 1085, in make
    save=save, max_workers=max_workers, **kwargs):
  File "/home/xedaq/software/strax/strax/context.py", line 901, in get_iter
    chunk_number=_chunk_number)
  File "/home/xedaq/software/strax/strax/context.py", line 745, in get_components
    check_cache(d)
  File "/home/xedaq/software/strax/strax/context.py", line 665, in check_cache
    check_cache(dep_d)
  File "/home/xedaq/software/strax/strax/context.py", line 603, in check_cache
    time_range=time_range)
  File "/home/xedaq/software/strax/strax/context.py", line 550, in _get_partial_loader_for
    sf.find(key, **self._find_options)
  File "/home/xedaq/software/strax/strax/storage/common.py", line 239, in find
    meta = self._get_backend(backend_name).get_metadata(backend_key)
  File "/home/xedaq/software/strax/strax/storage/files.py", line 215, in get_metadata
    raise strax.DataCorrupted(f"Data in {dirname} has no metadata")
strax.storage.common.DataCorrupted: Data in /data/xenonnt_processed/009655-lone_hits-nagx3zzuiv has no metadata
```