### PR TITLE
Add funcs for getting stored source

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1679,17 +1679,23 @@ class Context:
             return None
 
         forbidden = strax.to_str_tuple(self.context_config['forbid_creation_of'])
+        forbidden_warning = (
+            'For {run_id}:{target}, you are not allowed to make {dep} and '
+            'it is not stored. Disable check with check_forbidden=False'
+        )
         if check_forbidden and target in forbidden:
+            self.log.warning(forbidden_warning.format(run_id=run_id,
+                                                      target=target,
+                                                      dep=target
+                             ))
             return None
 
         stored_sources = set()
         for dep in deps:
-            if self.is_stored(run_id, dep):
-                stored_sources |= {dep}
-            elif check_forbidden and dep in forbidden:
-                self.log.warning(f'For run {run_id}:{target}, you are not '
-                                 f'allowed to make {dep} and it is not stored. '
-                                 f'Disable with check_forbidden=False'
+            if check_forbidden and dep in forbidden:
+                self.log.warning(forbidden_warning.format(run_id=run_id,
+                                                          target=target,
+                                                          dep=dep)
                                  )
                 return None
             else:

--- a/strax/context.py
+++ b/strax/context.py
@@ -1677,12 +1677,12 @@ class Context:
         deps = strax.to_str_tuple(self._plugin_class_registry[target].depends_on)
         if not deps:
             return None
-        stored_sources = set()
+
         forbidden = strax.to_str_tuple(self.context_config['forbid_creation_of'])
         if check_forbidden and target in forbidden:
-            # Simple, we are not allowed to make this
             return None
 
+        stored_sources = set()
         for dep in deps:
             if self.is_stored(run_id, dep):
                 stored_sources |= {dep}
@@ -1694,7 +1694,7 @@ class Context:
                 return None
             else:
                 deeper = self.get_source(run_id, dep, check_forbidden=check_forbidden)
-                if not deeper:
+                if deeper is None:
                     self.log.info(f'For run {run_id}, requested dependency '
                                   f'{dep} for {target} is not stored')
                     return None

--- a/strax/context.py
+++ b/strax/context.py
@@ -1686,8 +1686,7 @@ class Context:
         if check_forbidden and target in forbidden:
             self.log.warning(forbidden_warning.format(run_id=run_id,
                                                       target=target,
-                                                      dep=target
-                             ))
+                                                      dep=target,))
             return None
 
         stored_sources = set()
@@ -1695,8 +1694,7 @@ class Context:
             if check_forbidden and dep in forbidden:
                 self.log.warning(forbidden_warning.format(run_id=run_id,
                                                           target=target,
-                                                          dep=dep)
-                                 )
+                                                          dep=dep,))
                 return None
             else:
                 deeper = self.get_source(run_id, dep, check_forbidden=check_forbidden)

--- a/strax/context.py
+++ b/strax/context.py
@@ -457,7 +457,7 @@ class Context:
             {data_type: (plugin.__version__, plugin.compressor, plugin.input_timeout)
              for data_type, plugin in self._plugin_class_registry.items()
              if not data_type.startswith('_temp_')
-            })
+             })
         return strax.deterministic_hash(base_hash_on_config)
 
     def _plugins_are_cached(self, targets: ty.Tuple[str],) -> bool:
@@ -1381,10 +1381,9 @@ class Context:
                     f"array fields. Please use get_array.")
             raise
 
-
-    def get_zarr(self, run_ids, targets, storage='./strax_temp_data', 
-                progress_bar=False, overwrite=True, **kwargs):
-        """get perisistant arrays using zarr. This is useful when
+    def get_zarr(self, run_ids, targets, storage='./strax_temp_data',
+                 progress_bar=False, overwrite=True, **kwargs):
+        """get persistent  arrays using zarr. This is useful when
             loading large amounts of data that cannot fit in memory
             zarr is very compatible with dask.
             Targets are loaded into separate arrays and runs are merged.
@@ -1655,6 +1654,35 @@ class Context:
                 raise strax.DataExistsError(
                     f'Trying to write {data_key} to {t_sf} which already exists, '
                     'do you have two storage frontends writing to the same place?')
+
+    def get_source(self, run_id: str, target: str) -> ty.Union[set, None]:
+        """
+        For a given run_id and target get the stored bases where we can
+        start processing from, if no base is available, return None.
+
+        :param run_id: run_id
+        :param target:  target
+        :return: set of plugin names that are needed to start processing
+            from and are needed in order to build this target.
+        """
+        if self.is_stored(run_id, target):
+            return {target}
+
+        deps = strax.to_str_tuple(self._plugin_class_registry[target].depends_on)
+        if not deps:
+            return None
+        stored_sources = set()
+        for dep in deps:
+            if self.is_stored(run_id, dep):
+                stored_sources |= {dep}
+            else:
+                deeper = self.get_source(run_id, dep)
+                if not deeper:
+                    self.log.info(f'For run {run_id}, requested dependency '
+                                  f'{dep} for {target} is not stored')
+                    return None
+                stored_sources |= deeper
+        return stored_sources
 
     def _is_stored_in_sf(self, run_id, target,
                          storage_frontend: strax.StorageFrontend) -> bool:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,17 +1,15 @@
-
-from numpy.lib.arraysetops import isin
 import strax
 import numpy as np
 import tempfile
 import unittest
 import hypothesis
-from hypothesis import given, settings
+from hypothesis import given
+
 
 @strax.takes_config(
     strax.Option(name='int_option', type=int, default=42),
     strax.Option(name='str_option', type=str, default='forty_two'),
     strax.Config(name='mixed', type=int, default=42),
-
 )
 class DummyPlugin(strax.Plugin):
     depends_on = ()
@@ -56,7 +54,6 @@ class TestPluginConfig(unittest.TestCase):
         assert p.int_config == p.int_option == int_value    
         assert p.str_option == p.str_config == str_value
 
-
     @given(
         hypothesis.strategies.integers(),
         hypothesis.strategies.text(),
@@ -75,7 +72,6 @@ class TestPluginConfig(unittest.TestCase):
         p = self.get_plugin(config)
         assert p.config['int_config'] == p.config['int_option'] == int_value    
         assert p.config['str_config'] == p.config['str_option'] == str_value
-
 
     def test_config_backward_compatibility(self):
         p = self.get_plugin({})

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -313,4 +313,3 @@ class TestContext(unittest.TestCase):
             depends_on = 'peaks'
             provides = 'cut_peaks'
         return DummyDependsOnPeaks
-


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Sometimes you want to process `event_info` but don't know if you have all the required datatypes that are needed for making that data. Rather than doing a try for except, you might from the start want to know if that data can be computed, and where you need to start processing from.

In this PR we add just that.

**Can you briefly describe how it works?**
Look at the target you want to compute, if it's not stored, check if the dependencies are stored. If finally you reach a plugin that is either not stored or not depending on anything (`raw_records`), return `None`, indicating that you cannot make this data.
