### PR TITLE
Numbafy split by containment

### DIFF
--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -144,7 +144,12 @@ def split_by_containment(things, containers):
     Assumes everything is sorted, and containers are non-overlapping.
     """
     if not len(containers):
-        return []
+        # No containers so return empty numba.typed.List
+        empty_list = List()
+        # Small hack to define its type before returning it:
+        empty_list.append(np.zeros(0, dtype=things.dtype))
+        empty_list = empty_list[:0]
+        return empty_list
 
     return _split_by_containment(things, containers)
 

--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -169,6 +169,7 @@ def _fc_in(a_starts, b_starts, a_ends, b_ends, result):
         if b_starts[b_i] <= a_starts[a_i] and a_ends[a_i] <= b_ends[b_i]:
             result[a_i] = b_i
 
+
 @export
 def split_by_containment(things, containers):
     """
@@ -216,12 +217,12 @@ def _split_by_containment(things, containers):
 @numba.njit(cache=True, nogil=True)
 def _split(things, split_indices):
     """
-    Helper to replace np.split, reuqired since numba numpy.split does
+    Helper to replace np.split, required since numba numpy.split does
     not return a typed.List. Hence outputs cannot be unified.
     """
     things_split = List()
     if len(split_indices):
-        # Found split indicies so split things up:
+        # Found split indices so split things up:
         prev_si = 0
         for si in split_indices:
             things_split.append(things[prev_si:si])
@@ -231,7 +232,7 @@ def _split(things, split_indices):
             # Append things after last gap if exist
             things_split.append(things[prev_si:])
     else:
-        # If there are no split indicies, all things are in the same
+        # If there are no split indices, all things are in the same
         # container
         things_split.append(things)
     return things_split

--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -2,6 +2,7 @@ import os
 
 import strax
 import numba
+from numba.typed import List
 import numpy as np
 
 export, __all__ = strax.exporter()
@@ -100,6 +101,42 @@ def _find_break_i(data, safe_break, not_before):
 
 
 @export
+@numba.jit(nopython=True, nogil=True, cache=True)
+def fully_contained_in(things, containers):
+    """Return array of len(things) with index of interval in containers
+    for which things are fully contained in a container, or -1 if no such
+    exists.
+    We assume all intervals are sorted by time, and b_intervals
+    non overlapping.
+    """
+    result = np.ones(len(things), dtype=np.int32) * -1
+    a_starts = things['time']
+    b_starts = containers['time']
+    a_ends = strax.endtime(things)
+    b_ends = strax.endtime(containers)
+    _fc_in(a_starts, b_starts, a_ends, b_ends, result)
+    return result
+
+
+@numba.jit(nopython=True, nogil=True, cache=True)
+def _fc_in(a_starts, b_starts, a_ends, b_ends, result):
+    b_i = 0
+    for a_i in range(len(a_starts)):
+        # Skip ahead one or more b's if we're beyond them
+        # Note <= in second condition: end is an exclusive bound
+        while b_i < len(b_starts) and b_ends[b_i] <= a_starts[a_i]:
+            b_i += 1
+        if b_i == len(b_starts):
+            break
+
+        # Check for containment. We only need to check one b, since bs
+        # are nonoverlapping
+        if b_starts[b_i] <= a_starts[a_i] and a_ends[a_i] <= b_ends[b_i]:
+            result[a_i] = b_i
+
+
+@export
+@numba.jit(nopython=True, nogil=True, cache=True)
 def fully_contained_in(things, containers):
     """Return array of len(things) with index of interval in containers
     for which things are fully contained in a container, or -1 if no such
@@ -132,16 +169,22 @@ def _fc_in(a_starts, b_starts, a_ends, b_ends, result):
         if b_starts[b_i] <= a_starts[a_i] and a_ends[a_i] <= b_ends[b_i]:
             result[a_i] = b_i
 
-
 @export
 def split_by_containment(things, containers):
-    """Return list of thing-arrays contained in each container
+    """
+    Return list of thing-arrays contained in each container. Result is
+    returned as a numba.typed.List or list if containers are empty.
 
-    Assumes everything is sorted, and containers are nonoverlapping
+    Assumes everything is sorted, and containers are non-overlapping.
     """
     if not len(containers):
         return []
 
+    return _split_by_containment(things, containers)
+
+
+@numba.jit(nopython=True, nogil=True, cache=True)
+def _split_by_containment(things, containers):
     # Index of which container each thing belongs to, or -1
     which_container = fully_contained_in(things, containers)
 
@@ -150,20 +193,73 @@ def split_by_containment(things, containers):
     things = things[mask]
     which_container = which_container[mask]
     if not len(things):
-        # np.split has confusing behaviour for empty arrays
-        return [things[:0] for _ in range(len(containers))]
+        # Return list of empty things in case things are empty,
+        # needed to preserve dtype in LoopPlugins.
+        things_split = List()
+        for _ in range(len(containers)):
+            things_split.append(things[:0])
+        return things_split
 
     # Split things up by container
     split_indices = np.where(np.diff(which_container))[0] + 1
-    things_split = np.split(things, split_indices)
+    things_split = _split(things, split_indices)
 
     # Insert empty arrays for empty containers
-    empty_containers = np.setdiff1d(np.arange(len(containers)),
-                                    np.unique(which_container))
+    empty_containers = _get_empty_container_ids(len(containers),
+                                                np.unique(which_container))
     for c_i in empty_containers:
         things_split.insert(c_i, things[:0])
 
     return things_split
