### PR TITLE
change default pbar behavior (for multiple runs)

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1095,6 +1095,8 @@ class Context:
         """Compute target for run_id. Returns nothing (None).
         {get_docs}
         """
+        kwargs.setdefault('progress_bar', False)
+
         # Multi-run support
         run_ids = strax.to_str_tuple(run_id)
         if len(run_ids) == 0:

--- a/strax/context.py
+++ b/strax/context.py
@@ -1095,7 +1095,7 @@ class Context:
 
     def make(self, run_id: ty.Union[str, tuple, list],
              targets, save=tuple(), max_workers=None,
-             progress_bar=False, _skip_if_built=True,
+             _skip_if_built=True,
              **kwargs) -> None:
         """Compute target for run_id. Returns nothing (None).
         {get_docs}
@@ -1108,14 +1108,12 @@ class Context:
             return strax.multi_run(
                 self.get_array, run_ids, targets=targets,
                 throw_away_result=True,
-                progress_bar=progress_bar,
                 save=save, max_workers=max_workers, **kwargs)
 
         if _skip_if_built and self.is_stored(run_id, targets):
             return
 
         for _ in self.get_iter(run_ids[0], targets,
-                               progress_bar=progress_bar,
                                save=save, max_workers=max_workers, **kwargs):
             pass
 
@@ -1547,6 +1545,7 @@ the start of the run to load.
 - skip: Do not select a time range, even if other arguments say so
 :param _chunk_number: For internal use: return data from one chunk.
 :param progress_bar: Display a progress bar if metedata exists.
+:param multi_run_progress_bar: Display a progress bar for loading multiple runs
 """
 
 get_docs = """

--- a/strax/context.py
+++ b/strax/context.py
@@ -1,4 +1,3 @@
-import collections
 import datetime
 import logging
 import fnmatch
@@ -11,18 +10,14 @@ import time
 import numpy as np
 import pandas as pd
 import strax
-import sys
-if any('jupyter' in arg for arg in sys.argv):
-    # In some cases we are not using any notebooks,
-    # Taken from 44952863 on stack overflow thanks!
-    from tqdm.notebook import tqdm
-else:
-    from tqdm import tqdm
 
 export, __all__ = strax.exporter()
 __all__ += ['RUN_DEFAULTS_KEY']
 
 RUN_DEFAULTS_KEY = 'strax_defaults'
+
+# use tqdm as loaded in utils (from tqdm.notebook when in a juypyter env)
+tqdm = strax.utils.tqdm
 
 
 @strax.takes_config(

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -15,8 +15,6 @@ import dill
 import numba
 import numpy as np
 import pandas as pd
-# Use the notebook progressbar as loaded in context.py
-from .context import tqdm
 
 # Change numba's caching backend from pickle to dill
 # I'm sure they don't mind...
@@ -26,6 +24,13 @@ try:
 except AttributeError:
     # Numba < 0.49
     numba.caching.pickle = dill
+
+if any('jupyter' in arg for arg in sys.argv):
+    # In some cases we are not using any notebooks,
+    # Taken from 44952863 on stack overflow thanks!
+    from tqdm.notebook import tqdm
+else:
+    from tqdm import tqdm
 
 
 def exporter(export_self=False):

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -433,17 +433,17 @@ def multi_run(exec_function, run_ids, *args,
               throw_away_result=False,
               multi_run_progress_bar=True,
               **kwargs):
-    """Execute f(run_id, **kwargs) over multiple runs,
+    """Execute exec_function(run_id, *args, **kwargs) over multiple runs,
     then return list of result arrays, each with a run_id column added.
 
     :param exec_function: Function to run
-    :param run_ids: list/tuple of runids
+    :param run_ids: list/tuple of run_ids
     :param max_workers: number of worker threads/processes to spawn.
-    If set to None, defaults to 1.
+        If set to None, defaults to 1.
     :param throw_away_result: instead of collecting result, return None.
     :param multi_run_progress_bar: show a tqdm progressbar for multiple runs.
 
-    Other (kw)args will be passed to the function
+    Other (kw)args will be passed to the exec_function.
     """
     if max_workers is None:
         max_workers = 1


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
As discussed in https://github.com/AxFoundation/strax/pull/476, change the default behavior for loading multiple runs since having two competing pbars is messy.

Also make the runs-pbar configurable.

**Can you briefly describe how it works?**
Rather than disabling the pbar altogether (as in  #476) only do it for multiple runs in the multi-run code.

