### PR TITLE
Fix strax.select_runs for available = tuple

### DIFF
--- a/strax/run_selection.py
+++ b/strax/run_selection.py
@@ -209,9 +209,13 @@ def select_runs(self, run_mode=None, run_id=None,
     for d in have_available:
         if not d + '_available' in dsets.columns:
             # Get extra availability info from the run db
-            self.runs[d + '_available'] = np.in1d(
-                self.runs.name.values,
-                self.list_available(d))
+            d_available = np.in1d(self.runs.name.values,
+                                  self.list_available(d))
+            # Save both in the context and for this selection using
+            # available = ('data_type',)
+            self.runs[d + '_available'] = d_available
+            dsets[d + '_available'] = d_available
+    for d in have_available:
         dsets = dsets[dsets[d + '_available']]
 
     return dsets


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Fix https://github.com/AxFoundation/strax/issues/331
**Can you briefly describe how it works?**
We were updating the self.runs of the context but not returning it actually as the datasets that were selected in the st.select_runs

**Can you give a minimal working example (or illustrate with a figure)?**
```python
st.select_runs(available=('raw_records', 'peaklets'))
```

this now returns the df that was asked for.
Previously did raise:
```python
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~/miniconda3/envs/strax/lib/python3.8/site-packages/pandas/core/indexes/base.py in get_loc(self, key, method, tolerance)
   2894             try:
-> 2895                 return self._engine.get_loc(casted_key)
   2896             except KeyError as err:

pandas/_libs/index.pyx in pandas._libs.index.IndexEngine.get_loc()

pandas/_libs/index.pyx in pandas._libs.index.IndexEngine.get_loc()

pandas/_libs/hashtable_class_helper.pxi in pandas._libs.hashtable.PyObjectHashTable.get_item()

pandas/_libs/hashtable_class_helper.pxi in pandas._libs.hashtable.PyObjectHashTable.get_item()

KeyError: 'peaklets_available'

The above exception was the direct cause of the following exception:

KeyError                                  Traceback (most recent call last)
<ipython-input-4-1070a107c871> in <module>
----> 1 st.select_runs(available=('peaklets', 'records' ))

/mnt/d/Google_Drive/PhD-master/ubuntu-storage/ubuntu-windows/software/strax_official/strax/run_selection.py in select_runs(self, run_mode, run_id, include_tags, exclude_tags, available, pattern_type, ignore_underscore)
    213                 self.runs.name.values,
    214                 self.list_available(d))
--> 215         dsets = dsets[dsets[d + '_available']]
    216 
    217     return dsets

~/miniconda3/envs/strax/lib/python3.8/site-packages/pandas/core/frame.py in __getitem__(self, key)
   2900             if self.columns.nlevels > 1:
   2901                 return self._getitem_multilevel(key)
-> 2902             indexer = self.columns.get_loc(key)
   2903             if is_integer(indexer):
   2904                 indexer = [indexer]

~/miniconda3/envs/strax/lib/python3.8/site-packages/pandas/core/indexes/base.py in get_loc(self, key, method, tolerance)
   2895                 return self._engine.get_loc(casted_key)
   2896             except KeyError as err:
-> 2897                 raise KeyError(key) from err
   2898 
   2899         if tolerance is not None:

KeyError: 'peaklets_available'

```
