### PR TITLE
fix key error for non rr multiprocess

### DIFF
--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -886,8 +886,19 @@ class ParallelSourcePlugin(Plugin):
         p.sub_savers = sub_savers
         p.start_from = start_from
         if p.multi_output:
-            p.dtype = {d: p.sub_plugins[d].dtype_for(d)
-                       for d in outputs_to_send}
+            p.dtype = {}
+            for d in outputs_to_send:
+                if d in p.sub_plugins:
+                    p.dtype[d] = p.sub_plugins[d].dtype_for(d)
+                else:
+                    log.debug(f'Finding plugin that provides {d}')
+                    # Need to do some more work to get the plugin that
+                    # provides this data-type.
+                    for sp in p.sub_plugins.values():
+                        if d in sp.provides:
+                            log.debug(f'{sp} provides {d}')
+                            p.dtype[d] = sp.dtype_for(d)
+                            break
         else:
             to_send = list(outputs_to_send)[0]
             p.dtype = p.sub_plugins[to_send].dtype_for(to_send)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
See issue #372 for the problem.

**Can you briefly describe how it works?**
When we create a `ParallelSourcePlugin`, there is some error in finding the `dtype` for a requested data type. This yields the error as in #372.

Usually this is not much of a problem but if we already have raw_records registered, this becomes a mess. I now just iterate over the known plugins to the `ParallelSourcePlugin` to find the right dtype. Given that we have been running like this for a long time illustrates that there are probably few people actually using strax to it's max performance and few will notice.

**Can you give a minimal working example (or illustrate with a figure)?**
I'll upload a `multiprocess problem.ipynb` to the StraxTests on the analysiscode repo.

**Tests?**
Nah don't think such a think is likely to occur again any time soon.