### PR TITLE
Fix test

### DIFF
--- a/strax/processor.py
+++ b/strax/processor.py
@@ -135,7 +135,9 @@ class ThreadedMailboxProcessor:
 
         multi_output_seen = []
         for d, p in components.plugins.items():
-            if p in multi_output_seen:
+            # Have to check if we have seen already this plugin class
+            # instance of the class maybe different for different data_types
+            if p.__class__ in multi_output_seen:
                 continue
 
             executor = None
@@ -145,7 +147,7 @@ class ThreadedMailboxProcessor:
                 executor = self.thread_executor
 
             if p.multi_output:
-                multi_output_seen.append(p)
+                multi_output_seen.append(p.__class__)
 
                 # Create temp mailbox that receives multi-output dicts
                 # and sends them forth to other mailboxes


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Small two line fix for https://github.com/XENONnT/straxen/pull/623. The issue arises from the fact that the divided_output plugin is created twice for the same multi-output plugin. The reason for this is that the check in line https://github.com/AxFoundation/strax/blob/df18c9cef38ea1cee9737d56b1bea078ebb246a9/strax/processor.py#L138 compares the plugin instances and not the plugin class. The instances are different for the same multi-output plugin. I am not sure if this is a legacy problem or if this was introduced with the [plugin caching](https://github.com/AxFoundation/strax/pull/483) added recently. 
