### PR TITLE
very small simplification of pbar

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -927,11 +927,10 @@ class Context:
                 max_messages=self.context_config['max_messages'],
                 timeout=self.context_config['timeout']).iter()
 
-        # If no selection is specified we have to get the last end_time:
+        # If no selection is specified we have to get the last end_time
+        # for the progress bar:
         start_time = None
         end_time = None
-
-        # Defining time ranges for the progress bar:
         if time_range:
             # user specified a time selection
             start_time, end_time = time_range
@@ -949,7 +948,6 @@ class Context:
                     break
                 except (strax.DataNotAvailable, KeyError, IndexError):
                     pass
-
         try:
             pbar = self._make_progress_bar(progress_bar=progress_bar)
             _last_t_pbar = pbar.last_print_t
@@ -965,8 +963,7 @@ class Context:
                     time_range=time_range,
                     time_selection=time_selection)
                 _last_t_pbar = self._update_progress_bar(
-                    pbar, start_time, end_time, n_chunks, _last_t_pbar,
-                    result.end)
+                    pbar, start_time, end_time, n_chunks, _last_t_pbar, result.end)
                 yield result
 
         except GeneratorExit:
@@ -984,20 +981,20 @@ class Context:
             raise ValueError(f"Invalid time range: {time_range}, "
                              "returned no chunks!")
 
-    def _make_progress_bar(self, progress_bar=True):
+    @staticmethod
+    def _make_progress_bar(progress_bar=True):
         # Define nice progressbar format:
         bar_format = ("{desc}: |{bar}| {percentage:.2f} % [{elapsed}<{remaining}],"
                       "{postfix[0]}  {postfix[1][spc]:.2f} s/chunk, "
                       "#chunks processed: {postfix[1][n]}")
         sec_per_chunk = np.nan  # Have not computed any chunk yet.
         post_fix = ['Rate last Chunk:', {'spc': sec_per_chunk, 'n': 0}]
-        pbar = tqdm(total=1,
-                    postfix=post_fix,
-                    bar_format=bar_format,
+        pbar = tqdm(total=1, postfix=post_fix, bar_format=bar_format,
                     disable=not progress_bar)
         return pbar
 
-    def _update_progress_bar(self, pbar, start_time, end_time, n_chunks, last_time, chunk_end):
+    @staticmethod
+    def _update_progress_bar(pbar, start_time, end_time, n_chunks, last_time, chunk_end):
         if end_time - start_time > 0:
             pbar.n = (chunk_end - start_time) / (end_time - start_time)
         else:
@@ -1005,10 +1002,9 @@ class Context:
             # don't have data yet e.g. allow_incomplete == True.
             pbar.n = 0
         pbar.update(0)
-        # Now get last time printed and refresh seconds_per_chunk:
-        # This is a small work around since we do not know the
-        # pacemaker here and therefore we do not know the number of
-        # chunks.
+        # Now get last time printed and refresh seconds_per_chunk: This is a
+        # small work around since we do not know the pacemaker here and
+        # therefore we do not know the number of chunks.
         pbar.postfix[1]['spc'] = pbar.last_print_t - last_time
         pbar.postfix[1]['n'] = n_chunks
         pbar.refresh()

--- a/strax/context.py
+++ b/strax/context.py
@@ -974,7 +974,7 @@ class Context:
         """
         try:
             t_start, t_end, = self.estimate_run_start_and_end(run_id, targets)
-        except (MemoryError):
+        except (AttributeError, KeyError, IndexError):
             # During testing some thing remain a secret
             t_start, t_end, = 0, float('inf')
         if t_end == float('inf'):

--- a/strax/context.py
+++ b/strax/context.py
@@ -8,8 +8,10 @@ import string
 import typing as ty
 import warnings
 import time
-
-import contextlib
+import numexpr
+import numpy as np
+import pandas as pd
+import strax
 import sys
 if any('jupyter' in arg for arg in sys.argv):
     # In some cases we are not using any notebooks,
@@ -18,11 +20,6 @@ if any('jupyter' in arg for arg in sys.argv):
 else:
     from tqdm import tqdm
 
-import numexpr
-import numpy as np
-import pandas as pd
-
-import strax
 export, __all__ = strax.exporter()
 __all__ += ['RUN_DEFAULTS_KEY']
 

--- a/strax/context.py
+++ b/strax/context.py
@@ -974,7 +974,7 @@ class Context:
         """
         try:
             t_start, t_end, = self.estimate_run_start_and_end(run_id, targets)
-        except (AttributeError, KeyError, IndexError):
+        except (MemoryError):
             # During testing some thing remain a secret
             t_start, t_end, = 0, float('inf')
         if t_end == float('inf'):
@@ -992,7 +992,7 @@ class Context:
                     bar_format=bar_format,
                     leave=True,
                     disable=not progress_bar)
-        return pbar, t_start, t_end,
+        return pbar, t_start, t_end
 
     @staticmethod
     def _update_progress_bar(pbar, t_start, t_end, n_chunks,  chunk_end):

--- a/strax/context.py
+++ b/strax/context.py
@@ -969,7 +969,7 @@ class Context:
         """
         Make a progress bar for get_iter
         :param run_id, targets: run_id and targets
-        :param progress_bar: Bool weither or not to display the progress bar
+        :param progress_bar: Bool whether or not to display the progress bar
         :return: progress bar, t_start (run) and t_end (run)
         """
         try:
@@ -995,15 +995,15 @@ class Context:
         return pbar, t_start, t_end
 
     @staticmethod
-    def _update_progress_bar(pbar, t_start, t_end, n_chunks,  chunk_end):
+    def _update_progress_bar(pbar, t_start, t_end, n_chunks, chunk_end):
         """Do some tqdm voodoo to get the progress bar for st.get_iter"""
         if t_end - t_start > 0:
-            pbar.n += (chunk_end - t_start) / (t_end - t_start)/n_chunks
+            pbar.n = (chunk_end - t_start) / (t_end - t_start)
         else:
-            # Strange, start and endtime are the same, probably we
-            # don't have data yet e.g. allow_incomplete == True.
+            # Strange, start and endtime are the same, probably we don't
+            # have data yet e.g. allow_incomplete == True.
             pbar.n = 0
-        # Let's add the postfix which is some info behind the tqdm marker
+        # Let's add the postfix which is the info behind the tqdm marker
         seconds_per_chunk = time.time() - pbar.last_print_t
         postfix = f'Last chunk: {seconds_per_chunk:.2f} s. #chunks {n_chunks}'
         pbar.set_postfix_str(postfix)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Very very small tweak to progress bar. Was working on something related and recognized it might also work here, seems like it does. Could have written an issue but would have been as much work as this small tweak. Daniel did all the actual work 😉 .

**Can you briefly describe how it works?**
Reduce the `get_iter` complexity by allowing a disabled progress bar.

**Extra feature**
Because we slightly changed how the pbar is set up, it now also works for `st.make` (at least, I thought this did not work before) :
![afbeelding](https://user-images.githubusercontent.com/22295914/105647139-efc0c400-5ea3-11eb-82cb-d98e6a47d7f5.png)
