### PR TITLE
Copy plugin instance for processing

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -494,6 +494,7 @@ class Context:
             self._fix_dependency(requested_plugins, final_plugins)
         return requested_plugins
 
+
     def _get_plugins(self,
                      targets: ty.Tuple[str],
                      run_id: str) -> ty.Dict[str, strax.Plugin]:
@@ -1352,14 +1353,20 @@ class Context:
     def key_for(self, run_id, target):
         """
         Get the DataKey for a given run and a given target plugin. The
-        DataKey is inferred from the plugin lineage.
+        DataKey is inferred from the plugin lineage. The lineage can
+        come either from the _fixed_plugin_cache or computed on the fly.
 
         :param run_id: run id to get
         :param target: data type to get
         :return: strax.DataKey of the target
         """
-        p = self._get_plugins((target,), run_id)[target]
-        return strax.DataKey(run_id, target, p.lineage)
+        if self._plugins_are_cached((target,)):
+            plugins = self._fixed_plugin_cache[self._context_hash()]
+        else:
+            plugins = self._get_plugins((target,), run_id)
+
+        lineage = plugins[target].lineage
+        return strax.DataKey(run_id, target, lineage)
 
     def get_meta(self, run_id, target) -> dict:
         """Return metadata for target for run_id, or raise DataNotAvailable

--- a/strax/context.py
+++ b/strax/context.py
@@ -461,14 +461,14 @@ class Context:
         for target, plugin in plugins.items():
             self._fixed_plugin_cache[context_hash][target] = plugin
 
-    def _fix_dependency(self, register, end_plugin):
+    def _fix_dependency(self, plugin_resistry: dict, end_plugin: str):
         """
         Starting from end-plugin, fix the dtype until there is nothing
         left to fix. Keep in mind that dtypes can be chained.
         """
-        for go_to in register[end_plugin].depends_on:
-            self._fix_dependency(register, go_to)
-        register[end_plugin].fix_dtype()
+        for go_to in plugin_resistry[end_plugin].depends_on:
+            self._fix_dependency(plugin_resistry, go_to)
+        plugin_resistry[end_plugin].fix_dtype()
 
     def __get_plugins_from_cache(self,
                                  run_id: str) -> ty.Dict[str, strax.Plugin]:

--- a/strax/context.py
+++ b/strax/context.py
@@ -430,9 +430,9 @@ class Context:
         """
         base_hash_on_config = self.config.copy()
         # Also take into account the versions of the plugins registered
-        base_hash_on_config.update({data_type: plugin.__version__
-                                    for data_type, plugin in
-                                    self._plugin_class_registry.items()})
+        base_hash_on_config.update(
+            {data_type: (plugin.__version__, plugin.compressor, plugin.input_timeout)
+             for data_type, plugin in self._plugin_class_registry.items()})
         return strax.deterministic_hash(base_hash_on_config)
 
     def _plugins_are_cached(self, targets: ty.Tuple[str],) -> bool:

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -126,12 +126,19 @@ class Plugin:
         Note:
             self.deps is NOT copied for it is recursive and therefor slow.
             Instead, this is better handled within the context after all
-            plugins are coppied.
+            plugins are copied.
         """
         plugin_copy = self.__class__()
         plugin_copy.__init__()
-
-        for attribute in ['dtype', 'lineage', 'takes_config', '__version__', 'config', 'data_kind']:
+        # As explained in PR #485 only copy attributes whereof we know
+        # don't depend on the run_id (for use_per_run_defaults == False).
+        # Otherwise we might copy run-dependent things like to_pe.
+        for attribute in ['dtype',
+                          'lineage',
+                          'takes_config',
+                          '__version__',
+                          'config',
+                          'data_kind']:
             source_value = getattr(self, attribute)
             if _deep_copy:
                 plugin_copy.__setattr__(attribute, deepcopy(source_value))

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -3,7 +3,6 @@
 A 'plugin' is something that outputs an array and gets arrays
 from one or more other plugins.
 """
