### PR TITLE
Change growing result offset dtype to int64

### DIFF
--- a/strax/utils.py
+++ b/strax/utils.py
@@ -63,7 +63,7 @@ def inherit_docstring_from(cls):
 
 
 @export
-def growing_result(dtype=np.int, chunk_size=10000):
+def growing_result(dtype=np.int64, chunk_size=10000):
     """Decorator factory for functions that fill numpy arrays
 
     Functions must obey following API:


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Changes default dtype for offset in growing result to np.int64 removes the following warning from tests:

```
../strax/strax/utils.py:60
  /home/dwenz/mymodules/strax/strax/utils.py:60: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    def growing_result(dtype=np.int, chunk_size=10000):
```
