### PR TITLE
Refactor hitlets

### DIFF
--- a/strax/dtypes.py
+++ b/strax/dtypes.py
@@ -166,6 +166,10 @@ def hitlet_with_data_dtype(n_samples=2):
     dtype = hitlet_dtype()
     additional_fields = [(('Hitlet data in PE/sample with ZLE (only the first length samples are filled)', 'data'),
                            np.float32, n_samples),
+                         (('Dummy field required for splitting',
+                           'max_gap'), np.int32),
+                         (('Maximum interior goodness of split',
+                           'max_goodness_of_split'), np.float32),
                          ]
 
     return dtype + additional_fields

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -165,7 +165,7 @@ def get_hitlets_data(hitlets, records, to_pe, min_hitlet_sample=100):
         (if it did not exists before it will be added.)
     """
     if len(hitlets) == 0:
-        return hitlets
+        return np.zeros(0, dtype=strax.hitlet_with_data_dtype(2))
 
     if len(hitlets) > 0 and len(records) == 0:
         raise ValueError('Cannot get for hitlets if records are empty!')

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -21,10 +21,13 @@ def create_hitlets_from_hits(hits,
 
     :param hits: Hits found in records.
     :param save_outside_hits: Tuple with left and right hit extension.
-    :param channel_range: Detectors change range from channelmap.
-    :param chunk_start: Start of the chunk or run.
-    :param chunk_end: End of the chunk or run.
-    :param min_samples_data_field: Minimal length of the hitlet data field.
+    :param channel_range: Detectors change range from channel map.
+    :param chunk_start: Start of either a chunk. Ensures that
+        no hitlet is extended beyond chunk boundaries. You can keep the
+        defaults if not used inside of a plugin.
+    :param chunk_end: End of a chunk Ensures that no hitlet is extended
+        beyond chunk boundaries. You can keep the  defaults if not used
+        inside of a plugin.
 
     :return: Hitlets with temporary fields (data, max_goodness_of_split...)
     """

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -148,7 +148,7 @@ def _concat_overlapping_hits(hits,
 
 
 @export
-def get_hitlets_data(hitlets, records, to_pe, min_hitlet_sample=100):
+def get_hitlets_data(hitlets, records, to_pe, min_hitlet_sample=200):
     """
     Function which searches for every hitlet in a given chunk the 
     corresponding records data. Additionally compute the total area of
@@ -165,7 +165,7 @@ def get_hitlets_data(hitlets, records, to_pe, min_hitlet_sample=100):
         (if it did not exists before it will be added.)
     """
     if len(hitlets) == 0:
-        return np.zeros(0, dtype=strax.hitlet_with_data_dtype(2))
+        return np.zeros(0, dtype=strax.hitlet_with_data_dtype(min_hitlet_sample))
 
     if len(hitlets) > 0 and len(records) == 0:
         raise ValueError('Cannot get data for hitlets if records are empty!')

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -22,12 +22,10 @@ def create_hitlets_from_hits(hits,
     :param hits: Hits found in records.
     :param save_outside_hits: Tuple with left and right hit extension.
     :param channel_range: Detectors change range from channel map.
-    :param chunk_start: Start of either a chunk. Ensures that
-        no hitlet is extended beyond chunk boundaries. You can keep the
-        defaults if not used inside of a plugin.
-    :param chunk_end: End of a chunk Ensures that no hitlet is extended
-        beyond chunk boundaries. You can keep the  defaults if not used
-        inside of a plugin.
+    :param chunk_start: (optional) start time of a chunk. Ensures that
+        no hitlet is earlier than this timestamp.
+    :param chunk_end: (optional) end time of a chunk. Ensures that
+        no hitlet ends later than this timestamp.
 
     :return: Hitlets with temporary fields (data, max_goodness_of_split...)
     """

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -168,7 +168,7 @@ def get_hitlets_data(hitlets, records, to_pe, min_hitlet_sample=100):
         return np.zeros(0, dtype=strax.hitlet_with_data_dtype(2))
 
     if len(hitlets) > 0 and len(records) == 0:
-        raise ValueError('Cannot get for hitlets if records are empty!')
+        raise ValueError('Cannot get data for hitlets if records are empty!')
 
     # Numba will not raise any exceptions if to_pe is too short, leading
     # to strange bugs.

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -164,6 +164,12 @@ def get_hitlets_data(hitlets, records, to_pe, min_hitlet_sample=100):
     :returns: Hitlets including data stored in the "data" field
         (if it did not exists before it will be added.)
     """
+    if len(hitlets) == 0:
+        return hitlets
+
+    if len(hitlets) > 0 and len(records) == 0:
+        raise ValueError('Cannot get for hitlets if records are empty!')
+
     # Numba will not raise any exceptions if to_pe is too short, leading
     # to strange bugs.
     to_pe_has_wrong_shape = len(to_pe) < hitlets['channel'].max()

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -16,8 +16,7 @@ def create_hitlets_from_hits(hits,
                              save_outside_hits,
                              channel_range,
                              chunk_start=0,
-                             chunk_end=np.inf,
-                             min_samples_data_field=100, ):
+                             chunk_end=np.inf,):
     """
     Function which creates hitlets from a bunch of hits.
 
@@ -40,14 +39,9 @@ def create_hitlets_from_hits(hits,
                                          chunk_end, )
     hits = strax.sort_by_time(hits)
 
-    # Now convert hits into temp_hitlets including the data field:
-    nsamples = min_samples_data_field
-    if len(hits):
-        nsamples = max(hits['length'].max(), nsamples)
-
-    temp_hitlets = np.zeros(len(hits), strax.hitlet_dtype())
-    strax.copy_to_buffer(hits, temp_hitlets, '_refresh_hit_to_hitlets')
-    return temp_hitlets
+    hitlets = np.zeros(len(hits), strax.hitlet_dtype())
+    strax.copy_to_buffer(hits, hitlets, '_refresh_hit_to_hitlets')
+    return hitlets
 
 
 @export

--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -7,12 +7,9 @@ from strax.processing.general import _touching_windows
 export, __all__ = strax.exporter()
 
 # Hardcoded numbers:
-TRIAL_COUNTER_NEIGHBORING_RECORDS = 100  # Trial counter when looking for hitlet data.
 NO_FWXM = -42  # Value in case FWXM cannot be found.
 
-# ----------------------
-# Hitlet building:
-# ----------------------
+
 @export
 def create_hitlets_from_hits(hits,
                              save_outside_hits,

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -117,9 +117,6 @@ class PeakSplitter:
         """Loop over peaks, pass waveforms to algorithm, construct
         new peaks if and where a split occurs.
         """
-        # NB: code very similar to _split_hitlets see
-        # github.com/AxFoundation/strax/pull/309 for more info. Keep in mind
-        # that changing one function should also be reflected in the other.
         new_peaks = _result_buffer
         offset = 0
 

--- a/tests/test_hitlet.py
+++ b/tests/test_hitlet.py
@@ -157,7 +157,7 @@ class TestGetHitletData(unittest.TestCase):
                          ]
 
         records, hitlets = self.make_records_and_hitlets(dummy_records)
-        hitlets = strax.get_hitlets_data(hitlets, records, np.ones([1, 1]))
+        hitlets = strax.get_hitlets_data(hitlets, records, np.ones(2))
 
         for i, (a, wf, t) in enumerate(zip(true_area, true_waveform, true_time)):
             h = hitlets[i]

--- a/tests/test_hitlet.py
+++ b/tests/test_hitlet.py
@@ -83,6 +83,20 @@ class TestGetHitletData(unittest.TestCase):
         hitlets = strax.create_hitlets_from_hits(hits, (1, 1), (0, 1), 0, float('inf'))
         return records, hitlets
 
+    def test_inputs_are_empty(self):
+        records, hitlets = self.make_records_and_hitlets([[self.test_data]])
+        hitlets_empty = np.zeros(0, dtype=strax.hitlet_with_data_dtype(2))
+        records_empty = np.zeros(0, dtype=strax.record_dtype(10))
+
+        hitlets_result = strax.get_hitlets_data(hitlets_empty, records, np.ones(3000))
+        assert len(hitlets_result) == 0, 'get_hitlet_data returned result for empty hitlets'
+
+        hitlets_result = strax.get_hitlets_data(hitlets_empty, records_empty, np.ones(3000))
+        assert len(hitlets_result) == 0, 'get_hitlet_data returned result for empty hitlets'
+
+        self.assertRaises(ValueError, strax.get_hitlets_data, hitlets, records_empty, np.ones(3000))
+
+
     def test_to_pe_wrong_shape(self):
         records, hitlets = self.make_records_and_hitlets([[self.test_data]])
         hitlets['channel'] = 2000

--- a/tests/test_hitlet.py
+++ b/tests/test_hitlet.py
@@ -9,9 +9,6 @@ import unittest
 from strax.testutils import fake_hits
 
 
-# -----------------------
-# Concatenated overlapping hits:
-# -----------------------
 @given(fake_hits,
        fake_hits,
        st.integers(min_value=0, max_value=10),
@@ -68,11 +65,12 @@ def test_concat_overlapping_hits(hits0, hits1, le, re):
                 assert np.all(mask < 0), f'Found two hits within {ch} which are touching or overlapping'
 
 
-# -----------------------------
-# Test for get_hitlets_data.
-# This test is done with some predefined
-# records.
-# -----------------------------
+def test_create_hits_from_hitlets_empty_hits():
+    hits = np.zeros(0, dtype=strax.hit_dtype)
+    hitlets = strax.create_hitlets_from_hits(hits, (1, 1), (0, 1))
+    assert len(hitlets) == 0, 'Hitlets should be empty'
+
+
 class TestGetHitletData(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
With this PR we refactor the hitlet data_type a bit. 

1. get_hitlet_data also supports now empty inputs. A corresponding test was added.
2. The the hitlet dtype with data field was extended by goodness of split and max gap. This allows to share the _split_peaks function of our PeakSplitter class. Hence we can remove some redundant code. 
3. I refactored straxen's hitlet plugin by adding a new function called `create_hitlets_from_hits`. This gives the plugin a bit more structure and generalizes hitlets such that it can also be used more easily for other analyses. Further, this allowed to remove the `refresh_hit_to_hitlets`.

This PR goes together with [#463](https://github.com/XENONnT/straxen/pull/463/files).