### PR TITLE
Refactor concat and get data

### DIFF
--- a/strax/dtypes.py
+++ b/strax/dtypes.py
@@ -152,20 +152,18 @@ def hitlet_dtype():
     return dtype
 
 
-def hitlet_with_data_dtype(n_samples):
+def hitlet_with_data_dtype(n_samples=2):
     """
     Hitlet dtype with data field. Required within the plugins to compute
     hitlet properties. 
     
     :param n_samples: Buffer length of the data field. Make sure it can
         hold the longest hitlet.
-    :param n_widths: Number of area deciles width.
-
-    Note:
-        The data buffer will be at least 2 samples long
     """
+    if n_samples < 2:
+        raise ValueError('n_samples must be at least 2!')
+
     dtype = hitlet_dtype()
-    n_samples = max(n_samples, 2)
     additional_fields = [(('Hitlet data in PE/sample with ZLE (only the first length samples are filled)', 'data'),
                            np.float32, n_samples),
                          ]

--- a/strax/dtypes.py
+++ b/strax/dtypes.py
@@ -168,8 +168,6 @@ def hitlet_with_data_dtype(n_samples):
     n_samples = max(n_samples, 2)
     additional_fields = [(('Hitlet data in PE/sample with ZLE (only the first length samples are filled)', 'data'),
                            np.float32, n_samples),
-                         (('Fragment number in the pulse',
-                           'record_i'), np.int32),
                          ]
 
     return dtype + additional_fields

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -149,12 +149,19 @@ def get_hitlets_data(hitlets, records, to_pe):
     :param hitlets: Hitlets found in a chunk of records.
     :param records: Records of the chunk.
     :param to_pe: Array with area conversion factors from adc/sample to
-        pe/sample.
-    :param channel_offset: Channel offset of the nveto with respect to
-        zero. Required to query the correct gain values.
+        pe/sample. Please make sure that to_pe has the correct shape.
+        The array index should match the channel number.
     :returns: Hitlets including data stored in the "data" field
         (if it did not exists before it will be added.)
     """
+    # Numba will not raise any exceptions if to_pe is too short, leading
+    # to strange bugs. This check is somewhat not complete, but should
+    # be sufficient in most cases.
+    to_pe_has_wrong_shape = len(to_pe) < hitlets['channel'].max()
+    if to_pe_has_wrong_shape:
+        raise ValueError('"to_pe" has a wrong shape. Array index must'
+                         ' match channel numbers.')
+
     hitelts_is_single_row = isinstance(hitlets, np.void)
     if hitelts_is_single_row:
         # A structured array becomes void type if a single row is called,

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -136,7 +136,7 @@ def refresh_hit_to_hitlets(hits, hitlets):
 
 
 @export
-def get_hitlets_data(hitlets, records, to_pe):
+def get_hitlets_data(hitlets, records, to_pe, min_hitlet_sample=100):
     """
     Function which searches for every hitlet in a given chunk the 
     corresponding records data. Additionally compute the total area of
@@ -147,6 +147,8 @@ def get_hitlets_data(hitlets, records, to_pe):
     :param to_pe: Array with area conversion factors from adc/sample to
         pe/sample. Please make sure that to_pe has the correct shape.
         The array index should match the channel number.
+    :param min_hitlet_sample: minimal length of the hitlet data field.
+        prevents numba compiling from running into race conditions.
     :returns: Hitlets including data stored in the "data" field
         (if it did not exists before it will be added.)
     """
@@ -176,7 +178,7 @@ def get_hitlets_data(hitlets, records, to_pe):
 
         hitlets_with_data_field = hitlets
     else:
-        n_samples = max(100, hitlets['length'].max())
+        n_samples = max(min_hitlet_sample, hitlets['length'].max())
         hitlets_with_data_field = np.zeros(len(hitlets), strax.hitlet_with_data_dtype(n_samples))
         strax.copy_to_buffer(hitlets,
                              hitlets_with_data_field,

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -505,6 +505,7 @@ def highest_density_region_width(data,
     
     if np.all(data == 0):
         res[:] = np.nan
+        return res
     else:
         inter, amps = strax.highest_density_region(data,
                                                    fractions_desired, _buffer_size=_buffer_size)

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -136,7 +136,6 @@ def refresh_hit_to_hitlets(hits, hitlets):
         h_new['length'] = h_old['length']
         h_new['channel'] = h_old['channel']
         h_new['area'] = h_old['area']
-        h_new['record_i'] = h_old['record_i']
         h_new['dt'] = h_old['dt']
 
 

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -242,7 +242,7 @@ def hitlet_properties(hitlets):
     for ind, h in enumerate(hitlets):
         dt = h['dt']
         data = h['data'][:h['length']]
-        
+
         if not np.any(data):
             continue
 
@@ -502,7 +502,12 @@ def highest_density_region_width(data,
     """
     res = np.zeros((len(fractions_desired), 2), dtype=np.float32)
     data = np.maximum(data, 0)
