### PR TITLE
re-use instance of plugin for multi output

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -477,9 +477,17 @@ class Context:
         """Load requested plugins from the plugin_cache"""
         requested_plugins = {}
         for target, plugin in self._fixed_plugin_cache[self._context_hash()].items():
-            # Lineage is fixed, just replace the run_id
-            requested_plugins[target] = plugin.__copy__()
-            requested_plugins[target].run_id = run_id
+            if target in requested_plugins:
+                # If e.g. target is already seen because the plugin is
+                # multi output
+                continue
+
+            requested_p = plugin.__copy__()
+            requested_p.run_id = run_id
+
+            # Re-use only one instance if the plugin is multi output
+            for provides in strax.to_str_tuple(requested_p.provides):
+                requested_plugins[provides] = requested_p
 
         # At this stage, all the plugins should be in requested_plugins
         # To prevent infinite copying, we are only now linking the
@@ -494,7 +502,6 @@ class Context:
         for final_plugins in self._get_end_targets(requested_plugins):
             self._fix_dependency(requested_plugins, final_plugins)
         return requested_plugins
-
 
     def _get_plugins(self,
                      targets: ty.Tuple[str],


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
__Thanks @WenzDaniel for spotting and recognising the issue__

https://github.com/XENONnT/straxen/pull/623 seems to be induced by copying plugins even if the plugin is multioutput. This lead to a separate instance for the processing even if one plugin is doing the providing of multiple targets.

To reproduce: 
```bash
cd straxen
pytest tests/test_several.py -vs
```
To prove it's indeed the plugin caching add the following line [here](https://github.com/XENONnT/straxen/blob/a9ec90f74dbdc5c4ccd5ba31f5aac21e3e75dfdf/tests/test_several.py#L235) (disabling the caching all together):
```python
st.set_context_config(dict(use_per_run_defaults=False))
```

**Can you briefly describe how it works?**
Set the same instance for all the products of one multioutput plugin
