### PR TITLE
Added keep_columns into docstring

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1480,6 +1480,8 @@ class Context:
 
 select_docs = """
 :param selection_str: Query string or sequence of strings to apply.
+:param keep_columns: Array field/dataframe column names to keep. 
+    Useful to reduce amount of data in memory.
 :param time_range: (start, stop) range to load, in ns since the epoch
 :param seconds_range: (start, stop) range of seconds since
 the start of the run to load.


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Adds keep_columns to iter/get_array doc strings. I am not sure if I am recalling it correclty, but I think we had this doc-string already before and lost it at some point. But, I wa snot able to track down the commit in which it happened.