-from concurrent.futures import wait
 from enum import IntEnum
 import inspect
 import itertools
@@ -13,7 +12,7 @@ import typing
 from warnings import warn
 from immutabledict import immutabledict
 import numpy as np
-
+from copy import copy, deepcopy
 import strax
 export, __all__ = strax.exporter()
 
@@ -64,7 +63,6 @@ class Plugin:
     # How large (uncompressed) should re-chunked chunks be?
     # Meaningless if rechunk_on_save is False
     chunk_target_size_mb = strax.default_chunk_size_mb
-
 
     # For a source with online input (e.g. DAQ readers), crash if no new input
     # has appeared for this many seconds
@@ -121,9 +119,37 @@ class Plugin:
         self.compute_pars = compute_pars
         self.input_buffer = dict()
 
+    def __copy__(self, _deep_copy=False):
+        """
+        Copy main attributes that are set after __init__ by the context.
+
+        Note:
+            self.deps is NOT copied for it is recursive and therefor slow.
+            Instead, this is better handled within the context after all
+            plugins are coppied.
+        """
+        plugin_copy = self.__class__()
+        plugin_copy.__init__()
+
+        for attribute in ['dtype', 'lineage', 'takes_config', '__version__', 'config', 'data_kind']:
+            source_value = getattr(self, attribute)
+            if _deep_copy:
+                plugin_copy.__setattr__(attribute, deepcopy(source_value))
+            else:
+                plugin_copy.__setattr__(attribute, copy(source_value))
+        return plugin_copy
+
+    def __deepcopy__(self):
+        return self.__copy__(_deep_copy=True)
+
     def fix_dtype(self):
-        if not hasattr(self, 'dtype'):
+        try:
+            # Infer dtype should always precede self.dtype (e.g. due to
+            # copying)
             self.dtype = self.infer_dtype()
+        except RuntimeError:
+            if not hasattr(self, 'dtype'):
+                raise NotImplementedError(f'No dtype or infer_dtype specified')
 
         if self.multi_output:
             # Convert to a dict of numpy dtypes