+
+
+@numba.njit(cache=True, nogil=True)
+def _split(things, split_indices):
+    """
+    Helper to replace np.split, reuqired since numba numpy.split does
+    not return a typed.List. Hence outputs cannot be unified.
+    """
+    things_split = List()
+    if len(split_indices):
+        # Found split indicies so split things up:
+        prev_si = 0
+        for si in split_indices:
+            things_split.append(things[prev_si:si])
+            prev_si = si
+
+        if prev_si < len(things):
+            # Append things after last gap if exist
+            things_split.append(things[prev_si:])
+    else:
+        # If there are no split indicies, all things are in the same
+        # container
+        things_split.append(things)
+    return things_split
+
+
+@numba.njit(cache=True, nogil=True)
+def _get_empty_container_ids(n_containers, full_container_ids):
+    """
+    Helper to replace np.setdiff1d for numbafied split_by_containment.
+    """
+    res = np.zeros(n_containers, dtype=np.int64)
+
+    n_empty = 0
+    prev_fid = 0
+    for fid in full_container_ids:
+        # Loop over all container ids with input, ids in between
+        # must be empty:
+        n = fid - prev_fid
+        res[n_empty:n_empty + n] = np.arange(prev_fid, fid, dtype=np.int64)
+        prev_fid = fid + 1
+        n_empty += n
+
+    if prev_fid < n_containers:
+        # Do the rest if there is any:
+        n = n_containers - prev_fid
+        res[n_empty:n_empty + n] = np.arange(prev_fid, n_containers, dtype=np.int64)
+        n_empty += n
+    return res[:n_empty]
 
 
 @export

--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -107,41 +107,6 @@ def fully_contained_in(things, containers):
     for which things are fully contained in a container, or -1 if no such
     exists.
     We assume all intervals are sorted by time, and b_intervals
-    non overlapping.
-    """
-    result = np.ones(len(things), dtype=np.int32) * -1
-    a_starts = things['time']
-    b_starts = containers['time']
-    a_ends = strax.endtime(things)
-    b_ends = strax.endtime(containers)
-    _fc_in(a_starts, b_starts, a_ends, b_ends, result)
-    return result
-
-
-@numba.jit(nopython=True, nogil=True, cache=True)
-def _fc_in(a_starts, b_starts, a_ends, b_ends, result):
-    b_i = 0
-    for a_i in range(len(a_starts)):
-        # Skip ahead one or more b's if we're beyond them
-        # Note <= in second condition: end is an exclusive bound
-        while b_i < len(b_starts) and b_ends[b_i] <= a_starts[a_i]:
-            b_i += 1
-        if b_i == len(b_starts):
-            break
-
-        # Check for containment. We only need to check one b, since bs
-        # are nonoverlapping
-        if b_starts[b_i] <= a_starts[a_i] and a_ends[a_i] <= b_ends[b_i]:
-            result[a_i] = b_i
-
-
-@export
-@numba.jit(nopython=True, nogil=True, cache=True)
-def fully_contained_in(things, containers):
-    """Return array of len(things) with index of interval in containers
-    for which things are fully contained in a container, or -1 if no such
-    exists.
-    We assume all intervals are sorted by time, and b_intervals
     nonoverlapping.
     """
     result = np.ones(len(things), dtype=np.int32) * -1

--- a/tests/test_general_processing.py
+++ b/tests/test_general_processing.py
@@ -101,6 +101,17 @@ def _is_contained(_thing, _container):
                                    unique=True))
 @hypothesis.settings(deadline=None)
 def test_get_empty_container_ids(full_container_ids):
+    """
+    Helper function to test if strax.processing.general._get_empty_container_ids
+    behaves the same as np.setdiff1d. Both functions should compute the
+    a set diff of the two arrays. E.g. in this case an array with unique
+    numbers between 0 and 15 which are not in full_container_ids.
+
+    :param full_container_ids: Array which mimics the ids of full containers.
+        the array has a size between 0 and 10 and is filled with integer
+        values between 0 and 15.
+    :return:
+    """
     full_container_ids = np.sort(full_container_ids)
 
     if len(full_container_ids):
@@ -134,12 +145,22 @@ def test_get_empty_container_ids(full_container_ids):
                   )
 @hypothesis.settings(deadline=None)
 def test_split(things, split_indices):
+    """
+    Test to check if strax.processing.general._split shows the same
+    behavior as np.split for the previous split_by_containment function.
+
+    :param things: things to be split. Hypothesis will create here an
+        array of a length between 0 and 10. Each element in this array
+        can also range between 0 and 10.
+    :param split_indices: Indices at which things should be split.
+    """
     split_indices = np.sort(split_indices)
 
     split_things = strax.processing.general._split(things, split_indices)
     split_things_np = np.split(things, split_indices)
 
     for ci, (s, snp) in enumerate(zip(split_things, split_things_np)):
+        # Loop over splitted objects and check if they are the same.
         mes = f'Not all splitted things are the same for split {ci}!'
         assert np.all(s == snp), mes
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
In this PR we numbafy `split_by_containment` and change its return value into a numba.typed.List instead of a normal Python list. This has the advantage that the result of `split_by_containment` can be used in numba njitted functions which enhances there speed. Further, this PR increases the performance of  `split_by_containment` by a factor of x2 to x4 depending on its inputs. This performance increase will directly manifest in a performance increase of LoopPlugins. 
If the numba.typed.List output is used instead of a LoopPlugin one can gain another factor x10 boost if needed. This enables maybe new usages of `split_by_containment`. 
In addition to the function changes I added small tests to ensure, that the required replacement functions behave as their numpy counterparts. 

**Can you give a minimal working example (or illustrate with a figure)?**
A simple comparison notebook can be found [here](https://github.com/XENONnT/analysiscode/blob/master/StraxTests/NumbafiedSplitByContainment.ipynb).