### PR TITLE
Check data availability for single run

### DIFF
--- a/strax/run_selection.py
+++ b/strax/run_selection.py
@@ -299,7 +299,8 @@ def available_for_run(self: strax.Context,
     :param exclude_targets: targets to exclude e.g. raw_records,
         raw_records* or *_nv. If multiple targets (e.g. a list) is
         provided, the target should match none of the arguments!
-    :param pattern_type: either 'fnmatch' or 're'
+    :param pattern_type: either 'fnmatch' (Unix filename pattern
+        matching) or 're' (Regular expression operations).
     :return: Table of available data per target
     """
     if not isinstance(run_id, str):

--- a/strax/run_selection.py
+++ b/strax/run_selection.py
@@ -2,7 +2,7 @@
 import fnmatch
 import re
 import typing as ty
-
+from collections import defaultdict
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
@@ -281,6 +281,66 @@ def define_run(self: strax.Context,
     else:
         raise RuntimeError("No storage frontend registered that allows"
                            " run definition")
+
+
+@strax.Context.add_method
+def available_for_run(self: strax.Context,
+                      run_id: str,
+                      include_targets: ty.Union[None, list, tuple, str] = None,
+                      exclude_targets: ty.Union[None, list, tuple, str] = None,
+                      pattern_type: str = 'fnmatch') -> pd.DataFrame:
+    """
+    For a given single run, check all the targets if they are stored.
+        Excludes the target if never stored anyway.
+    :param run_id: requested run
+    :param include_targets: targets to include e.g. raw_records,
+        raw_records* or *_nv. If multiple targets (e.g. a list) is
+        provided, the target should match any of the arguments!
+    :param exclude_targets: targets to exclude e.g. raw_records,
+        raw_records* or *_nv. If multiple targets (e.g. a list) is
+        provided, the target should match none of the arguments!
+    :param pattern_type: either 'fnmatch' or 're'
+    :return: Table of available data per target
+    """
+    if not isinstance(run_id, str):
+        raise ValueError(f'Only single run_id is allowed (str),'
+                         f' got {run_id} ({type(run_id)})')
+
+    if exclude_targets is None:
+        exclude_targets = []
+    if include_targets is None:
+        include_targets = []
+
+    is_stored = defaultdict(list)
+    for target in self._plugin_class_registry.keys():
+        # Skip targets that are not stored
+        if not self._plugin_class_registry[target].save_when > strax.SaveWhen.NEVER:
+            continue
+
+        # Should we include this target or exclude it?
+        include_t = []
+        exclude_t = False
+
+        for excl in strax.to_str_tuple(exclude_targets):
+            # Simple logic, if we match the excluded target, we should
+            # should not continue
+            if _tag_match(target, excl, pattern_type, False):
+                exclude_t = True
+                break
+
+        # We can match any of the "incl" targets, keep a list and check
+        # of any of the "incl" matches the target.
+        for incl in strax.to_str_tuple(include_targets):
+            include_t.append(_tag_match(target, incl, pattern_type, False))
+
+        # Convert to simple bool. If no include_targets is specified,
+        # all are fine, otherwise check at least one is matching.
+        include_t = True if not len(include_t) else any(include_t)
+
+        if include_t and not exclude_t:
+            is_stored['target'].append(target)
+            is_stored['is_stored'].append(self.is_stored(run_id, target))
+    return pd.DataFrame(is_stored)
 
 
 def _tags_match(dsets, patterns, pattern_type, ignore_underscore):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -298,7 +298,6 @@ def test_run_selection():
     with tempfile.TemporaryDirectory() as temp_dir:
         sf = strax.DataDirectory(path=temp_dir,
                                  deep_scan=True, provide_run_metadata=True)
-
         # Write mock runs db
         for d in mock_rundb:
             sf.write_run_metadata(d['name'], d)
@@ -448,3 +447,20 @@ def test_allow_multiple_inverted():
     # actually depending on the second. In that case, we should
     # subscribe the first target as the endpoint of the processing
     test_allow_multiple(targets=('records', 'peaks',))
+
+
+def test_available_for_run():
+    """Very simply test the available_for_run function"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        mystrax = strax.Context(storage=strax.DataDirectory(temp_dir,
+                                                            deep_scan=True),
+                                register=[Records, Peaks])
+        targets = list(mystrax._plugin_class_registry.keys())
+        for exclude_i in range(len(targets)):
+            for include_i in range(len(targets)):
+                df = mystrax.available_for_run(run_id,
+                                               include_targets = targets[:include_i],
+                                               exclude_targets = targets[:exclude_i])
+                if len(df):
+                    # We haven't made any data
+                    assert not sum(df['is_stored'])


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Imagine, you want to have a detailed report for a single run what is stored and what is not. This is chunky with current strax. Therefore, this PR adds a function that allows you to check what is stored for a single run with some simple regex matching.

**Can you give a minimal working example (or illustrate with a figure)?**
### Example 1
```python
st.available_for_run('012275', 
                     include_targets = ('raw_records', 'peaklets'))
```
 target | is_stored
-- | --
peaklets | True
raw_records | False


### Example 2
```python
st.available_for_run('012275', 
                     include_targets = ('*record*'),
                     exclude_targets = ('*_mv', '*_nv', '*_he'))
```

target | is_stored
-- | --
records | False
raw_records | False
raw_records_aqmon | False


### Example 3


```python
st.available_for_run('012275', include_targets = ('*peak*')
```` 
target | is_stored
 -- | --
peaklet_classification | True
peaklet_classification_he | False
peaklets | True
peaklets_he | False
online_peak_monitor | False
peak_basics | True
peak_proximity | True
peak_positions_cnn | True
peak_positions_mlp | True
peak_positions_gcn | True
peak_basics_he | False

### Example 4
```python
st.available_for_run('012275')
```
target | is_stored
-- | --
corrected_areas | True
energy_estimates | False
event_basics | True
event_posrec_many | True
event_info | True
event_positions | True
events | True
distinct_channels | True
raw_records_coin_nv | False
lone_raw_records_nv | False
lone_raw_record_statistics_nv | False
records_mv | False
records_nv | False
hitlets_mv | False
hitlets_nv | False
event_positions_nv | False
events_nv | False
aqmon_hits | False
veto_intervals | False
records | False
veto_regions | True
pulse_counts | True
records_he | False
pulse_counts_he | False
merged_s2s | True
merged_s2s_he | False
peaklet_classification | True
peaklet_classification_he | False
peaklets | True
lone_hits | True
peaklets_he | False
online_event_monitor | False
online_peak_monitor | False
peak_basics | True
peak_proximity | True
peak_positions_cnn | True
peak_positions_mlp | True
peak_positions_gcn | True
peak_basics_he | False
raw_records | False
raw_records_he | False
raw_records_aqmon | False
raw_records_nv | False
raw_records_aqmon_nv | False
raw_records_aux_mv | False
raw_records_mv | False
led_calibration | False


