### PR TITLE
Fix digitizer saturation check

### DIFF
--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -235,7 +235,7 @@ def sum_waveform(peaks, records, adc_to_pe, select_peaks_indices=None):
                 p['time'] // dt, n_p)
 
             max_in_record = r['data'][r_start:r_end].max() * multiplier
-            p['saturated_channel'][ch] |= np.int8(max_in_record >= r['baseline'])
+            p['saturated_channel'][ch] |= np.int8(max_in_record >= np.int16(r['baseline']))
 
             bl_fpart = r['baseline'] % 1
             # TODO: check numba does casting correctly here!


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Fix a bug that's causing pulse saturation check not working. The right condition should be `max_in_record >= int(baseline)`, as `record = int(baseline) -  raw_record` and pulse saturation results into `raw_record = 0`