### PR TITLE
Update splitter for merged s2s data kind

### DIFF
--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -92,7 +92,7 @@ def replace_merged(orig, merge):
         return orig
 
     skip_windows = strax.touching_windows(orig, merge)
-    skip_n = len(np.unique(np.concatenate([np.arange(l, r) for l, r in skip_windows])))
+    skip_n = np.diff(skip_windows, axis=1).sum()
     result = np.zeros(len(orig) - skip_n + len(merge),
                       dtype=orig.dtype)
     _replace_merged(result, orig, merge, skip_windows)

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -92,7 +92,7 @@ def replace_merged(orig, merge):
         return orig
 
     skip_windows = strax.touching_windows(orig, merge)
-    skip_n = np.diff(skip_windows, axis=1).sum()
+    skip_n = len(np.unique(np.concatenate([np.arange(l, r) for l, r in skip_windows])))
     result = np.zeros(len(orig) - skip_n + len(merge),
                       dtype=orig.dtype)
     _replace_merged(result, orig, merge, skip_windows)

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -45,6 +45,9 @@ class PeakSplitter:
     :param data_type: 'peaks' or 'hitlets'. Specifies whether to use
         sum_waveform or get_hitlets_data to compute the waveform of the
         new split peaks/hitlets.
+    :param concat_orig: Return original peaks and new peaks from 
+        splitting concatenated together. Otherwise, return as a tuple
+        (original peaks, new peaks)
     :param do_iterations: maximum number of times peaks are recursively split.
     :param min_area: Minimum area to do split. Smaller peaks are not split.
 

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -58,7 +58,7 @@ class PeakSplitter:
 
     def __call__(self, peaks, records, to_pe, data_type, concat_orig,
                  do_iterations=1, min_area=0, **kwargs):
-        if not len(peaks) or not do_iterations:
+        if not len(records) or not len(peaks) or not do_iterations:
             return peaks
 
         # Build the *args tuple for self.find_split_points from kwargs


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
The gap-size-based merging algorithm we are using now is not able to / optimized for splitting merged multiple scatter S2s, and thus motivates potentially adding the natural break after the merging. This pr is going to update the splitter so that it can also process merged s2s, particularly to circumvent calling sum waveform.

**Can you briefly describe how it works?**
The first change is to the peak building part that for merged s2s, instead of resetting `dt` and `data` with the records, we simply copy the part of `data` from the pre-split peak and keep the same `dt`. (One thing to note is that those two fields are only kept within the splitting process, so the split iteration can work. Once outside, those split peaks will be rebuilt from peaklets, so that they have the correct area_per_channel, saturation info, and so on)

The second change is to make it possible to return the peaks in two arrays, one without any splitting and the new peaks from the splitting. This return option is needed, as mentioned above, we need to rebuild the peaks from peaklets but just for those split peaks.

