### PR TITLE
specify saver timeout at context level

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -67,6 +67,9 @@ RUN_DEFAULTS_KEY = 'strax_defaults'
     strax.Option(name='timeout', default=24 * 3600,
                  help="Terminate processing if any one mailbox receives "
                       "no result for more than this many seconds"),
+    strax.Option(name='saver_timeout', default=900,
+                 help="Max time [s] a saver can take to store a result. Set "
+                      "high for slow compression algorithms."),
     strax.Option(name='use_per_run_defaults', default=False,
                  help='Scan the run db for per-run defaults. '
                       'This is an experimental strax feature that will '
@@ -744,7 +747,9 @@ class Context:
                             key,
                             metadata=p.metadata(
                                 run_id,
-                                d_to_save)))
+                                d_to_save),
+                            saver_timeout=self.context_config['saver_timeout']
+                        ))
                     except strax.DataNotAvailable:
                         # This frontend cannot save. Too bad.
                         pass

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -231,7 +231,7 @@ class FileSytemBackend(strax.StorageBackend):
         fn = osp.join(dirname, chunk_info['filename'])
         return strax.load_file(fn, dtype=dtype, compressor=compressor)
 
-    def _saver(self, dirname, metadata):
+    def _saver(self, dirname, metadata, **kwargs):
         # Test if the parent directory is writeable.
         # We need abspath since the dir itself may not exist,
         # even though its parent-to-be does
@@ -254,7 +254,7 @@ class FileSytemBackend(strax.StorageBackend):
                 f"Can't write data to {dirname}, "
                 f"no write permissions in {parent_dir}.")
 
-        return FileSaver(dirname, metadata=metadata)
+        return FileSaver(dirname, metadata=metadata, **kwargs)
 
 
 @export
@@ -262,8 +262,8 @@ class FileSaver(strax.Saver):
     """Saves data to compressed binary files"""
     json_options = dict(sort_keys=True, indent=4)
 
-    def __init__(self, dirname, metadata):
-        super().__init__(metadata)
+    def __init__(self, dirname, metadata, **kwargs):
+        super().__init__(metadata, **kwargs)
         self.dirname = dirname
         self.tempdirname = dirname + '_temp'
         self.prefix = dirname_to_prefix(dirname)

--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -83,11 +83,11 @@ class MongoBackend(StorageBackend):
                 result[i][key] = chunk_doc[i][key]
         return result
 
-    def _saver(self, key, metadata):
+    def _saver(self, key, metadata, **kwargs):
         """See strax.Backend"""
         # Use the key to make a collection otherwise, use the backend-key
         col = self.db[self.col_name if self.col_name is not None else str(key)]
-        return MongoSaver(key, metadata, col)
+        return MongoSaver(key, metadata, col, **kwargs)
 
     def get_metadata(self, key):
         """See strax.Backend"""

--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -194,7 +194,7 @@ class MongoFrontend(StorageFrontend):
 class MongoSaver(Saver):
     allow_rechunk = False
 
-    def __init__(self, key, metadata, col):
+    def __init__(self, key, metadata, col, **kwargs):
         """
         Mongo saver
         :param key: strax.Datakey
@@ -202,7 +202,7 @@ class MongoSaver(Saver):
         :param col: collection (NB! pymongo collection object) of mongo
         instance to write to
         """
-        super().__init__(metadata)
+        super().__init__(metadata, **kwargs)
         self.col = col
         # All meta_documents should have the key to query against
         basic_meta = backend_key_to_query(key).copy()


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Allow the timeout for the saver to be specified at the context level.

When storing files [with high compression](https://github.com/XENONnT/straxen/pull/358), one might change the context to allow also slower savers. However at the moment this is not such a trivial task. Using the context_config, we can change this number to some different value without having to change the strax source.

