### PR TITLE
use utilix for client

### DIFF
--- a/strax/corrections.py
+++ b/strax/corrections.py
@@ -28,19 +28,20 @@ class CorrectionsInterface:
     this means a unique set of correction maps.
     """
 
-    def __init__(self, client=None,
-                 host=None, username=None, password=None,
-                 database_name='corrections'):
+    def __init__(self, database_name='corrections', client=None,
+                 host=None, username=None, password=None,):
         """
         Start the CorrectionsInterface. To initialize you need either:
-         - a pymongo.MongoClient (add as argument client) OR
-         - the credentials and url to connect to the pymongo instance
-         one wants to be using.
+            - a pymongo.MongoClient (add as argument client) OR
+            - the credentials and url to connect to the pymongo instance
+            one wants to be using.
+        :param database_name: Database name
         :param client: pymongo client, a pymongo.MongoClient object
+
+        (optional if client is not provided)
         :param host: DB host or IP address e.g. "127.0.0.1"
-        :param username: DB username
-        :param password: DB password
-        :param database_name: DB name
+        :param username: Database username
+        :param password: Database password
         """
         # Let's see if someone just provided a pymongo.MongoClient
         if (client is not None) and (

--- a/strax/corrections.py
+++ b/strax/corrections.py
@@ -28,13 +28,43 @@ class CorrectionsInterface:
     this means a unique set of correction maps.
     """
 
-    def __init__(self, client, database_name='corrections'):
+    def __init__(self, client=None,
+                 host=None, username=None, password=None,
+                 database_name='corrections'):
         """
-        :param client: DB pymongo client
+        Start the CorrectionsInterface. To initialize you need either:
+         - a pymongo.MongoClient (add as argument client) OR
+         - the credentials and url to connect to the pymongo instance
+         one wants to be using.
+        :param client: pymongo client, a pymongo.MongoClient object
+        :param host: DB host or IP address e.g. "127.0.0.1"
+        :param username: DB username
+        :param password: DB password
         :param database_name: DB name
         """
+        # Let's see if someone just provided a pymongo.MongoClient
+        if (client is not None) and (
+                host is None and
+                username is None and
+                password is None):
+            if not isinstance(client, pymongo.MongoClient):
+                raise TypeError(f'{client} is not a pymongo.MongoClient.')
+            self.client = client
+        # In this case, let's just initialize a new pymongo.MongoClient
+        elif (client is None) and (
+                host is not None and
+                username is not None
+                and password is not None):
+            self.client = pymongo.MongoClient(host=host,
+                                              username=username,
+                                              password=password)
+        else:
+            # Let's not be flexible with our inputs to prevent later
+            # misunderstandings because someone thought to be handling a
+            # different client than anticipated.
+            raise ValueError('Can only init using *either* the "client" or the '
+                             'combination of "host+username+password", not both')
 
-        self.client = client
         self.database_name = database_name
 
     def list_corrections(self):

--- a/strax/corrections.py
+++ b/strax/corrections.py
@@ -28,15 +28,15 @@ class CorrectionsInterface:
     this means a unique set of correction maps.
     """
 
-    def __init__(self, database_name='corrections', client=None,
+    def __init__(self, client=None, database_name='corrections',
                  host=None, username=None, password=None,):
         """
         Start the CorrectionsInterface. To initialize you need either:
             - a pymongo.MongoClient (add as argument client) OR
             - the credentials and url to connect to the pymongo instance
             one wants to be using.
-        :param database_name: Database name
         :param client: pymongo client, a pymongo.MongoClient object
+        :param database_name: Database name
 
         (optional if client is not provided)
         :param host: DB host or IP address e.g. "127.0.0.1"

--- a/strax/corrections.py
+++ b/strax/corrections.py
@@ -28,21 +28,13 @@ class CorrectionsInterface:
     this means a unique set of correction maps.
     """
 
-    def __init__(self, host='127.0.0.1', username=None, password=None,
-                 database_name='corrections'):
+    def __init__(self, client, database_name='corrections'):
         """
-        :param host: DB host
-        :param username: DB username
-        :param password: DB password
+        :param client: DB pymongo client
         :param database_name: DB name
         """
 
-        self.host = host
-        self.username = username
-        self.password = password
-        self.client = pymongo.MongoClient(host=self.host,
-                                          username=self.username,
-                                          password=self.password)
+        self.client = client
         self.database_name = database_name
 
     def list_corrections(self):


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Change the way we init the pymongo client for the corrections. NB: the init is now done on the `straxen` side (makes more sense to do it in the nT specific package).

**Can you briefly describe how it works?**
Given recent changes (https://github.com/XENONnT/straxen/pull/163), it makes more sense to use a centralized initiation for the pymongo client (i.e. `utilix`). 

**Can you give a minimal working example (or illustrate with a figure)?**
All should work just as before. It's only when someone uses this script outside of the straxen environment that one should initialize a client (see https://github.com/XENONnT/straxen/pull/288).

