### PR TITLE
Adds information about failing chunk

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1109,7 +1109,7 @@ class Context:
 
         except Exception as e:
             generator.throw(e)
-            raise
+            raise ValueError(f'Failed to process chunk {n_chunks}!')
 
         if not seen_a_chunk:
             if time_range is None:


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Trivial change, adds information about which chunked failed during processing. E.g. instead of just showing:

```
....
ValueError: Want to add a new zero-length peak after splitting!
```

The new error message shows now:

```
...
ValueError: Want to add a new zero-length peak after splitting!
The above exception was the direct cause of the following exception:
...
ValueError: Failed to process chunk 57.
``` 

Which makes debugging easier. (E.g. one can download the offending chunk and reproduce with `st.make(run_id, data_type, _chunk_number=XYZ)`)
