### PR TITLE
Change tempdirs in test

### DIFF
--- a/tests/test_saving.py
+++ b/tests/test_saving.py
@@ -11,16 +11,15 @@ class TestPerRunDefaults(unittest.TestCase):
     def setUp(self):
         self.test_run_id = '0'
         self.target = 'records'
-        self.path = os.path.join(tempfile.gettempdir(), 'strax_data')
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.path = self.tempdir.name
         self.st = strax.Context(use_per_run_defaults=True,
                                 register=[Records],
                                 storage=[strax.DataDirectory(self.path)])
         assert not self.st.is_stored(self.test_run_id, self.target)
 
     def tearDown(self):
-        if os.path.exists(self.path):
-            print(f'rm {self.path}')
-            shutil.rmtree(self.path)
+        self.tempdir.cleanup()
 
     def test_savewhen_never(self, **kwargs):
         self.set_save_when('NEVER')

--- a/tests/test_saving.py
+++ b/tests/test_saving.py
@@ -2,7 +2,6 @@ import unittest
 import strax
 from strax.testutils import Records, Peaks
 import os
-import shutil
 import tempfile
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -15,15 +15,14 @@ class TestPerRunDefaults(TestCase):
     """
 
     def setUp(self):
-        self.path = os.path.join(tempfile.gettempdir(), 'strax_data')
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.path = self.tempdir.name
         self.st = strax.Context(use_per_run_defaults=True,
                                 register=[Records], )
         self.target = 'records'
 
     def tearDown(self):
-        if os.path.exists(self.path):
-            print(f'rm {self.path}')
-            shutil.rmtree(self.path)
+        self.tempdir.cleanup()
 
     def test_write_data_dir(self):
         self.st.storage = [strax.DataDirectory(self.path)]
@@ -85,13 +84,12 @@ class TestStorageType(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         """Get a temp directory available of all the tests"""
-        cls.path = os.path.join(tempfile.gettempdir(), 'strax_data')
+        cls.tempdir = tempfile.TemporaryDirectory()
+        cls.path = cls.tempdir.name
 
     def tearDown(self):
         """After each test, delete the temporary directory"""
-        if os.path.exists(self.path):
-            print(f'rm {self.path}')
-            shutil.rmtree(self.path)
+        self.tempdir.cleanup()
 
     def _sub_dir(self, subdir: str) -> str:
         return os.path.join(self.path, subdir)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,8 +1,7 @@
-from unittest import TestCase, skipIf
+from unittest import TestCase
 import strax
 from strax.testutils import Records
 import os
-import shutil
 import tempfile
 import numpy as np
 import typing as ty


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

**Can you briefly describe how it works?**
Change the tempdir creation of some of our tests. The new procedure uses a tempdir created by `tempfile.TemporaryDirectory` this method has a weak  reference in its init which ensures that the directory gets deleted if its reference is garbage collected. In this way we can ensure permission denied erros etc. on shared systems like dali. 

See also: 

https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory

and

https://stackoverflow.com/questions/50649701/shutil-rmtree-does-not-work-on-tempfile-temporarydirectory