### PR TITLE
Fix #452 assert there is a mailbox for the final generator

### DIFF
--- a/strax/processor.py
+++ b/strax/processor.py
@@ -227,13 +227,7 @@ class ThreadedMailboxProcessor:
 
     def iter(self):
         target = self.components.targets[0]
-
-        if target in self.mailboxes:
-            final_generator = self.mailboxes[target].subscribe()
-        else:
-            # We might not know who is the final generator if everything
-            # is in the ParallelSourcePlugin.
-            final_generator = None
+        final_generator = self.mailboxes[target].subscribe()
 
         self.log.debug("Starting threads")
         for m in self.mailboxes.values():

--- a/strax/processor.py
+++ b/strax/processor.py
@@ -9,12 +9,10 @@ from concurrent.futures import ProcessPoolExecutor
 import numpy as np
 
 import strax
-
 export, __all__ = strax.exporter()
 
 try:
     import npshmex
-
     SHMExecutor = npshmex.ProcessPoolExecutor
     npshmex.register_array_wrapper(strax.Chunk, 'data')
 except ImportError:
@@ -206,7 +204,6 @@ class ThreadedMailboxProcessor:
         def discarder(source):
             for _ in source:
                 pass
-
         for d in to_discard:
             self.mailboxes[d].add_reader(
                 discarder, name=f'discard_{d}')
@@ -236,7 +233,6 @@ class ThreadedMailboxProcessor:
 
         self.log.debug(f"Yielding {target}")
         traceback, exc, reason = None, None, None
-
 
         try:
             yield from final_generator

--- a/strax/processor.py
+++ b/strax/processor.py
@@ -231,7 +231,7 @@ class ThreadedMailboxProcessor:
             final_generator = self.mailboxes[target].subscribe()
         else:
             # We might not know who is the final generator if everything
-            # is parallel.q
+            # is in the ParallelSourcePlugin.
             final_generator = None
 
         self.log.debug("Starting threads")


### PR DESCRIPTION
_this PR was edited after Yossi's review and uses his proposal instead_
**What is the problem / what does the code in this PR do**
In PR #452 we have set the behavior of the mailbox dict to be non-defaultdict like. This however causes problems when only ParallelSourcePlugin plugins are subscribed since the results from these plugins are saved under the divide_output mailbox. 

As per @jmosbacher 's suggestion https://github.com/AxFoundation/strax/pull/463#issuecomment-857522815, the correct way of dealing with it is making sure there is a mailbox for each of the outputs of a multi-output plugin.

**The error:**
https://github.com/AxFoundation/strax/pull/452#issuecomment-855790815