### PR TITLE
update apply function to data & test

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -960,6 +960,11 @@ class Context:
                     if not isinstance(result, strax.Chunk):
                         raise ValueError(f"Got type {type(result)} rather than "
                                          f"a strax Chunk from the processor!")
+                    # Apply functions known to contexts if any.
+                    result.data = self._apply_function(result.data,
+                                                       run_id,
+                                                       targets)
+
                     result.data = self.apply_selection(
                         result.data,
                         selection_str=selection_str,
@@ -968,10 +973,6 @@ class Context:
                         time_selection=time_selection)
                     self._update_progress_bar(
                         pbar, t_start, t_end, n_chunks, result.end)
-                    # Apply functions known to contexts if any.
-                    result.data = self._apply_function(result.data,
-                                                       run_id,
-                                                       targets)
                     yield result
             _p.close()
 

--- a/strax/context.py
+++ b/strax/context.py
@@ -79,7 +79,7 @@ RUN_DEFAULTS_KEY = 'strax_defaults'
                       'even when no registered plugin takes them.'),
     strax.Option(name='apply_data_function', default=tuple(),
                  help='Apply a function to the data prior to returning the'
-                      'data. The function should take thee positional arguments: '
+                      'data. The function should take three positional arguments: '
                       'func(<data>, <run_id>, <targets>).')
 )
 @export

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -73,7 +73,7 @@ def test_apply_drop_data():
     class Drop:
         """Small class to keep track of the number of dropped rows"""
 
-        dropped = 0
+        kept = []
 
         def drop(self, data, r, t):
             """Drop a random portion of the data"""
@@ -82,7 +82,7 @@ def test_apply_drop_data():
             keep = np.random.randint(0, 2, len(data)).astype(np.bool_)
 
             # Keep in mind that we do this on a per chunk basis!
-            self.kept = keep
+            self.kept += [keep]
             res = data.copy()[keep]
             return res
 
@@ -91,8 +91,7 @@ def test_apply_drop_data():
     r, r_changed = _apply_function_to_data(dropper.drop)
 
     # The number of records should e
-    assert np.all(r[dropper.kept] == r_changed)
-
+    assert np.all(r[np.concatenate(dropper.kept)] == r_changed)
 
 
 def test_accumulate():

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -32,7 +32,8 @@ def _apply_function_to_data(function
 def test_apply_pass_to_data():
     """
     What happens if we apply a function that does nothing (well,
-        nothing hopefully)
+    nothing hopefully)
+
     :return: None
     """
 
@@ -97,8 +98,9 @@ def test_apply_drop_data():
 def test_accumulate():
     """
     Test the st.accumulate function. Should add the results and
-        accumulate per chunk. Lets add channels and verify the results
-        are correct.
+    accumulate per chunk. Lets add channels and verify the results
+    are correct.
+
     :return: None
     """
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -70,7 +70,8 @@ def test_apply_drop_data():
     """
 
     class Drop:
-        """Small class to keep track of the number of dropped fields"""
+        """Small class to keep track of the number of dropped rows"""
+
         dropped = 0
 
         def drop(self, data, r, t):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -90,7 +90,8 @@ def test_apply_drop_data():
     r, r_changed = _apply_function_to_data(dropper.drop)
 
     # The number of records should e
-    assert (dropper.dropped == len(r) - len(r_changed))
+    assert np.all(r[dropper.kept] == r_changed)
+
 
 
 def test_accumulate():

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,108 @@
+import strax
+from strax.testutils import Records, run_id
+import tempfile
+import numpy as np
+from hypothesis import given
+import hypothesis.strategies as st
+import typing as ty
+
+
+def _apply_function_to_data(function
+                            ) -> ty.Tuple[np.ndarray, np.ndarray]:
+    """
+    Inner core to test apply function to data
+    :param function: some callable function that takes thee positional
+        arguments
+    :return: records, records with function applied
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        st = strax.Context(storage=strax.DataDirectory(temp_dir,
+                                                       deep_scan=True),
+                           register=[Records])
+
+        # First load normal records
+        records = st.get_array(run_id, 'records')
+
+        # Next update the context and apply
+        st.set_context_config({'apply_data_function': function})
+        changed_records = st.get_array(run_id, 'records')
+    return records, changed_records
+
+
+def test_apply_pass_to_data():
+    """
+    What happens if we apply a function that does nothing (well,
+        nothing hopefully)
+    :return: None
+    """
+
+    def nothing(data, r, t):
+        return data
+
+    r, r_changed = _apply_function_to_data(nothing)
+    assert np.all(r == r_changed)
+
+
+@given(st.integers(min_value=-10, max_value=10))
+def test_apply_ch_shift_to_data(magic_shift: int):
+    """
+    Apply some magic shift number to the channel field and check the results
+    :param magic_shift: some number to check that we can shift the
+        channel field with
+    :return: None
+    """
+
+    def shift_channel(data, r, t):
+        """Add a magic number to the channel field in the data"""
+        res = data.copy()
+        res['channel'] += magic_shift
+        return res
+
+    r, r_changed = _apply_function_to_data(shift_channel)
+    assert len(r) == len(r_changed)
+    assert np.all((r_changed['channel'] - (r['channel'] + magic_shift)) == 0)
+
+
+def test_apply_drop_data():
+    """
+    What if we drop random portions of the data, do we get the right results?
+    :return: None
+    """
+
+    class Drop:
+        """Small class to keep track of the number of dropped fields"""
+        dropped = 0
+
+        def drop(self, data, r, t):
+            """Drop a random portion of the data"""
+            # I was too lazy to write a strategy to get the right number
+            # of random drops based on the input records.
+            keep = np.random.randint(0, 2, len(data)).astype(np.bool_)
+
+            # Keep in mind that we do this on a per chunk basis!
+            self.dropped += len(data) - np.sum(keep)
+            res = data.copy()[keep]
+            return res
+
+    # Init the bookkeeping class
+    dropper = Drop()
+    r, r_changed = _apply_function_to_data(dropper.drop)
+
+    # The number of records should e
+    assert (dropper.dropped == len(r) - len(r_changed))
+
+
+def test_accumulate():
+    """
+    Test the st.accumulate function. Should add the results and
+        accumulate per chunk. Lets add channels and verify the results
+        are correct.
+    :return: None
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        st = strax.Context(storage=strax.DataDirectory(temp_dir,
+                                                       deep_scan=True),
+                           register=[Records])
+        channels_from_array = np.sum(st.get_array(run_id, 'records')['channel'])
+        channels = st.accumulate(run_id, 'records', fields='channel')['channel']
+    assert (channels_from_array == channels)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -81,7 +81,7 @@ def test_apply_drop_data():
             keep = np.random.randint(0, 2, len(data)).astype(np.bool_)
 
             # Keep in mind that we do this on a per chunk basis!
-            self.dropped += len(data) - np.sum(keep)
+            self.kept = keep
             res = data.copy()[keep]
             return res
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Move the `apply_data_function` logic from `st.get_array` to `st.get_iter` to avoid any malicious/accidental usage of `st.get_iter` thereby bypassing `apply_data_function`.

Additionally, we fix an issue we had for a while in straxen that this option was incompatible with selection strings:
https://github.com/XENONnT/straxen/blob/5c945e141bee0d5fa976a6e1a78516a0a172305a/straxen/common.py#L491-L493
Therefore, move the application of this function prior to the application of a selection string.

**Can you briefly describe how it works?**
apply_data_function is applied just prior to returning the data to the user.

**Can you give a minimal working example (or illustrate with a figure)?**
See the tests as simple examples of use cases.
