### PR TITLE
Better queries in online monitor

### DIFF
--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -92,10 +92,14 @@ class MongoBackend(StorageBackend):
     def get_metadata(self, key):
         """See strax.Backend"""
         query = backend_key_to_query(key)
+
         # Make sure to get the last of the meta-data docs. Otherwise we
-        # might be getting a previously failed document.
+        # might be getting a previously failed document. Sort argument
+        # should be obsolete (due to the self.col.delete_many in the
+        # MongoSaver) but rather safe than sorry.
         doc = self.db[self.col_name].find_one({
             **query, 'metadata': {"$exists": True}},
+            # **query, 'provides_meta': True}, <-change to this after TTL has flushed
             sort=[('write_time', DESCENDING)])
         if doc and 'metadata' in doc:
             return doc['metadata']
@@ -103,17 +107,19 @@ class MongoBackend(StorageBackend):
 
     def _build_chunk_registry(self, backend_key):
         """
-        :param backend_key: strax.DataKey to query the collection for
         Build chunk info in a single registry using only one query to
         the database. This is much faster as one does not have to do
         n-chunk queries to the database. Just one will do. As the
         documents-size is limited to 16 MB, it's unlikely that we will
         run into memory issues (that we otherwise would not run into).
+
+        :param backend_key: strax.DataKey to query the collection for
         """
 
         query = backend_key_to_query(backend_key)
         chunks_registry = self.db[self.col_name].find(
             {**query, 'chunk_i': {'$exists': True}},
+            # {**query, 'provides_meta': False},  <-change to this after TTL has flushed
             {"chunk_i": 1, "data": 1})
 
         # We are going to convert this to a dictionary as that is
@@ -199,12 +205,11 @@ class MongoSaver(Saver):
         """
         super().__init__(metadata)
         self.col = col
-        # Parse basic properties for online document by forcing keys in
-        # specific representations (rep)
-        basic_meta = {}
-        for k, rep in (
-                ('run_id', int), ('data_type', str), ('lineage_hash', str)):
-            basic_meta[k.replace('run_id', 'number')] = rep(self.md[k])
+        # All meta_documents should have the key to query against
+        basic_meta = backend_key_to_query(key).copy()
+        # Start with a clean sheet, we are just going to overwrite
+        self.col.delete_many(basic_meta)
+
         # Add datetime objects as candidates for TTL collections. Either
         # can be used according to the preference of the user to index.
         # Two entries can be used:
@@ -215,6 +220,8 @@ class MongoSaver(Saver):
         # in the _save_chunk_metadata for the first chunk. Nevertheless
         # we need an object in case there e.g. is no chunk.
         basic_meta['run_start_time'] = datetime.now(py_utc)
+        # Add flag to doc that we are providing the metadata
+        basic_meta['provides_meta'] = True
         # If available later update with this value:
         self.run_start = None
         # This info should be added to all of the associated documents
@@ -267,6 +274,7 @@ class MongoSaver(Saver):
             doc['write_time'] = datetime.now(py_utc)
             doc['chunk_i'] = chunk_i
             doc["data"] = aggregate_data
+            doc['provides_meta'] = False
 
             chunk_id = self.col.insert_one(doc).inserted_id
             self.ids_chunk[chunk_i] = chunk_id

--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -158,6 +158,7 @@ class MongoBackend(StorageBackend):
                 del self.chunks_registry[registry_key]
         del self._buffered_backend_keys[0]
 
+
 @export
 class MongoFrontend(StorageFrontend):
     """MongoDB storage frontend"""
@@ -209,7 +210,6 @@ class MongoSaver(Saver):
         basic_meta = backend_key_to_query(key).copy()
         # Start with a clean sheet, we are just going to overwrite
         self.col.delete_many(basic_meta)
-
         # Add datetime objects as candidates for TTL collections. Either
         # can be used according to the preference of the user to index.
         # Two entries can be used:


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
As explained in https://github.com/AxFoundation/strax/issues/365 and https://github.com/AxFoundation/strax/issues/374 there are two things that need addressing:

- When re-making data, we should clear previous entries. -> To this end I added a `collection.delete_many` operation at the init of the saver. This should only happen when the data was not correctly stored. If it is already stored, you won't be accessing the `MongoSaver` anyways. This only happens when during progressing that there occurred an error, after this, there is an [exception](https://github.com/AxFoundation/strax/blob/a1c87937b9aa86105fdb0cff57590f3dbcfa72e6/strax/storage/common.py#L253) added to the metadata. We should delete this stuff if we try to process the same run again.
- We should distinguish between `metadata` and `chunk` documents. -> To this end I propose to add a `provides_meta` boolean to each document. This prevents `$exists`-operations.

**Implementation**
Please notice that I'm planning on a two stage PR, there are two places that need to be uncommented after a week when all the documents are updated with the `provides_meta` boolean.

**Question to mongo expert (Darryl)**
Does querying against a number provide improved performance w.r.t. querying against a boolean?