### PR TITLE
Add representation to strax.StorageFrontend

### DIFF
--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -126,6 +126,9 @@ class StorageFrontend:
         self.readonly = readonly
         self.log = logging.getLogger(self.__class__.__name__)
 
+    def __str__(self):
+        return self.__repr__()
+
     def __repr__(self):
         # List the relevant attributes ('path' is actually for the
         # strax.DataDirectory but it makes more sense to put it here).

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -130,7 +130,7 @@ class StorageFrontend:
         # List the relevant attributes ('path' is actually for the
         # strax.DataDirectory but it makes more sense to put it here).
         attributes = ('readonly', 'path', 'exclude', 'take_only')
-        representation = self.__class__.__name__
+        representation = self.__class__.__name__ + '-StorageFrontend'
         for attr in attributes:
             if hasattr(self, attr) and getattr(self, attr):
                 representation += f', {attr}: {getattr(self, attr)}'

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -126,6 +126,16 @@ class StorageFrontend:
         self.readonly = readonly
         self.log = logging.getLogger(self.__class__.__name__)
 
+    def __repr__(self):
+        # List the relevant attributes ('path' is actually for the
+        # strax.DataDirectory but it makes more sense to put it here).
+        attributes = ('readonly', 'path', 'exclude', 'take_only')
+        representation = self.__class__.__name__
+        for attr in attributes:
+            if hasattr(self, attr) and getattr(self, attr):
+                representation += f', {attr}: {getattr(self, attr)}'
+        return representation
+
     def loader(self, key: DataKey,
                time_range=None,
                allow_incomplete=False,

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -130,7 +130,7 @@ class StorageFrontend:
         # List the relevant attributes ('path' is actually for the
         # strax.DataDirectory but it makes more sense to put it here).
         attributes = ('readonly', 'path', 'exclude', 'take_only')
-        representation = self.__class__.__name__ + '-StorageFrontend'
+        representation = f'{self.__class__.__module__}.{self.__class__.__name__}'
         for attr in attributes:
             if hasattr(self, attr) and getattr(self, attr):
                 representation += f', {attr}: {getattr(self, attr)}'


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
This fixes https://github.com/AxFoundation/strax/issues/332

**Can you briefly describe how it works?**
It allows you to print the StorageFrontend Class providing you with more usefull info.


**Can you give a minimal working example (or illustrate with a figure)?**
```python
st = straxen.contexts.xenonnt_online()
for sf in st.storage:
    print(sf)
``` 
returns
```python
straxen.rundb.RunDB, readonly: True
strax.storage.files.DataDirectory, readonly: True, path: /dali/lgrandi/xenonnt/raw, take_only: ('raw_records', 'raw_records_he', 'raw_records_aqmon', 'raw_records_nv', 'raw_records_aqmon_nv', 'raw_records_mv')
strax.storage.files.DataDirectory, readonly: True, path: /dali/lgrandi/xenonnt/processed
strax.storage.files.DataDirectory, path: ./strax_data
```

This used to return:
```python
<straxen.rundb.RunDB object at 0x7fa902955580>
<strax.storage.files.DataDirectory object at 0x7fa902955fd0>
<strax.storage.files.DataDirectory object at 0x7fa902955910>
<strax.storage.files.DataDirectory object at 0x7fa9029f4bb0>
```
