### PR TITLE
Warn for non saved plugins, fix #379

### DIFF
--- a/strax/run_selection.py
+++ b/strax/run_selection.py
@@ -60,6 +60,12 @@ def scan_runs(self: strax.Context,
         list(strax.to_str_tuple(check_available))
         + list(self.context_config['check_available'])))
 
+    for target in check_available:
+        p = self._plugin_class_registry[target]
+        if p.save_when < strax.SaveWhen.ALWAYS:
+            self.log.warning(f'{p.__name__}-plugin is {str(p.save_when)}. '
+                             f'Therefore {target} is most likely not stored!')
+
     docs = None
     for sf in self.storage:
         _temp_docs = []


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Warn if targets are not saved. Otherwise people might get the wrong impression.

**Can you give a minimal working example (or illustrate with a figure)?**
```python
st=straxen.contexts.xenonnt_online()
st.context_config['check_available'] = strax.to_str_tuple(list(st._plugin_class_registry.keys()))
st.select_runs()
```
```text
Peaks-plugin is SaveWhen.NEVER. Therefore peaks is most likely not stored!
EventInfoDouble-plugin is SaveWhen.NEVER. Therefore event_info_double is most likely not stored!
nVETOPulseProcessing-plugin is SaveWhen.TARGET. Therefore records_nv is most likely not stored!
PeakPositionsNT-plugin is SaveWhen.NEVER. Therefore peak_positions is most likely not stored!
nVETORecorder-plugin is SaveWhen.TARGET. Therefore raw_records_coin_nv is most likely not stored!
nVETORecorder-plugin is SaveWhen.TARGET. Therefore lone_raw_records_nv is most likely not stored!
PeaksHighEnergy-plugin is SaveWhen.NEVER. Therefore peaks_he is most likely not stored!
nVETORecorder-plugin is SaveWhen.TARGET. Therefore lone_raw_record_statistics_nv is most likely not stored!
muVETOPulseProcessing-plugin is SaveWhen.TARGET. Therefore records_mv is most likely not stored!
AqmonHits-plugin is SaveWhen.TARGET. Therefore aqmon_hits is most likely not stored!
Fetching run info from MongoDB: 100%|██████████| 4881/4881 [00:05<00:00, 924.25it/s]
```

