### PR TITLE
Add raise if instance are not equal

### DIFF
--- a/strax/processor.py
+++ b/strax/processor.py
@@ -137,6 +137,10 @@ class ThreadedMailboxProcessor:
         for d, p in components.plugins.items():
             if p in multi_output_seen:
                 continue
+                
+            if p.__class__ in [mp_seen.__class__ for mp_seen in multi_output_seen]:
+                raise ValueError('A multi-output plugin is registered with different '
+                                 'instances for its provided data_types!')
 
             executor = None
             if p.parallel == 'process':


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
After fixing the caching issue in https://github.com/AxFoundation/strax/pull/516. We decided to add also a raise condition in processor.py if the plugin instances are not the same.
