### PR TITLE
Change non thread safe iteration

### DIFF
--- a/strax/processor.py
+++ b/strax/processor.py
@@ -213,7 +213,7 @@ class ThreadedMailboxProcessor:
         final_generator = self.mailboxes[target].subscribe()
 
         self.log.debug("Starting threads")
-        for m in self.mailboxes.values():
+        for m in list(self.mailboxes.values()):
             m.start()
 
         self.log.debug(f"Yielding {target}")


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
During testing of the mc_chain we ran into an error. When starting up the mailboxes we iterate over a list of mailboxes. However during the iteration this dict changes, leading to a crash. Because you're not allowed to change something you're iterating over. 
This results in the following error:
`  File "/opt/XENONnT/anaconda/envs/XENONnT_development/lib/python3.8/site-packages/strax/processor.py", line 216, in iter
    for m in self.mailboxes.values():
RuntimeError: dictionary changed size during iteration`

The problem is this way of iterating is aparantly bad and not tread safe. After some googling this came up as a solution: https://stackoverflow.com/questions/45276407/dictionary-changed-size-during-iteration-in-multithreading-app (oke it was the very first thing to show up)

So by making a copy of this list we solve our issue

There is a big however though: maybe this actually just sweeps something under the carpet