### PR TITLE
fail for - run_ids

### DIFF
--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -94,6 +94,7 @@ class DataDirectory(StorageFrontend):
 
     def _find(self, key, write,
               allow_incomplete, fuzzy_for, fuzzy_for_options):
+        self.raise_if_non_compatible_run_id(key.run_id)
         dirname = osp.join(self.path, str(key))
         exists = os.path.exists(dirname)
         bk = self.backend_key(dirname)
@@ -192,6 +193,11 @@ class DataDirectory(StorageFrontend):
         # (which FileStore should do) is sufficient.
         pass
 
+    @staticmethod
+    def raise_if_non_compatible_run_id(run_id):
+        if '-' in str(run_id):
+            raise ValueError("The filesystem frontend does not understand"
+                             " run_id's with '-', please replace with '_'")
 
 @export
 def dirname_to_prefix(dirname):

--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -309,7 +309,11 @@ class MongoSaver(Saver):
 
 def backend_key_to_query(backend_key):
     """Convert backend key to queryable dictionary"""
-    n, d, l = backend_key.split('-')
+    split_key = backend_key.split('-')
+    if len(split_key) != 3:
+        raise ValueError(f'backend_key ({backend_key}) has too many "-"s,'
+                         f' don\'t use "-" within run_ids')
+    n, d, l = split_key
     return {'number': int(n), 'data_type': d, 'lineage_hash': l}
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,32 @@
+import unittest
+import strax
+from strax.testutils import Records, Peaks
+import os
+import shutil
+import tempfile
+
+
+class TestPerRunDefaults(unittest.TestCase):
+    """Test the saving behavior of the context"""
+    def setUp(self):
+        self.path = os.path.join(tempfile.gettempdir(), 'strax_data')
+        self.st = strax.Context(use_per_run_defaults=True,
+                                register=[Records],)
+        self.target = 'records'
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            print(f'rm {self.path}')
+            shutil.rmtree(self.path)
+
+    def test_write_data_dir(self):
+        self.st.storage = [strax.DataDirectory(self.path)]
+        run_id = '0'
+        self.st.make(run_id, self.target)
+        assert self.st.is_stored(run_id, self.target)
+
+    def test_complain_run_id(self):
+        self.st.storage = [strax.DataDirectory(self.path)]
+        run_id = 'run-0'
+        with self.assertRaises(ValueError):
+            self.st.make(run_id, self.target)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
For WFSim, sometimes users use a run-naming scheme which relies on `'-'`, for example `'run-0'`. This sounds quite intuative and there is also nothing clearly wrong with choosing such a name. However, this leads to very strange results with some of the Strorage frontends, which do not understand folders with too many `'-'`s. 

So let's fail when a user tries using a run_id with `-`. I think we can easily live without this flexibility. 
