### PR TITLE
Make truly HDR

### DIFF
--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -548,6 +548,7 @@ def highest_density_region_width(data,
 
     inter, amps = strax.highest_density_region(data,
                                                fractions_desired,
+                                               only_upper_part=True,
                                                _buffer_size=_buffer_size,
                                                )
 

--- a/strax/processing/statistics.py
+++ b/strax/processing/statistics.py
@@ -4,13 +4,13 @@ import numba
 import strax
 export, __all__ = strax.exporter()
 
+
 @export
 @numba.njit(cache=True)
-def highest_density_region(data, fractions_desired, _buffer_size=10):
+def highest_density_region(data, fractions_desired, only_upper_part=False, _buffer_size=10):
     """
     Computes for a given sampled distribution the highest density region
     of the desired fractions.
-
     Does not assume anything on the normalisation of the data.
 
     :param data: Sampled distribution
@@ -18,11 +18,11 @@ def highest_density_region(data, fractions_desired, _buffer_size=10):
         the hdr should be computed.
     :param _buffer_size: Size of the result buffer. The size is
         equivalent to the maximal number of allowed intervals.
-
+    :param only_upper_part: Boolean, if true only computes
+        area/probability between maximum and current hight.
     :return: two arrays: The first one stores the start and inclusive
         endindex of the highest density region. The second array holds
         the amplitude for which the desired fraction was reached.
-
     Note:
         Also goes by the name highest posterior density. Please note,
         that the right edge corresponds to the right side of the sample.
@@ -50,6 +50,7 @@ def highest_density_region(data, fractions_desired, _buffer_size=10):
             continue
 
         lowest_sample_seen = data[max_to_min[j]]
+        lowest_sample_seen *= only_upper_part
         sorted_data_max_to_j = data[max_to_min[:j]]
         fraction_seen = np.sum(sorted_data_max_to_j - lowest_sample_seen) / area_tot
 
@@ -110,7 +111,7 @@ def highest_density_region(data, fractions_desired, _buffer_size=10):
         if fi == (len(fractions_desired)):
             # Found all fractions so we are done
             return res, res_amp
-    
+
     # If we end up here this might be due to an offset 
     # of the distribution with respect to zero. In that case it can
     # happen that we do not find all desired fractions.

--- a/strax/processing/statistics.py
+++ b/strax/processing/statistics.py
@@ -50,7 +50,7 @@ def highest_density_region(data, fractions_desired, only_upper_part=False, _buff
             continue
 
         lowest_sample_seen = data[max_to_min[j]]
-        lowest_sample_seen *= only_upper_part
+        lowest_sample_seen *= int(only_upper_part)
         sorted_data_max_to_j = data[max_to_min[:j]]
         fraction_seen = np.sum(sorted_data_max_to_j - lowest_sample_seen) / area_tot
 

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,5 +1,6 @@
 import strax
 import numpy as np
+from scipy.stats import norm
 from strax.processing.hitlets import highest_density_region_width
 
 
@@ -20,7 +21,10 @@ def test_highest_density_region():
 
 
 def _test_highest_density_region(distribution, truth_dict):
-    intervals, heights = strax.highest_density_region(distribution, np.array(list(truth_dict.keys())))
+    intervals, heights = strax.highest_density_region(distribution,
+                                                      np.array(list(truth_dict.keys())),
+                                                      only_upper_part=True,
+                                                      )
     for fraction_ind, (key, values) in enumerate(truth_dict.items()):
         for ind_interval, interval in enumerate(values):
             int_found = intervals[fraction_ind, :, ind_interval]
@@ -35,10 +39,34 @@ def test_too_small_buffer():
     """
     distribution = np.ones(1000)
     distribution[::4] = 0
-    indicies, _ = strax.highest_density_region(distribution, np.array([0.5]))
+    indicies, _ = strax.highest_density_region(distribution,
+                                               np.array([0.5]),
+                                               only_upper_part=True,
+                                               )
     assert np.all(indicies == -1)
 
     width = highest_density_region_width(distribution,
                                          fractions_desired=np.array([0.5]),
                                          _buffer_size=10)
     assert np.all(np.isnan(width))
+
+
+def test_true_hdr():
+    """
+    Tests if highest density region returns for a normal
+    distribution the expected -1/1 boundaries for 68.27% coverage.
+
+    We are not using a too high precision here to reduce the total test
+    time.
+    """
+    x = np.arange(-5, 5, 10**-4)
+    data = norm.pdf(x)
+    data /= np.sum(data)
+    index, _ = strax.highest_density_region(data, fractions_desired=np.array([0.6827]))
+    a_index = index[0, 0, 0]
+    b_index = index[0, 1, 0]
+    area = np.sum(data[a_index:(b_index-1)])
+
+    assert np.isclose(area, 0.6827, rtol=10**-4), (area, 0.6827)
+    assert np.isclose(x[a_index], -1, rtol=10**-3), (x[a_index], -1)
+    assert np.isclose(x[b_index-1], 1, rtol=10**-3), (x[b_index-1], 1)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Small PR which fixes the definition of the highest density region.  The difference is illustrated in the image below:

![example](https://user-images.githubusercontent.com/43881800/146014609-f4b16755-232c-4200-a614-37660ba8b199.png)

In the previous version we computed the area wrongly in case one is truly  interested in the HDR.  So far this function was only used to get a width estimate for the hitlet data_type. No need in straxen needed. The behavior of the already existing function was changed such that they behave consistently. 

I also added a test which shows that the HDR of the 68.27% a normal distribution corresponds to the expected +/- sigma.