### PR TITLE
Add property provided_dtypes to Context

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1462,17 +1462,17 @@ class Context:
             raise ValueError('This cannot happen, we just checked that this '
                              'run should be stored?!?')
 
-    @property
-    def provided_dtypes(self):
+    def provided_dtypes(self, runid='0'):
         """
         Summarize useful dtype information provided by this context
         :return: dictionary of provided dtypes with their corresponding lineage hash and save_when
         """
-        hashes = set([(d, self.key_for('0', d).lineage_hash, p.save_when)
+        hashes = set([(d, self.key_for(runid, d).lineage_hash, p.save_when, p.__version__)
                     for p in self._plugin_class_registry.values()
                     for d in p.provides])
 
-        return {dtype: dict(hash=h, save_when=save_when.name) for dtype, h, save_when in hashes}
+        return {dtype: dict(hash=h, save_when=save_when.name, version=version)
+                for dtype, h, save_when, version in hashes}
 
     @classmethod
     def add_method(cls, f):

--- a/strax/context.py
+++ b/strax/context.py
@@ -1466,7 +1466,7 @@ class Context:
     def provided_dtypes(self):
         """
         Summarize useful dtype information provided by this context
-        :return: dictionary of provided dtypes with their corresponding lineage hash
+        :return: dictionary of provided dtypes with their corresponding lineage hash and save_when
         """
         hashes = set([(d, self.key_for('0', d).lineage_hash, p.save_when)
                     for p in self._plugin_class_registry.values()

--- a/strax/context.py
+++ b/strax/context.py
@@ -1465,7 +1465,7 @@ class Context:
     def provided_dtypes(self, runid='0'):
         """
         Summarize useful dtype information provided by this context
-        :return: dictionary of provided dtypes with their corresponding lineage hash and save_when
+        :return: dictionary of provided dtypes with their corresponding lineage hash, save_when, version
         """
         hashes = set([(d, self.key_for(runid, d).lineage_hash, p.save_when, p.__version__)
                     for p in self._plugin_class_registry.values()

--- a/strax/context.py
+++ b/strax/context.py
@@ -1462,6 +1462,18 @@ class Context:
             raise ValueError('This cannot happen, we just checked that this '
                              'run should be stored?!?')
 
+    @property
+    def provided_dtypes(self):
+        """
+        Summarize useful dtype information provided by this context
+        :return: dictionary of provided dtypes with their corresponding lineage hash
+        """
+        hashes = set([(d, self.key_for('0', d).lineage_hash, p.save_when)
+                    for p in self._plugin_class_registry.values()
+                    for d in p.provides])
+
+        return {dtype: dict(hash=h, save_when=save_when.name) for dtype, h, save_when in hashes}
+
     @classmethod
     def add_method(cls, f):
         """Add f as a new Context method"""


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
I often want a broad overview of the different data types, their lineage hashes, and whether they are saved to disk or not. This is especially useful for e.g. reprocessing or for comparing the changes to hashes between different contexts.

**Can you briefly describe how it works?**
It's a convenience function -- no new functionality. I thought making it a `property` would be best to make it immutable (or at least more difficult to mutate) but still a dictionary which is nice to work with.

**Can you give a minimal working example (or illustrate with a figure)?**
Sure:

```
import strax
from pprint import pprint
import numpy as np

_dtype_name = 'variable'
_dtype = ('variable 1', _dtype_name)
test_dtype = [(_dtype, np.float64)] + strax.time_fields

class UselessPlugin(strax.Plugin):
    """The plugin that we will be sub-classing"""
    provides = 'useless_data'
    dtype = test_dtype
    depends_on = tuple()

    def compute(self, something):
        return np.ones(len(something), dtype=self.dtype)

class UselessPlugin2(strax.Plugin):
    """The plugin that we will be sub-classing"""
    dtype = test_dtype
    provides = 'more_useless_data'
    depends_on = 'useless_data'
    save_when = strax.SaveWhen.TARGET

    def compute(self, something):
        return np.ones(len(something), dtype=self.dtype) * 2

st = strax.Context(storage=[])
st.register((UselessPlugin, UselessPlugin2))

pprint(st.provided_dtypes)
```

prints:
```
{'more_useless_data': {'hash': 'yxzcuhurrz', 'save_when': 'TARGET'},
 'useless_data': {'hash': 'bpf35bjrkg', 'save_when': 'ALWAYS'}}
```

This new method should not require any changes apart from perhaps including it in the documentation. I don't think tests are necessary. 

