### PR TITLE
Prevent late creation of unattended mailboxes

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -612,7 +612,7 @@ class Context:
         # have to do computation. (their instances will stick around
         # though the .deps attribute of plugins that do)
         loaders = dict()
-        savers = collections.defaultdict(list)
+        savers = dict()
         seen = set()
         to_compute = dict()
 
@@ -736,7 +736,7 @@ class Context:
 
             # Save the target and any other outputs of the plugin.
             for d_to_save in set([d] + list(p.provides)):
-                if d_to_save in savers and len(savers[d_to_save]):
+                if savers.get(d_to_save):
                     # This multi-output plugin was scanned before
                     # let's not create doubled savers
                     assert p.multi_output
@@ -762,13 +762,15 @@ class Context:
                             pass
                     # If we get here, we must try to save
                     try:
-                        savers[d_to_save].append(sf.saver(
+                        saver = sf.saver(
                             key,
                             metadata=p.metadata(
                                 run_id,
                                 d_to_save),
-                            saver_timeout=self.context_config['saver_timeout']
-                        ))
+                            saver_timeout=self.context_config['saver_timeout'])
+                        # Now that we are surely saving, make an entry in savers
+                        savers.setdefault(d_to_save, [])
+                        savers[d_to_save].append(saver)
                     except strax.DataNotAvailable:
                         # This frontend cannot save. Too bad.
                         pass

--- a/strax/context.py
+++ b/strax/context.py
@@ -799,7 +799,7 @@ class Context:
         return strax.ProcessorComponents(
             plugins=plugins,
             loaders=loaders,
-            savers=dict(savers),
+            savers=savers,
             targets=strax.to_str_tuple(final_plugin))
 
     def estimate_run_start_and_end(self, run_id, targets=None):

--- a/strax/processor.py
+++ b/strax/processor.py
@@ -104,7 +104,10 @@ class ThreadedMailboxProcessor:
         #  - we should discard (produced but neither required not saved)
         produced = set(components.loaders)
         required = set(components.targets)
-        saved = set(components.savers.keys())
+        # Do not just take keys from savers, perhaps some have no savers are under them!
+        # (see #444)
+        saved = set([k for k, v in components.savers.items()
+                     if v])
         for p in components.plugins.values():
             produced.update(p.provides)
             required.update(p.depends_on)

--- a/strax/processor.py
+++ b/strax/processor.py
@@ -104,8 +104,8 @@ class ThreadedMailboxProcessor:
         #  - we should discard (produced but neither required not saved)
         produced = set(components.loaders)
         required = set(components.targets)
-        # Do not just take keys from savers, perhaps some have no savers are under them!
-        # (see #444)
+        # Do not just take keys from savers, perhaps some keys
+        # have no savers are under them (see #444)
         saved = set([k for k, v in components.savers.items()
                      if v])
         for p in components.plugins.values():

--- a/strax/processor.py
+++ b/strax/processor.py
@@ -208,6 +208,10 @@ class ThreadedMailboxProcessor:
                 if max_m is not None:
                     m.max_messages = max_m
 
+        # Remove defaultdict-like behaviour; all mailboxes should
+        # have been made by now. See #444
+        self.mailboxes = dict(self.mailboxes)
+
     def iter(self):
         target = self.components.targets[0]
         final_generator = self.mailboxes[target].subscribe()


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Due to a few subtle interacting bugs / missing checks, a situation can occur where a new mailbox gets created __after__ processing has started. If this happens during https://github.com/AxFoundation/strax/blob/master/strax/processor.py#L216 we get the crash Peter reported in https://github.com/AxFoundation/strax/pull/444. But in principle this could happen at any later time, in which case messages would probably accumulate in the unattended mailbox until we run out of memory. For more details, see https://github.com/AxFoundation/strax/pull/444. 


**Can you briefly describe how it works?**

This will:
  * Replace the `MailboxDict` with a regular dict at the end of `ThreadedMailboxProcessor.__init__`, stopping automatic mailbox creation beyond that point. If (through some bug) someone tries to send to mailboxes['nonexisting'], they will now get the expected `KeyError`.
  * Fix the discarder-detection code at https://github.com/AxFoundation/strax/blob/master/strax/context.py#L765. If (through some bug / oversight) empty-list entries are left in `savers`, we will still add mailboxes and discarders for those outputs when they are produced but not consumed.
  * Rewrite the `savers`-construction code in `context.py` to prevent creation of empty-list entries. (When multiprocessing, `ParallelSourcePlugin` can cause new empty-list entries to appear, but it already cleans them up: https://github.com/AxFoundation/strax/blob/master/strax/plugin.py#L934.)