### PR TITLE
Allow multiple targets to be computed simultaneously

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -771,7 +771,7 @@ class Context:
         if len(intersec):
             raise RuntimeError(f"{intersec} both computed and loaded?!")
         if len(targets) > 1:
-            final_plugin = self._get_end_targets(plugins)
+            final_plugin = self._get_end_targets(plugins)[:1]
             self.log.warning(
                 f'Multiple targets detected! This is only suitable for mass '
                 f'producing dataypes since only {final_plugin} will be '

--- a/strax/context.py
+++ b/strax/context.py
@@ -360,7 +360,7 @@ class Context:
 
         for x in dir(module):
             x = getattr(module, x)
-            if type(x) != type(type):
+            if not isinstance(x, type(type)):
                 continue
             if issubclass(x, strax.Plugin):
                 self.register(x)
@@ -901,7 +901,7 @@ class Context:
                          dict(depends_on=tuple(targets)))
                 self.register(p)
                 targets = (temp_name,)
-            if not allow_multiple:
+            elif not allow_multiple:
                 raise RuntimeError("Cannot automerge different data kinds!")
 
         components = self.get_components(run_id,

--- a/strax/context.py
+++ b/strax/context.py
@@ -1122,6 +1122,10 @@ class Context:
         {get_docs}
         """
         run_ids = strax.to_str_tuple(run_id)
+
+        if kwargs.get('allow_multiple', False):
+            raise RuntimeError('Cannot allow_multiple with get_array/get_df')
+
         if len(run_ids) > 1:
             results = strax.multi_run(
                 self.get_array, run_ids, targets=targets,
@@ -1132,7 +1136,6 @@ class Context:
                 targets,
                 save=save,
                 max_workers=max_workers,
-                allow_multiple=False,
                 **kwargs)
             results = [x.data for x in source]
 
@@ -1183,6 +1186,9 @@ class Context:
                 n_chunks: number of chunks in run
                 n_rows: number of data entries in run
         """
+        if kwargs.get('allow_multiple', False):
+            raise RuntimeError('Cannot allow_multiple with accumulate')
+
         n_chunks = 0
         seen_data = False
         result = {'n_rows': 0}
@@ -1194,7 +1200,6 @@ class Context:
             function_takes_fields = False
 
         for chunk in self.get_iter(run_id, targets,
-                                   allow_multiple=False,
                                    **kwargs):
             data = chunk.data
             data = self._apply_function(data, targets)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -421,7 +421,7 @@ def test_allow_multiple(targets=('peaks', 'records')):
                 function(run_id=run_id,
                          allow_multiple=True,
                          targets=targets)
-            except TypeError:
+            except RuntimeError:
                 # Great, this doesn't work (and it shouldn't!)
                 continue
             raise ValueError(f'{function} could run with allow_multiple')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -404,3 +404,46 @@ def test_superrun():
         np.testing.assert_array_equal(p1['area'], np.zeros(len(p1)))
         np.testing.assert_array_equal(p2['area'], np.zeros(len(p2)))
         np.testing.assert_array_equal(ps, np.concatenate([p1, p2]))
+
+
+def test_allow_multiple(targets=('peaks', 'records')):
+    """Test if we can use the allow_multiple correctly and fail otherwise"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        mystrax = strax.Context(storage=strax.DataDirectory(temp_dir,
+                                                            deep_scan=True),
+                                register=[Records, Peaks])
+        for p in mystrax._plugin_class_registry.values():
+            p.parallel = False
+        assert not mystrax.is_stored(run_id, 'peaks')
+        # Create everything at once with get_array and get_df should fail
+        for function in [mystrax.get_array, mystrax.get_df]:
+            try:
+                function(run_id=run_id,
+                         allow_multiple=True,
+                         targets=targets)
+            except TypeError:
+                # Great, this doesn't work (and it shouldn't!)
+                continue
+            raise ValueError(f'{function} could run with allow_multiple')
+
+        try:
+            mystrax.make(run_id=run_id,
+                         targets=targets)
+        except RuntimeError:
+            # Great, we shouldn't be allowed
+            pass
+
+        assert not mystrax.is_stored(run_id, 'peaks')
+        mystrax.make(run_id=run_id,
+                     allow_multiple=True,
+                     targets=targets)
+
+        for t in targets:
+            assert mystrax.is_stored(run_id, t)
+
+
+def test_allow_multiple_inverted():
+    # Make sure that the processing also works if the first target is
+    # actually depending on the second. In that case, we should
+    # subscribe the first target as the endpoint of the processing
+    test_allow_multiple(targets=('records', 'peaks',))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -412,8 +412,6 @@ def test_allow_multiple(targets=('peaks', 'records')):
         mystrax = strax.Context(storage=strax.DataDirectory(temp_dir,
                                                             deep_scan=True),
                                 register=[Records, Peaks])
-        for p in mystrax._plugin_class_registry.values():
-            p.parallel = False
         assert not mystrax.is_stored(run_id, 'peaks')
         # Create everything at once with get_array and get_df should fail
         for function in [mystrax.get_array, mystrax.get_df]:


### PR DESCRIPTION
# **What is the problem / what does the code in this PR do**
On the eventbuilders we need to compute targets that are not always depending on one another. For example [event info](https://straxen.readthedocs.io/en/latest/reference/datastructure.html#event-info) and [online_peak_monitor](https://straxen.readthedocs.io/en/latest/reference/datastructure.html#online-peak-monitor) don't depend on each other and don't have the same datakind. This makes it impossible to use `st.make` on these target.

So far, I've been using a [https://github.com/XENONnT/straxen/blob/master/bin/bootstrax#L327-L335](work-around) of registering a temporary plugin for merging these non-unify-able targets. However, this is causing quite some issues in the merging step especially given the fact that the online-peak monitor is a monolithic event per chunk (i.e. unable to split to get a nice input buffer). This is causing issues in the online processing and can be expected to get worse when the process is also dealing with other datakinds like the NV/MV/HE datastreams. We need something smarter from strax.

## **Can you briefly describe how it works?**
We ditch the paradigm of allowing only multiple targets when asking for the processing components. This means the components can comprise multiple targets that can be computed simultaneously. However, we need to be careful when to allow this, we don't want people to use this functionality in `st.get_array` or `st.get_df` but only for mass producing datatypes (e.g. using `st.make`). 

One thing I did notice is that we should be careful not to start multiple targets for the mailboxes, I spend a good hour or four trying to get that done properly but I got lost and also figured it is not the scope I'm aiming for. Instead, I allow only the first target to be subscribed. That should suffice.

## **Can you give a minimal working example (or illustrate with a figure)?**
I tested it using a very slightly altered version of [this notebook](https://github.com/XENONnT/analysiscode/tree/master/DAQ/bootstrax_on_dali) on live data and all works fine. I even went completely nuts by stetting the targets to all plugins in `_plugin_class_registry` (if `parallel!='process'`) and it worked just fine starting from the real live data.

## **Tests**
In b5c9474 I added a test, while writing this, I noticed that we should check that the mailbox subscribed plugin is not depended on, otherwise we are going to get a screwed up chain and infinite hangs. Got to love tests for figuring this out.