### PR TITLE
Close inlined savers on exceptions in multiprocessing

### DIFF
--- a/strax/mailbox.py
+++ b/strax/mailbox.py
@@ -255,7 +255,12 @@ class Mailbox:
                 except StopIteration:
                     # No need to send this yet, close will do that
                     break
-                self.send(x)
+                try:
+                    self.send(x)
+                except Exception as e:
+                    # Inform the source we're going down
+                    iterable.throw(e)
+                    raise
                 i += 1
 
         except Exception as e:
@@ -488,8 +493,13 @@ def divide_outputs(source,
                 # No need to send this yet, close will do that
                 break
 
-            for d, x in result.items():
-                mailboxes[d].send(x)
+            try:
+                for d, x in result.items():
+                    mailboxes[d].send(x)
+            except Exception as e:
+                # Inform the source we're going down
+                source.throw(e)
+                raise
             i += 1
 
     except Exception as e:

--- a/strax/testutils.py
+++ b/strax/testutils.py
@@ -148,6 +148,8 @@ class Records(strax.Plugin):
     depends_on = tuple()
     dtype = strax.record_dtype()
 
+    rechunk_on_save = False
+
     def source_finished(self):
         return True
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
This is a fix for exception handling during multiprocessing. Previously, if strax crashed during multiprocessing, `_temp` directories could remain on disk, and exceptions were not always recorded in metadata. This should fix that. It's a low-priority PR: this won't prevent any crashes, just handle them slightly nicer. In other words, a perfect hobby project for a 'retired' colleague ;-).

The problem in more detail: 
  * If an exception occurs, exceptions propagate through strax's mailbox system. Usually, all savers subscribe to some mailbox, so they will receive the exception, write it in their metadata, and close gracefully. (https://github.com/AxFoundation/strax/blob/master/strax/storage/common.py#L577)
  * During multiprocessing, `ParallelSourcePlugin` "inlines" some savers, so the save operation can happen in the same process that processes the data. Inlined savers are outside the mailbox system, and do not get informed of exceptions the usual way.

The PR looks bigger than it is; it changes many lines just to indent them.  `iter` won't win any beauty contests with its high indentation level; if you see a good way to refactor it, go for it!

**Can you briefly describe how it works?**
Two changes were needed to fix this:
  * Change `Plugin.iter` so the `cleanup` code is always called: basically, we wrap everything in a big try-except loop. This also serves another purpose: replacing duplicated 'cleanup + return' calls with raising a custom exception. 
  * Change `Mailbox._send_from` so that when sending to a mailbox fails -- most importantly because the mailbox is killed -- we `throw` the exception back to the sending iterable, i.e. the plugin or loader producing the input. Usually nothing will happen with this, and the exception is just reraised. However, it gives `ParallelSourcePlugin` a chance to call cleanup. This will wait for any outstanding save operations and close its savers (i.e. consolidate metadata, record the exception, and remove _temp). Finally, the exception will still be reraised, and strax continues to die as per usual.

**Can you give a minimal working example (or illustrate with a figure)?**

Try adding `rechunk_on_save = False` to `Records` in testutils.py; this will cause master to fail `test_exception` in `test_core`.