--- a/tests/test_fixed_plugin_cache.py
+++ b/tests/test_fixed_plugin_cache.py
@@ -1,0 +1,113 @@
+from strax.testutils import Records, Peaks
+import strax
+import unittest
+import numpy as np
+
+
+class ChannelIsRunidRecords(Records):
+    """Set the channel field equal to the run_id"""
+    def compute(self, chunk_i):
+        res = super().compute(chunk_i)
+        res.data['channel'][:] = int(self.run_id)
+        return res
+
+
+class MaxChannelPeaks(Peaks):
+    def infer_dtype(self):
+        # We are going to check later that the infer_dtype is always called.
+        dtype = strax.peak_dtype() + [
+            (('PMT with median most records',
+              'max_pmt'), np.int16)
+        ]
+        self.dtype_is_set = True
+        return dtype
+
+    def compute(self, records):
+        assert np.all(records['channel'] == int(self.run_id))
+        res = super().compute(records)
+        res['max_pmt'] = records['channel'].mean()
+        return res
+
+
+class TestContextFixedPluginCache(unittest.TestCase):
+    """Test the _fixed_plugin_cache of a context"""
+    def test_load_runs(self, n_runs=3, config_update=None, **kwargs):
+        """Try loading data for n_runs to make sure that we are """
+        run_ids = [str(r) for r in range(n_runs)]
+        st = self.get_context(use_per_run_defaults=False)
+        if config_update is not None:
+            st.set_context_config(config_update)
+        data = st.get_array(run_ids, 'records', **kwargs)
+        run_id_channel_diff = data['run_id'].astype(np.int64) - data['channel']
+        assert np.all(run_id_channel_diff == 0)
+
+        # To be sure also double check Peaks as self.deps of the Plugin
+        # class should be correctly taken care of by the context.
+        peaks_data = st.get_array(run_ids, 'peaks')
+        run_id_max_pmt_diff = peaks_data['max_pmt'] - peaks_data['run_id'].astype(np.int64)
+        assert np.all(run_id_max_pmt_diff == 0)
+
+    def test_get_plugin(self, n_runs=3):
+        run_ids = [str(r) for r in range(n_runs)]
+        st = self.get_context(use_per_run_defaults=False)
+        plugins_seen = []
+        for run in run_ids:
+            p = st.get_single_plugin(run, 'records')
+            plugins_seen.append(p)
+            assert p.run_id == run
+
+        # If we passed around a reference instead of a copy of the
+        # plugin, this would be a problem.
+        for r_i, run in enumerate(run_ids):
+            assert plugins_seen[r_i].run_id == run
+
+    def test_load_runs_multicore(self):
+        """Load the runs. If the references are mixed up the results are inconsistent"""
+        multicore_config = dict(allow_lazy=False,
+                                timeout=60,
+                                allow_multiprocess=True,
+                                )
+        self.test_load_runs(n_runs=10, config_update=multicore_config, max_workers=10)
+
+    def test_cache_changes(self):
+        """
+        Test that the _fixed_plugin_cache changes if we:
+          - Change the config
+          - Change the version of a plugin
+
+         """
+        st = self.get_context(use_per_run_defaults=False)
+
+        # Compute the key/hash under which we will store the plugins
+        first_key = st._context_hash()
+        assert first_key is not None
+
+        # Change the config triggers a new key
+        st.set_config({'bla': 1})
+        second_key = st._context_hash()
+
+        # Change the version of a plugin triggers a new key
+        st._plugin_class_registry['records'].__version__ = -1
+        third_key = st._context_hash()
+
+        assert first_key != second_key != third_key
+
+    def test_set_dtype(self):
+        st = self.get_context(use_per_run_defaults=False)
+
+        # Compute the key/hash under which we will store the plugins
+        st.key_for('0', 'peaks')
+        assert st._fixed_plugin_cache[st._context_hash()]['peaks'].dtype_is_set
+        
+        # Now recreate for a new run
+        st.key_for('1', 'peaks')
+        assert st._fixed_plugin_cache[st._context_hash()]['peaks'].dtype_is_set
+
+    @staticmethod
+    def get_context(use_per_run_defaults: bool):
+        """Get simple context"""
+        st = strax.Context(storage=[],
+                           register=(ChannelIsRunidRecords, MaxChannelPeaks),
+                           config=dict(bonus_area=1))
+        st.set_context_config({'use_per_run_defaults': use_per_run_defaults})
+        return st

--- a/tests/test_fixed_plugin_cache.py
+++ b/tests/test_fixed_plugin_cache.py
@@ -98,7 +98,7 @@ class TestContextFixedPluginCache(unittest.TestCase):
         # Compute the key/hash under which we will store the plugins
         st.key_for('0', 'peaks')
         assert st._fixed_plugin_cache[st._context_hash()]['peaks'].dtype_is_set
-        
+
         # Now recreate for a new run
         st.key_for('1', 'peaks')
         assert st._fixed_plugin_cache[st._context_hash()]['peaks'].dtype_is_set