-    inter, amps = strax.highest_density_region(data, fractions_desired, _buffer_size=_buffer_size)
+    
+    if np.all(data == 0):
+        res[:] = np.nan
+    else:
+        inter, amps = strax.highest_density_region(data,
+                                                   fractions_desired, _buffer_size=_buffer_size)
 
     for f_ind, (i, a) in enumerate(zip(inter, amps)):
         if not fractionl_edges:

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -194,6 +194,7 @@ def _get_hitlets_data(hitlets, records, to_pe, channel_offset):
     for i, h in enumerate(hitlets):
         recorded_samples_offset = 0
         n_recorded_samples = 0
+        is_first_record = True
         for ind, r_ind in enumerate(range(rranges[i][0], rranges[i][1])):
             r = records[r_ind]
             if r['channel'] != h['channel']:
@@ -205,8 +206,8 @@ def _get_hitlets_data(hitlets, records, to_pe, channel_offset):
                 h['time'] // h['dt'],
                 h['length'])
 
-            is_first_record = ind == 0
             if is_first_record:
+                is_first_record = False
                 recorded_samples_offset = h_start
             h_start -= recorded_samples_offset
             h_end -= recorded_samples_offset

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -140,7 +140,7 @@ def refresh_hit_to_hitlets(hits, hitlets):
 
 
 @export
