### PR TITLE
Added pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings = 
+	ignore::numba.NumbaExperimentalFeatureWarning


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Tiny PR which adds a ini for pytest which sets `numba.NumbaExperimentalFeatureWarning` to ignore. Reduce the amount of lengthy warning messages during testing. 
