### PR TITLE
clip progress progressbar

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -989,7 +989,11 @@ class Context:
     def _update_progress_bar(pbar, t_start, t_end, n_chunks, chunk_end):
         """Do some tqdm voodoo to get the progress bar for st.get_iter"""
         if t_end - t_start > 0:
-            pbar.n = (chunk_end - t_start) / (t_end - t_start)
+            fraction_done = (chunk_end - t_start) / (t_end - t_start)
+            if fraction_done > .99:
+                # Patch to 1 to not have a red pbar when very close to 100%
+                fraction_done = 1
+            pbar.n = np.clip(fraction_done, 0, 1)
         else:
             # Strange, start and endtime are the same, probably we don't
             # have data yet e.g. allow_incomplete == True.


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Fix issue #398 for progress bars that appear to be unfinished.

**Can you briefly describe how it works?**
There can be some jitter at the end of a run that appears to say you are are 99.x % or 100.x % whereas you are simply done, and we should set to progress to exactly 100%. 
