### PR TITLE
fix empty hitlets

### DIFF
--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -25,11 +25,11 @@ def concat_overlapping_hits(hits, extensions, pmt_channels, start, end):
     :param hits: Hits in records.
     :param extensions: Tuple of the left and right hit extension.
     :param pmt_channels: Tuple of the detectors first and last PMT
-    :param start: Startime of the chunk
+    :param start: Start time of the chunk
     :param end: Endtime of the chunk
 
     :returns:
-        array with concataneted hits.
+        array with concatenated hits.
     """
     first_channel, last_channel = pmt_channels
     nchannels = last_channel - first_channel + 1
@@ -152,6 +152,9 @@ def get_hitlets_data(hitlets, records, to_pe, min_hitlet_sample=100):
     :returns: Hitlets including data stored in the "data" field
         (if it did not exists before it will be added.)
     """
+    if not len(hitlets):
+        return hitlets
+
     # Numba will not raise any exceptions if to_pe is too short, leading
     # to strange bugs.
     to_pe_has_wrong_shape = len(to_pe) < hitlets['channel'].max()
@@ -373,6 +376,7 @@ def _get_fwxm_boundary(data, max_val):
             s = d
             return ind, s
     return len(data)-1, data[-1]
+
 
 @export
 def conditional_entropy(hitlets, template='flat', square_data=False):

--- a/tests/test_hitlet.py
+++ b/tests/test_hitlet.py
@@ -95,13 +95,11 @@ class TestGetHitletData(unittest.TestCase):
 
     def test_get_hitlets_data_for_single_hitlet(self):
         records, hitlets = self.make_records_and_hitlets([[self.test_data]])
-
         hitlets = strax.get_hitlets_data(hitlets[0], records, np.ones(3000))
         self._test_data_is_identical(hitlets, [self.test_data_truth])
 
     def test_data_field_is_empty(self):
         records, hitlets = self.make_records_and_hitlets([[self.test_data]])
-
         hitlets = strax.get_hitlets_data(hitlets, records, np.ones(3000))
         self.assertRaises(ValueError, strax.get_hitlets_data, hitlets, records, np.ones(3000))
         self._test_data_is_identical(hitlets, [self.test_data_truth])
@@ -110,13 +108,17 @@ class TestGetHitletData(unittest.TestCase):
         records, hitlets_with_data = self.make_records_and_hitlets([[self.test_data]])
         hitlets = np.zeros(len(hitlets_with_data), strax.hitlet_dtype())
         strax.copy_to_buffer(hitlets_with_data, hitlets, '_copy_hitlets_to_hitlets_without_data')
-
         hitlets = strax.get_hitlets_data(hitlets, records, np.ones(3000))
         self._test_data_is_identical(hitlets, [self.test_data_truth])
 
     def test_to_short_data_field(self):
         records, hitlets = self.make_records_and_hitlets([[self.test_data]], 2)
         self.assertRaises(ValueError, strax.get_hitlets_data, hitlets, records, np.ones(3000))
+
+    def test_no_hitlet(self):
+        records, _ = self.make_records_and_hitlets([[self.test_data]], 2)
+        hitlets = np.empty(0, strax.hitlet_with_data_dtype(n_samples=2))
+        strax.get_hitlets_data(hitlets, hitlets, records, np.array([1, 1]))
 
     def test_get_hitlets_data(self):
         dummy_records = [  # Contains Hitlet #:


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Due to https://github.com/AxFoundation/strax/pull/430, straxen master is failing:
https://github.com/XENONnT/straxen/runs/2482801332

We did not consider empty hitlets

**Can you briefly describe how it works?**
Return the empty hitlets-dtype if none was given

**Can you give a minimal working example (or illustrate with a figure)?**
See the example in the updated test