--- a/tests/test_loop_plugins.py
+++ b/tests/test_loop_plugins.py
@@ -96,8 +96,12 @@ def _loop_test_inner(big_data,
         depends_on = 'big_thing'
         provides = 'small_thing'
         data_kind = 'small_kinda_data'
-        dtype = _dtype
+
         rechunk_on_save = True
+
+        def infer_dtype(self):
+            dtype = _dtype
+            return dtype
 
         def compute(self, big_kinda_data):
             # Drop some of the data in big_kinda_data

--- a/tests/test_loop_plugins.py
+++ b/tests/test_loop_plugins.py
@@ -91,17 +91,13 @@ def _loop_test_inner(big_data,
         def source_finished(self):
             return True
 
-    class SmallThing(strax.CutPlugin):
+    class SmallThing(strax.Plugin):
         """Throw away some of the data in big_thing"""
         depends_on = 'big_thing'
         provides = 'small_thing'
         data_kind = 'small_kinda_data'
-
+        dtype =_dtype
         rechunk_on_save = True
-
-        def infer_dtype(self):
-            dtype = _dtype
-            return dtype
 
         def compute(self, big_kinda_data):
             # Drop some of the data in big_kinda_data


### PR DESCRIPTION
## What is the problem / what does the code in this PR do
So although #483 seemed nice, @jmosbacher  correctly pointed out that for multi-threading multiple runs, this can cause issues. In fact with the `.deps` tracking in the plugins, we were ever more obscurely shipping configs from older runs into the processing.

I should have written a test for it to catch these issues. So that is added in this PR.

## Design choice: reliability over performance
For the copy function several things could be copied that are setup during the init of a plugin:
 - `Plugin.deps` (the dependencies of the plugin that point to lower-level plugins)
 - `Plugin.infer_dtype()` results
 - `Plugin.setup()` results
 - `Plugin.config` (set in `Context._set_plugin_config`
 - `Plugin.lineage`

In the current implementation we went for reliability over performance. This means we only copy the `Plugin.config` and `plugin.lineage`. Below we discuss why the others are not copied:
 - `Plugin.setup()`. Since `Plugin.setup()` sets up things like [`Plugin.to_pe` ](https://github.com/XENONnT/straxen/blob/master/straxen/plugins/peaklet_processing.py#L110), those results should definitely **not** be copied. We could rely on the user to make sure to write the setup function in such a way that running it a second time just overwrites attributes like `Plugin.to_pe` but I can come up with implementations where you start re-using such attributes so I would rather not have to rely on the user not making an unintentional mistake. 
 - `Plugin.deps` : since this is where we keep a copy of the instances that are responsible for processing lower level data, these copies have the same issue as the lineage from above. Therefore, also these need be rebuild for every new run if we copy a plugin from the cache.
 - `Plugin.infer_dtype()` results depend often on `Plugin.deps`. There are a few plugins (e.g. [this one](https://github.com/XENONnT/straxen/blob/master/straxen/plugins/double_scatter.py#L72)) where class attributes are set during the `infer_dtype` which are then used in the compute. Maybe this is sloppy and we should move this to `setup` of those plugins, but I would rather just run `Plugin.infer_dtype()` again. 
 
#### Note on performance
If we would copy the `Plugin.infer_dtype()`-results as well and not use `Context._fix_dependency`, we could make `Context._get_plugins` ~15 times faster since it again does a recursive init. However, I don't mind if we spend a little more time here (still faster then without caching) to be safe rather than sorry for the reasons explained above. Especially since `Context._get_plugins` is now not per-se called for `Context.key_for` which is the driving function for loading data. Creating data takes time so spending ~O(30 ms) to start up a plugin or ~O(2 ms) is not going to make a very noticeable difference. The speed increase of `Context.key_for` (~750x) will show up during loading of data.

## Can you briefly describe how it works?
So now we instead make copies such that each tread in multiprocessing can be handled by a separate instance.

Also, for `Context.key_for` we *can* get the lineage from the cache without having to recompute anything (again if no run-defaults are allowed). So now the key-generation will be much faster, this will also make checking if something is stored much faster,

## Can you give a minimal working example (or illustrate with a figure)?
The performance increase in getting a single plugin is nice still:
![afbeelding](https://user-images.githubusercontent.com/22295914/125592752-e3b9681a-6626-4fe5-976e-e712e48c237e.png)


The biggest performance increase is for the key-generation which we use on data-loading. This will greatly affect things like e.g. cuts:
![afbeelding](https://user-images.githubusercontent.com/22295914/125592861-690c70ca-45ac-4cb8-a40c-8268f41543a8.png)

