### PR TITLE
Change default progress_bar=False for get_iter

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -894,7 +894,7 @@ class Context:
                  selection_str=None,
                  keep_columns=None,
                  allow_multiple=False,
-                 progress_bar=True,
+                 progress_bar=False,
                  _chunk_number=None,
                  **kwargs) -> ty.Iterator[strax.Chunk]:
         """Compute target for run_id and iterate over results.


### PR DESCRIPTION
Proposal for very simple change that will be less verbose. I think most users want to load multiple runs at a time anyway and so we automatically get a tqdm progress bar there, not to mention the fact that the main use-case is just loading data, not creating it. 