### PR TITLE
Fix error progress_bar

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -969,7 +969,12 @@ class Context:
                     
                     if progress_bar:
                         # Update progressbar:
-                        pbar.n = (result.end - start_time) / (end_time - start_time)
+                        if end_time - start_time > 0:
+                            pbar.n = (result.end - start_time) / (end_time - start_time)
+                        else:
+                            # Strange, start and endtime are the same, probably we 
+                            # don't have data yet e.g. allow_incomplete == True.
+                            pbar.n = 0
                         pbar.update(0)
                         # Now get last time printed and refresh seconds_per_chunk:
                         # This is a small work around since we do not know the


### PR DESCRIPTION
Here is the traceback, no need to say more:
```python
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
<ipython-input-11-27129e865a03> in <module>
      1 get_ipython().run_line_magic('matplotlib', 'notebook')
----> 2 OM.get_canvas(
      3     st,
      4     start_at_run= '10348', # This is the run I want to start from
      5     store_fig_at = './201121_daq_test',  # some path you want to store each figure

/mnt/d/Google_Drive/PhD-master/ubuntu-storage/ubuntu-windows/software/analysiscode/OnlineMonitor/online_monitor/online_monitor.py in get_canvas(st, run_id, time_sleep, store_fig_at, start_at_run, lone_hits_style)
    507         t_start = time.time()
    508 
--> 509         om, _run_id = get_run_and_data(st, run_id=run_id, timeout=time_sleep)
    510         if om is None:
    511             time.sleep(time_sleep)

/mnt/d/Google_Drive/PhD-master/ubuntu-storage/ubuntu-windows/software/analysiscode/OnlineMonitor/online_monitor/online_monitor.py in get_run_and_data(st, run_id, timeout)
    304         # Make the requested run
    305         _run_id = run_id
--> 306     om = get_data(st, _run_id)
    307     if om is None:
    308         print(f'Run {_run_id} starting. Waiting for data. Showing last '

/mnt/d/Google_Drive/PhD-master/ubuntu-storage/ubuntu-windows/software/analysiscode/OnlineMonitor/online_monitor/online_monitor.py in get_data(st, run_id)
    268             # We have some runs that may be fully finished, let's try to copy them
    269             online_monitor_to_frontend(st, run_id[:-1])
--> 270         om = st.get_array(run_id, 'online_monitor', allow_incomplete=True)
    271         return om
    272     except (strax.DataNotAvailable, ValueError):

/mnt/d/Google_Drive/PhD-master/ubuntu-storage/ubuntu-windows/software/strax_official/strax/context.py in get_array(self, run_id, targets, save, max_workers, **kwargs)
   1104                 max_workers=max_workers,
   1105                 **kwargs)
-> 1106             results = [x.data for x in source]
   1107 
   1108         results = np.concatenate(results)

/mnt/d/Google_Drive/PhD-master/ubuntu-storage/ubuntu-windows/software/strax_official/strax/context.py in <listcomp>(.0)
   1104                 max_workers=max_workers,
   1105                 **kwargs)
-> 1106             results = [x.data for x in source]
   1107 
   1108         results = np.concatenate(results)

/mnt/d/Google_Drive/PhD-master/ubuntu-storage/ubuntu-windows/software/strax_official/strax/context.py in get_iter(self, run_id, targets, save, max_workers, time_range, seconds_range, time_within, time_selection, selection_str, keep_columns, _chunk_number, progress_bar, **kwargs)
    990 
    991         except Exception as e:
--> 992             generator.throw(e)
    993             raise
    994 

/mnt/d/Google_Drive/PhD-master/ubuntu-storage/ubuntu-windows/software/strax_official/strax/processor.py in iter(self)
    268             # which is printed for the user
    269             self.log.debug("Reraising exception")
--> 270             raise exc.with_traceback(traceback)
    271 
    272         # Check the savers for any exception that occurred during saving

/mnt/d/Google_Drive/PhD-master/ubuntu-storage/ubuntu-windows/software/strax_official/strax/processor.py in iter(self)
    221 
    222         try:
--> 223             yield from final_generator
    224 
    225         # GeneratorExit results from exception in caller

/mnt/d/Google_Drive/PhD-master/ubuntu-storage/ubuntu-windows/software/strax_official/strax/mailbox.py in _read(self, subscriber_i)
    414                 except Exception as e:
    415                     # TODO: Should I also handle timeout errors like this?
--> 416                     self.kill_from_exception(e)
    417 
    418         self.log.debug("Done reading")

/mnt/d/Google_Drive/PhD-master/ubuntu-storage/ubuntu-windows/software/strax_official/strax/mailbox.py in kill_from_exception(self, e, reraise)
    184             self.kill(reason=(e.__class__, e, sys.exc_info()[2]))
    185             if reraise:
--> 186                 raise e
    187 
    188     def kill(self, upstream=True, reason=None):

/mnt/d/Google_Drive/PhD-master/ubuntu-storage/ubuntu-windows/software/strax_official/strax/mailbox.py in _read(self, subscriber_i)
    411 
    412                 try:
--> 413                     yield res
    414                 except Exception as e:
    415                     # TODO: Should I also handle timeout errors like this?

/mnt/d/Google_Drive/PhD-master/ubuntu-storage/ubuntu-windows/software/strax_official/strax/context.py in get_iter(self, run_id, targets, save, max_workers, time_range, seconds_range, time_within, time_selection, selection_str, keep_columns, _chunk_number, progress_bar, **kwargs)
    970                     if progress_bar:
    971                         # Update progressbar:
--> 972                         pbar.n = (result.end - start_time) / (end_time - start_time)
    973                         pbar.update(0)
    974                         # Now get last time printed and refresh seconds_per_chunk:

ZeroDivisionError: division by zero
```
