### PR TITLE
A few improvements on handling ONLINE vs OFFLINE corrections

### DIFF
--- a/strax/corrections.py
+++ b/strax/corrections.py
@@ -176,7 +176,7 @@ class CorrectionsInterface:
                 for column in df_old.columns:
                     if 'ONLINE' in column:
                         if new_date < now:
-                            for i in range(0, len(new_date)):
+                            for i, item in enumerate(new_date):
                                 new_value = df.loc[df.index == new_date[i].to_pydatetime(), column].values[0]
                                 old_value = df_old.loc[df_old.index < new_date[i].to_pydatetime(), column][-1]
                                 if new_value != old_value:


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
In the current configuration changes in the past are not allowed for either ONLINE or OFFLINE versions.
This PR allows user to change values in the past for OFFLINE versions only

**Can you briefly describe how it works?**
This PR allows user to change values in the past for OFFLINE versions only

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
