### PR TITLE
Allow loading SaveWhen.EXPLICIT time range selection

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -774,9 +774,13 @@ class Context:
                     # While the data type providing the time information is
                     # available (else we'd have failed earlier), one of the
                     # other requested data types is not.
-                    raise strax.DataNotAvailable(
-                        f"Time range selection assumes data is already "
-                        f"available, but {target_i} for {run_id} is not.")
+                    error_message = (
+                        f"Time range selection assumes data is already available,"
+                        f" but {target_i} for {run_id} is not.")
+                    if plugins[target_i].save_when == strax.SaveWhen.TARGET:
+                        error_message += (f"\nFirst run st.make({run_id}, "
+                                          f"{target_i}) to make {target_i}.")
+                    raise strax.DataNotAvailable(error_message)
                 if '*' in self.context_config['forbid_creation_of']:
                     raise strax.DataNotAvailable(
                         f"{target_i} for {run_id} not found in any storage, and "


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Time range selections for SaveWhen.NEVER and SaveWhen.EXPLICIT should be kept on equal footing. Requiring that one makes the data before allowing time ranges is unrealistic.

