### PR TITLE
Allow creation and storing of superruns if SaveWhen > 0

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -800,7 +800,7 @@ class Context:
             elif target_plugin.save_when == strax.SaveWhen.EXPLICIT:
                 # If we arrive here in case of a superrun the user want to save
                 # as self.context_config['write_superruns'] is true.
-                if target_i not in save:# and not _is_superrun:
+                if target_i not in save and not _is_superrun:
                     return
             else:
                 assert target_plugin.save_when == strax.SaveWhen.ALWAYS

--- a/strax/context.py
+++ b/strax/context.py
@@ -675,7 +675,6 @@ class Context:
         """Return components for setting up a processor
         {get_docs}
         """
-
         save = strax.to_str_tuple(save)
         targets = strax.to_str_tuple(targets)
 
@@ -801,7 +800,7 @@ class Context:
             elif target_plugin.save_when == strax.SaveWhen.EXPLICIT:
                 # If we arrive here in case of a superrun the user want to save
                 # as self.context_config['write_superruns'] is true.
-                if target_plugin not in save and not _is_superrun:
+                if target_i not in save:# and not _is_superrun:
                     return
             else:
                 assert target_plugin.save_when == strax.SaveWhen.ALWAYS


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Changed get_components such that superruns can be created from every plugin type except SaveWhen.NEVER plugins. This addresses: https://github.com/XENONnT/straxen/issues/605
