### PR TITLE
copy data from frontend to frontend

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1382,15 +1382,8 @@ class Context:
             raise ValueError(f'Cannot select {target_frontend_id}-th frontend as '
                              f'we only have {len(self.storage)} frontends!')
 
-        # Figure out which of the frontends has the data
-        source_sf = None
-        for sf in self.storage:
-            if self._is_stored_in_sf(run_id, target, sf):
-                source_sf = sf
-                # We only need a single source
-                break
-        if source_sf is None:
-            raise ValueError('This cannot happen, we just checked that this run is stored?!?')
+        # Figure out which of the frontends has the data. Raise error when none
+        source_sf = self._get_source_sf(run_id, target, raise_error=True)
 
         # Keep frontends that:
         #  1. already have the data; and
@@ -1440,6 +1433,25 @@ class Context:
             return True
         except strax.DataNotAvailable:
             return False
+
+    def _get_source_sf(self, run_id, target, raise_error=False):
+        """
+        Get the source storage frontend for a given run_id and target
+        :param run_id: run_id
+        :param target: target
+        :param raise_error: Raise a ValueError if we cannot find one
+        (e.g. we already checked the data is stored)
+        :return: strax.StorageFrontend or None (when raise_error is
+        """
+        source_sf = None
+        for sf in self.storage:
+            if self._is_stored_in_sf(run_id, target, sf):
+                source_sf = sf
+                # We only need a single source
+                break
+        if source_sf is None and raise_error:
+            raise ValueError('This cannot happen, we just checked that this '
+                             'run should be stored?!?')
 
     @classmethod
     def add_method(cls, f):

--- a/strax/context.py
+++ b/strax/context.py
@@ -1375,7 +1375,7 @@ class Context:
             raise ValueError('_copy_to_frontend only works for ')
         if target_frontend_id is None:
             target_sf = self.storage
-        elif len(self.storage) <= target_frontend_id:
+        elif len(self.storage) > target_frontend_id:
             # only write to selected other frontend
             target_sf = [self.storage[target_frontend_id]]
         else:

--- a/strax/context.py
+++ b/strax/context.py
@@ -1425,8 +1425,13 @@ class Context:
                     'do you have two storage frontends writing to the same place?')
 
     def _is_stored_in_sf(self, run_id, target,
-                         storage_frontend):
-        """Copy data from one frontend to another"""
+                         storage_frontend: strax.StorageFrontend) -> bool:
+        """
+        :param run_id, target: run_id, target
+        :param storage_frontend: strax.StorageFrontend to check if it has the
+        requested datakey for the run_id and target.
+        :return: if the frontend has the key or not.
+        """
         key = self.key_for(run_id, target)
         try:
             storage_frontend.find(key, **self._find_options)
@@ -1437,11 +1442,11 @@ class Context:
     def _get_source_sf(self, run_id, target, raise_error=False):
         """
         Get the source storage frontend for a given run_id and target
-        :param run_id: run_id
-        :param target: target
+        :param run_id, target: run_id, target
         :param raise_error: Raise a ValueError if we cannot find one
         (e.g. we already checked the data is stored)
         :return: strax.StorageFrontend or None (when raise_error is
+        False)
         """
         source_sf = None
         for sf in self.storage:

--- a/strax/context.py
+++ b/strax/context.py
@@ -1413,7 +1413,6 @@ class Context:
         s_be = source_sf._get_backend(s_be_str)
         md = s_be.get_metadata(s_be_key)
 
-        # Loop over the targets. Fill each with the info from the loader
         for t_sf in target_sf:
             try:
                 # Need to load a new loader each time since it's a generator


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Some frontends are harder to interface with than others. Using this new function, one is able to copy data from one frontend to another. This is especially useful in at least these two concrete examples:

1. Querying the database is in Mongo.py is expensive. Better save it to disk as that is quicker and prevents people from overloading the database.
2. The mongo backend is a nightmare to use outside of dali, it's much easier to transfer when backcasted to a normal DataDirectory frontend.

**Can you briefly describe how it works?**
Strax magic! I wrote it such that it can be used either trying to write to all the other frontends or to a specific one (

**Can you give a minimal working example (or illustrate with a figure)?**
```python
for sf in st.storage[1:]:
    print(sf)
    print(st._is_stored_in_sf(run_id, target, sf))
st._copy_to_frontend(run_id, target, target_frontend_id=3)
for sf in st.storage[1:]:
    print(sf)
    print(st._is_stored_in_sf(run_id, target, sf))
## output
strax.storage.files.DataDirectory, path: /data/real_data/
True
strax.storage.files.DataDirectory, path: /data/_tests8/
False
strax.storage.files.DataDirectory, path: /data/_tests9/
False
# After copy
strax.storage.files.DataDirectory, path: /data/real_data/
True
strax.storage.files.DataDirectory, path: /data/_tests8/
False
strax.storage.files.DataDirectory, path: /data/_tests9/
True
```

**Future requests**
One might think that we may just as well then erase the original copy. This is is however not per se trivial in strax (yet), I might think about if we need this at some point.

