### PR TITLE
Update run_selection.py

### DIFF
--- a/strax/run_selection.py
+++ b/strax/run_selection.py
@@ -167,7 +167,7 @@ def scan_runs(self: strax.Context,
 def select_runs(self, run_mode=None, run_id=None,
                 include_tags=None, exclude_tags=None,
                 available=tuple(),
-                pattern_type='fnmatch', ignore_underscore=True):
+                pattern_type='fnmatch', ignore_underscore=False):
     """Return pandas.DataFrame with basic info from runs
     that match selection criteria.
     :param run_mode: Pattern to match run modes (reader.ini.name)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
It feels a bit odd that official tags are excluded by default from the run_selection search. In this PR we change the setting