### PR TITLE
allow dynamic function creation for dtype copy

### DIFF
--- a/strax/processing/pulse_processing.py
+++ b/strax/processing/pulse_processing.py
@@ -6,7 +6,7 @@ import typing as ty
 import numpy as np
 import numba
 from scipy.ndimage import convolve1d
-
+from warnings import warn
 import strax
 export, __all__ = strax.exporter()
 __all__ += ['NO_RECORD_LINK']
@@ -76,25 +76,14 @@ def raw_to_records(raw_records):
         len(raw_records),
         dtype=strax.record_dtype(
             record_length_from_dtype(raw_records.dtype)))
-    copy_raw_records(raw_records, records)
+    strax.copy_to_buffer(raw_records, records, '_copy_raw_records')
     return records
 
 
-# Numpy record arrays have a rowwise memory layout, so filling it
-# rowwise should be faster.
 @export
-@numba.njit(nogil=True, cache=True)
 def copy_raw_records(old, new):
-    for i in range(len(old)):
-        r = old[i]
-        r2 = new[i]
-        r2['channel'] = r['channel']
-        r2['dt'] = r['dt']
-        r2['time'] = r['time']
-        r2['length'] = r['length']
-        r2['pulse_length'] = r['pulse_length']
-        r2['record_i'] = r['record_i']
-        r2['data'][:] = r['data'][:]
+    warn('Deprecated, use strax.copy_to_buffer')
+    strax.copy_to_buffer(old, new, '_copy_raw_records')
 
 
 @export

--- a/tests/test_general_processing.py
+++ b/tests/test_general_processing.py
@@ -198,3 +198,12 @@ def test_overlap_indices(a1, n_a, b1, n_b):
         (true_a_inds[0], true_a_inds[-1] + 1),
         (true_b_inds[0], true_b_inds[-1] + 1))
     assert found == expected
+
+
+@hypothesis.settings(deadline=None)
+@hypothesis.given(strax.testutils.several_fake_records)
+def test_raw_to_records(r):
+    buffer = np.zeros(len(r), r.dtype)
+    strax.copy_to_buffer(r, buffer, "_test_r_to_buffer")
+    if len(r):
+        assert np.all(buffer == r)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Add a function to more easily numbafy the copy from dtype to dtype. Also see https://github.com/XENONnT/straxen/issues/353

**Can you briefly describe how it works?**
Numba magic 🧙 

Rather than writing each time a cumbersome function that has to get the dtype write, why not code this. The annoying thing about numba is that it does not allow you to use strings to loop over. This is a workaround.

**Can you give a minimal working example (or illustrate with a figure)?**
```python
r = np.ones(1000, dtype=strax.raw_record_dtype()
def test_raw_to_records(r):
    buffer = np.zeros(len(r), r.dtype)
    strax.copy_to_buffer(r, buffer, "_test_r_to_buffer")
    if len(r):
        assert np.all(buffer == r)
```

**Special thanks to**
Daniel for helping writing this up nicely and Jim Pivarski for showing such functionality in numba.