-def get_hitlets_data(hitlets, records, to_pe, channel_offset=2000):
+def get_hitlets_data(hitlets, records, to_pe):
     """
     Function which searches for every hitlet in a given chunk the 
     corresponding records data. Additionally compute the total area of
@@ -180,12 +180,12 @@ def get_hitlets_data(hitlets, records, to_pe, channel_offset=2000):
                              hitlets_with_data_field,
                              '_copy_hitlets_to_hitlets_width_data')
 
-    _get_hitlets_data(hitlets_with_data_field, records, to_pe, channel_offset)
+    _get_hitlets_data(hitlets_with_data_field, records, to_pe)
     return hitlets_with_data_field
 
 
 @numba.jit(nopython=True, nogil=True, cache=True)
-def _get_hitlets_data(hitlets, records, to_pe, channel_offset):
+def _get_hitlets_data(hitlets, records, to_pe):
     rranges = _touching_windows(records['time'],
                                 strax.endtime(records),
                                 hitlets['time'],
@@ -219,7 +219,7 @@ def _get_hitlets_data(hitlets, records, to_pe, channel_offset):
         h['time'] += int(recorded_samples_offset * h['dt'])
         h['length'] = n_recorded_samples
 
-        h['data'][:] = h['data'][:] * to_pe[h['channel']-channel_offset]
+        h['data'][:] = h['data'][:] * to_pe[h['channel']]
         h['area'] = np.sum(h['data'])
 
 # ----------------------

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -317,7 +317,7 @@ def get_fwxm(hitlet, fraction=0.5):
 
     index_maximum = np.argmax(data)
     max_val = data[index_maximum] * fraction
-    if np.all(data > max_val) or np.all(data == 0):
+    if np.all(data > max_val) or np.all(data <= 0):
         # In case all samples are larger, FWXM is not definition.
         return np.nan, np.nan
 

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -44,8 +44,6 @@ class PeakSplitter:
     :param data_type: 'peaks' or 'hitlets'. Specifies whether to use
         sum_waveform or get_hitlets_data to compute the waveform of the
         new split peaks/hitlets.
-    :param next_ri: Index of next record for current record record_i.
-        None if not needed.
     :param do_iterations: maximum number of times peaks are recursively split.
     :param min_area: Minimum area to do split. Smaller peaks are not split.
 

--- a/tests/test_hitlet.py
+++ b/tests/test_hitlet.py
@@ -288,7 +288,7 @@ def test_hitlet_properties(hits_n_data):
     nsamples = 0
     if len(hits) >= 1:
         nsamples = hits['length'].max()
-    nsamples = np.max(nsamples, 2)
+    nsamples = np.max((nsamples, 2))
 
     hitlets = np.zeros(len(hits), dtype=strax.hitlet_with_data_dtype(nsamples))
     if len(hitlets):

--- a/tests/test_hitlet.py
+++ b/tests/test_hitlet.py
@@ -141,7 +141,7 @@ class TestGetHitletData(unittest.TestCase):
                          ]
 
         records, hitlets = self.make_records_and_hitlets(dummy_records)
-        strax.get_hitlets_data(hitlets, records, np.array([1, 1]))
+        strax.get_hitlets_data(hitlets, records, np.array([1, 1]), channel_offset=0)
 
         for i, (a, wf, t) in enumerate(zip(true_area, true_waveform, true_time)):
             h = hitlets[i]

--- a/tests/test_hitlet.py
+++ b/tests/test_hitlet.py
@@ -285,10 +285,10 @@ def test_hitlet_properties(hits_n_data):
 
     hits['time'] += 100
     # Step 1.: Produce fake hits and convert them into hitlets:
+    nsamples = 0
     if len(hits) >= 1:
         nsamples = hits['length'].max()
-    else:
-        nsamples = 2
+    nsamples = np.max(nsamples, 2)
 
     hitlets = np.zeros(len(hits), dtype=strax.hitlet_with_data_dtype(nsamples))
     if len(hitlets):

--- a/tests/test_hitlet.py
+++ b/tests/test_hitlet.py
@@ -366,22 +366,25 @@ def test_hitlet_properties(hits_n_data):
                 assert math.isclose(re - le, h[fwxm], rel_tol=10**-4,
                                     abs_tol=10**-4), f'FWHM does not match for {f}'
 
-    def test_not_defined_get_fhwm():
-        # This is a specific unity test for some edge-cases in which the full
-        # width half maximum is not defined.
-        odd_hitlets = np.zeros(3, dtype=strax.hitlet_with_data_dtype(10))
-        odd_hitlets[0]['data'][:5] = [2, 2, 3, 2, 2]
-        odd_hitlets[0]['length'] = 5
-        odd_hitlets[1]['data'][:2] = [5, 5]
-        odd_hitlets[1]['length'] = 2
-        odd_hitlets[2]['length'] = 3
 
-        for oh in odd_hitlets:
-            res = strax.get_fwxm(oh)
-            mes = (f'get_fxhm returned {res} for {oh["data"][:oh["length"]]}!'
-                   'However, the FWHM is not defined and the return should be nan!'
-                   )
-            assert np.all(np.isnan(res)), mes
+def test_not_defined_get_fhwm():
+    # This is a specific unity test for some edge-cases in which the full
+    # width half maximum is not defined.
+    odd_hitlets = np.zeros(4, dtype=strax.hitlet_with_data_dtype(10))
+    odd_hitlets[0]['data'][:5] = [2, 2, 3, 2, 2]
+    odd_hitlets[0]['length'] = 5
+    odd_hitlets[1]['data'][:2] = [5, 5]
+    odd_hitlets[1]['length'] = 2
+    odd_hitlets[2]['length'] = 3
+    odd_hitlets[3]['data'][:3] = [-1, -2, 0]
+    odd_hitlets[3]['length'] = 3
+
+    for oh in odd_hitlets:
+        res = strax.get_fwxm(oh)
+        mes = (f'get_fxhm returned {res} for {oh["data"][:oh["length"]]}!'
+               'However, the FWHM is not defined and the return should be nan!'
+               )
+        assert np.all(np.isnan(res)), mes
 
 
 # ------------------------

--- a/tests/test_hitlet.py
+++ b/tests/test_hitlet.py
@@ -88,6 +88,11 @@ class TestGetHitletData(unittest.TestCase):
         strax.refresh_hit_to_hitlets(hits, hitlets)
         return records, hitlets
 
+    def test_to_pe_wrong_shape(self):
+        records, hitlets = self.make_records_and_hitlets([[self.test_data]])
+        hitlets['channel'] = 2000
+        self.assertRaises(ValueError, strax.get_hitlets_data, hitlets, records, np.ones(10))
+
     def test_get_hitlets_data_for_single_hitlet(self):
         records, hitlets = self.make_records_and_hitlets([[self.test_data]])
 
@@ -141,7 +146,7 @@ class TestGetHitletData(unittest.TestCase):
                          ]
 
         records, hitlets = self.make_records_and_hitlets(dummy_records)
-        strax.get_hitlets_data(hitlets, records, np.array([1, 1]), channel_offset=0)
+        strax.get_hitlets_data(hitlets, records, np.array([1, 1]))
 
         for i, (a, wf, t) in enumerate(zip(true_area, true_waveform, true_time)):
             h = hitlets[i]

--- a/tests/test_hitlet.py
+++ b/tests/test_hitlet.py
@@ -254,6 +254,12 @@ def test_highest_density_region_width():
     truth_dict = {0.5: [[0, 1]], 0.8: [-0.3, 1.3]}
     _test_highest_density_region_width(np.array([1, 0]), truth_dict)
 
+    # Check that negative data does not raise:
+    res = strax.processing.hitlets.highest_density_region_width(np.array([0, -1, -2]),
+                                                          np.array([0.5]),
+                                                          fractionl_edges=True)
+    assert np.all(np.isnan(res)), 'For empty data HDR is not defined, should return np.nan!'
+
 
 def _test_highest_density_region_width(distribution, truth_dict):
     res = strax.processing.hitlets.highest_density_region_width(distribution,

--- a/tests/test_peak_splitting.py
+++ b/tests/test_peak_splitting.py
@@ -121,3 +121,32 @@ def _test_splitter_inner(min_heights,
         assert len(my_splits) <= int(len(waveform) / 2) + 1
         assert min(my_splits[:, 0]) == NO_MORE_SPLITS
         assert my_splits[-1, 0] == NO_MORE_SPLITS
+
+
+def test_splitter_outer():
+    data = [0, 2, 2, 0, 2, 2, 1]
+    records = np.zeros(1, dtype=strax.record_dtype(len(data)))
+    records['dt'] = 1
+    records['data'] = data
+    records['length'] = len(data)
+    records['pulse_length'] = len(data)
+    to_pe = np.ones(10)
+
+    peaks = np.zeros(1, dtype=strax.peak_dtype())
+    hitlets = np.zeros(1, dtype=strax.hitlet_with_data_dtype(10))
+    for data_type in (peaks, hitlets):
+        data_type['dt'] = 1
+        data_type['data'][0, :len(data)] = data
+        data_type['length'] = len(data)
+
+    peaks = strax.split_peaks(peaks, records,  to_pe, algorithm='local_minimum',
+                              data_type='peaks', min_height=1, min_ratio=0)
+
+    hitlets = strax.split_peaks(hitlets, records, to_pe, algorithm='local_minimum',
+                                data_type='hitlets', min_height=1, min_ratio=0)
+
+    for name, data_type in zip(('peaks', 'hitlets'), (peaks, hitlets)):
+        data = data_type[0]['data'][:data_type[0]['length']]
+        assert np.all(data == [0, 2, 2]), f'Wrong split for {name}, got {data}, expected {[0, 2, 2]}.'
+        data = data_type[1]['data'][:data_type[1]['length']]
+        assert np.all(data == [0, 2, 2, 1]), f'Wrong split for {name}, got {data}, expected {[0, 2, 2, 1]}.'


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
In this PR Tianyu and I (mostly Tianyu) refactored the get_hitlet_data function. Tianyus proposal makes the function much more flexible as we search no longer for the hitlet data via the `record_i` field but using time intervals instead. This change allows a much more general usage of the function. For this reason I added a "header" part which checks for different possibilities in calling this function. The corresponding tests have been added too.

Beside get_hitlet_data I refactored a bit concat_overlaping_hits as it was also part of the proposal. However, I did not manage to modify the function such, that it mimics the full behavior of the old method. But since the new method would lead to a performance drop of about 30% I decided to keep the old one. 

A more thorough discussion can be found in this [note](https://github.com/XENONnT/analysiscode/blob/master/nveto/RefactorGetHitletData.ipynb).

Open points:
- [x] Updated plugins, set correct channel offset for mv and nv.
- [x] Updated hitlet splitting
- [x] Add some test for hitlet splitting.
- [x] Test process some data