### PR TITLE
Fix memory explosion multi runs

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -25,3 +25,4 @@ scipy==1.7.1
 tqdm==4.62.2
 zarr==2.10.2
 zstd==1.5.0.2
+memory_profiler

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -9,6 +9,7 @@ fsspec==2021.10.1
 hypothesis==6.24.1
 immutabledict==2.2.1
 lz4==3.1.3
+memory_profiler==0.58.0
 mongomock==3.23.0
 npshmex==0.2.1
 numba==0.54.1
@@ -25,4 +26,3 @@ scipy==1.7.1
 tqdm==4.62.2
 zarr==2.10.2
 zstd==1.5.0.2
-memory_profiler

--- a/strax/context.py
+++ b/strax/context.py
@@ -1221,7 +1221,7 @@ class Context:
         if len(run_ids) > 1:
             return strax.multi_run(
                 self.get_array, run_ids, targets=targets,
-                throw_away_result=True,
+                throw_away_result=True, log=self.log,
                 save=save, max_workers=max_workers, **kwargs)
 
         if _skip_if_built and self.is_stored(run_id, targets):
@@ -1245,6 +1245,7 @@ class Context:
         if len(run_ids) > 1:
             results = strax.multi_run(
                 self.get_array, run_ids, targets=targets,
+                log=self.log,
                 save=save, max_workers=max_workers, **kwargs)
         else:
             source = self.get_iter(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -194,4 +194,3 @@ class TestMultiRun(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
-


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
In this PR we rework the job submission in multi-runs to address:  https://github.com/AxFoundation/strax/issues/563. The new function will always just submit twice as many jobs as there are workers. As soon as a job finishes its job the result is loaded and new jobs are submitted if needed. In this way we ensure that garbage collection is called in time on each individual worker. 

In addition I changed the function such that the output is sorted by run_id which was previously not the case. In terms of performance no significant increase in computing time can be observed. 

To test the different behavior just call 

```
st.make(run_ids, data_type)
```

or 

```
st.get_array(run_ids, data_type)
```

for more than a single run_id and observe the memory usage in python. 

I also added some test to ensure a correct behavior (doing an off by one error during the job submission was quite easy).
