### PR TITLE
Match cached buffer chunk start times OverlapWindowPlugin

### DIFF
--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -637,8 +637,8 @@ class OverlapWindowPlugin(Plugin):
                 _, self.cached_input[k] = v.split(t=prev_split,
                                                   allow_early_split=True)
                 prev_split = self.cached_input[k].start
-            n_start_times = len(set([c.start for c in self.cached_input.values()]))
-            if n_start_times == 1:
+            chunk_starts_are_equal = len(set([chunk.start for chunk in self.cached_input.values()])) == 1
+            if chunk_starts_are_equal :
                 self.log.debug(
                     f'Success after {counter}. '
                     f'Extra time = {cache_inputs_beyond-prev_split} ns')

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -591,10 +591,10 @@ class OverlapWindowPlugin(Plugin):
             raise RuntimeError("OverlapWindowPlugin must have a dependency")
 
         # Add cached inputs to compute arguments
-        for k, v in kwargs.items():
+        for data_kind, chunk in kwargs.items():
             if len(self.cached_input):
-                kwargs[k] = strax.Chunk.concatenate(
-                    [self.cached_input[k], v])
+                kwargs[data_kind] = strax.Chunk.concatenate(
+                    [self.cached_input[data_kind], chunk])
 
         # Compute new results
         result = super().do_compute(chunk_i=chunk_i, **kwargs)
@@ -604,7 +604,7 @@ class OverlapWindowPlugin(Plugin):
                                  allow_early_split=False)
 
         # When does this batch of inputs end?
-        ends = [v.end for v in kwargs.values()]
+        ends = [c.end for c in kwargs.values()]
         if not len(set(ends)) == 1:
             raise RuntimeError(
                 f"OverlapWindowPlugin got incongruent inputs: {kwargs}")
@@ -632,21 +632,24 @@ class OverlapWindowPlugin(Plugin):
         # prevent issues in input buffers later on
         prev_split = cache_inputs_beyond
         max_trials = 10
-        for counter in range(max_trials):
-            for k, v in kwargs.items():
-                _, self.cached_input[k] = v.split(t=prev_split,
-                                                  allow_early_split=True)
-                prev_split = self.cached_input[k].start
-            chunk_starts_are_equal = len(set([chunk.start for chunk in self.cached_input.values()])) == 1
-            if chunk_starts_are_equal :
+        for try_counter in range(max_trials):
+            for data_kind, chunk in kwargs.items():
+                _, self.cached_input[data_kind] = chunk.split(
+                    t=prev_split,
+                    allow_early_split=True)
+                prev_split = self.cached_input[data_kind].start
+
+            unique_starts = set([c.start for c in self.cached_input.values()])
+            chunk_starts_are_equal = len(unique_starts) == 1
+            if chunk_starts_are_equal:
                 self.log.debug(
-                    f'Success after {counter}. '
+                    f'Success after {try_counter}. '
                     f'Extra time = {cache_inputs_beyond-prev_split} ns')
                 break
             else:
                 self.log.debug(
                     f'Inconsistent start times of the cashed chunks after'
-                    f' {counter}/{max_trials} passes.\nChunks {self.cached_input}')
+                    f' {try_counter}/{max_trials} passes.\nChunks {self.cached_input}')
         else:
             raise ValueError(f'Buffer start time inconsistency cannot be '
                              f'resolved after {max_trials} tries')


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
In the overlap window plugin, we are strict for the end-time of the cached chunks. However, we are not so strict about our start times in the cached_input. This PR addresses this.

**Can you briefly describe how it works?**
Since we use `v.split(t=prev_split, allow_early_split=True)`, we can get chunks split on different times (the allow_early_split is True). This causes issues when one from chunk>0 tries to add the cached input into the `super().do_compute`. We don't want to `allow_early_split=False` since that raises an error to deal with. Instead, we can use the split point (i.e. start time) from the other chunk(s) to split on since allow_early_split=True. This will only increase the bit of information that is being send to the compute argument since we allow data from slightly more time to be added to the compute argument of the plugin.

This should all be safeguarded (that we don't store data twice) by `self.sent_until` (otherwise we could have never done `cache_inputs_beyond = int(self.sent_until- 2 * self.get_window_size() - 1)`)


This PR is needed in order to be able to run this straxen PR:https://github.com/XENONnT/straxen/pull/296