### PR TITLE
Tweaks to multitargets

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -918,8 +918,14 @@ class Context:
                 targets = (temp_name,)
             elif not allow_multiple:
                 raise RuntimeError("Cannot automerge different data kinds!")
-            elif self.context_config['allow_lazy'] or self.context_config['timeout'] > 7200:
-                raise RuntimeError(f'Cannot allow_multiple in lazy mode or with long timeouts.')
+            elif (self.context_config['timeout'] > 7200 or (
+                    self.context_config['allow_lazy'] and
+                    not self.context_config['allow_multiprocess'])):
+                # For allow_multiple we don't want allow this when in lazy mode
+                # with long timeouts (lazy-mode is disabled if multiprocessing
+                # so if that is activated, we can also continue)
+                raise RuntimeError(f'Cannot allow_multiple in lazy mode or '
+                                   f'with long timeouts.')
 
         components = self.get_components(run_id,
                                          targets=targets,

--- a/strax/context.py
+++ b/strax/context.py
@@ -771,7 +771,7 @@ class Context:
         if len(intersec):
             raise RuntimeError(f"{intersec} both computed and loaded?!")
         if len(targets) > 1:
-            final_plugin = self._get_end_targets(plugins)[:1]
+            final_plugin = [t for t in targets if t in self._get_end_targets(plugins)][:1]
             self.log.warning(
                 f'Multiple targets detected! This is only suitable for mass '
                 f'producing dataypes since only {final_plugin} will be '
@@ -918,6 +918,8 @@ class Context:
                 targets = (temp_name,)
             elif not allow_multiple:
                 raise RuntimeError("Cannot automerge different data kinds!")
+            elif self.context_config['allow_lazy']:
+                raise RuntimeError(f'Cannot allow_multiple in lazy mode.')
 
         components = self.get_components(run_id,
                                          targets=targets,

--- a/strax/context.py
+++ b/strax/context.py
@@ -918,8 +918,8 @@ class Context:
                 targets = (temp_name,)
             elif not allow_multiple:
                 raise RuntimeError("Cannot automerge different data kinds!")
-            elif self.context_config['allow_lazy']:
-                raise RuntimeError(f'Cannot allow_multiple in lazy mode.')
+            elif self.context_config['allow_lazy'] or self.context_config['timeout'] < 7200:
+                raise RuntimeError(f'Cannot allow_multiple in lazy mode or with long timeouts.')
 
         components = self.get_components(run_id,
                                          targets=targets,

--- a/strax/context.py
+++ b/strax/context.py
@@ -918,7 +918,7 @@ class Context:
                 targets = (temp_name,)
             elif not allow_multiple:
                 raise RuntimeError("Cannot automerge different data kinds!")
-            elif self.context_config['allow_lazy'] or self.context_config['timeout'] < 7200:
+            elif self.context_config['allow_lazy'] or self.context_config['timeout'] > 7200:
                 raise RuntimeError(f'Cannot allow_multiple in lazy mode or with long timeouts.')
 
         components = self.get_components(run_id,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -412,6 +412,8 @@ def test_allow_multiple(targets=('peaks', 'records')):
         mystrax = strax.Context(storage=strax.DataDirectory(temp_dir,
                                                             deep_scan=True),
                                 register=[Records, Peaks])
+        mystrax.set_context_config({'allow_lazy': False})
+
         assert not mystrax.is_stored(run_id, 'peaks')
         # Create everything at once with get_array and get_df should fail
         for function in [mystrax.get_array, mystrax.get_df]:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -412,7 +412,8 @@ def test_allow_multiple(targets=('peaks', 'records')):
         mystrax = strax.Context(storage=strax.DataDirectory(temp_dir,
                                                             deep_scan=True),
                                 register=[Records, Peaks])
-        mystrax.set_context_config({'allow_lazy': False})
+        mystrax.set_context_config({'allow_lazy': False,
+                                    'timeout': 80})
 
         assert not mystrax.is_stored(run_id, 'peaks')
         # Create everything at once with get_array and get_df should fail


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Tweak to #408 after [feedback from Jelle](https://github.com/AxFoundation/strax/pull/408#issuecomment-797667287).

**Can you briefly describe how it works?**
Three small tweaks:
1. Don't allow lazy mode for `allow_multiple`
2. Don't allow `timeouts >7200` for `allow_multiple`. Set this as a hard coded value for the moment.
3. Make sure to abide the order of the targets as specified in `get_iter`. We for now should be a little smart about the order of the plugins in order not to fall into the mailbox timeout. (Failures happening outside the final-target subscribers will only get caught by the last resort timeout of the mailboxes).
