### PR TITLE
CutPlugins save when plugin is target

### DIFF
--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -780,7 +780,7 @@ class LoopPlugin(Plugin):
 @export
 class CutPlugin(Plugin):
     """Generate a plugin that provides a boolean for a given cut specified by 'cut_by'"""
-    save_when = SaveWhen.NEVER
+    save_when = SaveWhen.TARGET
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Simple PR, the name says already all. Cut plugins can take a few minutes to compute. Hence, we should allow users to store the cuts instead of recomputing them every time they start an analysis.