### PR TITLE
Re ordered time field in cut plugins

### DIFF
--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -801,7 +801,7 @@ class CutPlugin(Plugin):
     def infer_dtype(self):
         dtype = [(self.cut_name, np.bool_, self.cut_description)]
         # Alternatively one could use time_dt_fields for low level plugins.
-        dtype = dtype + strax.time_fields
+        dtype = strax.time_fields + dtype
         return dtype
 
     def compute(self, **kwargs):


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Trivial change, I just re-aranged the time field position in our CutPlugin.  In an array of merged plugins the result will look like
```
False, 1621861432156179212, 1621861432159096710,  True, False,  True,  True, False
```
which drove me crazy. 