### PR TITLE
Add tests for lose ends

### DIFF
--- a/tests/test_multi_output.py
+++ b/tests/test_multi_output.py
@@ -170,16 +170,10 @@ class TestMultiOutputs(unittest.TestCase):
         for d in p.provides:
             assert p.save_when[d] == _save_when[d]
 
-        # Test if call of NEVER data_type makes any data:
-        assert not self.mystrax.is_stored('0', 'even_recs')
-        assert not self.mystrax.is_stored('0', 'odd_recs')
-        assert not self.mystrax.is_stored('0', 'rec_count')
-        self.mystrax.make('0', 'even_recs')
-        assert not self.mystrax.is_stored('0', 'even_recs')
-        assert not self.mystrax.is_stored('0', 'odd_recs')
-        assert not self.mystrax.is_stored('0', 'rec_count')
-
         # See if only ALWAYS is made:
+        assert not self.mystrax.is_stored('0', 'even_recs')
+        assert not self.mystrax.is_stored('0', 'odd_recs')
+        assert not self.mystrax.is_stored('0', 'rec_count')
         self.mystrax.make('0', 'rec_count')
         assert not self.mystrax.is_stored('0', 'even_recs')
         assert not self.mystrax.is_stored('0', 'odd_recs')

--- a/tests/test_multi_output.py
+++ b/tests/test_multi_output.py
@@ -230,10 +230,12 @@ class TestMultiOutputs(unittest.TestCase):
         assert not self.mystrax.is_stored('0', 'even_recs')
         assert not self.mystrax.is_stored('0', 'even_recs_classified')
         assert not self.mystrax.is_stored('0', 'peaks')
+        assert not self.mystrax.is_stored('0', 'rec_count')
         self.mystrax.make('0', 'peaks')
         assert not self.mystrax.is_stored('0', 'even_recs')
         assert not self.mystrax.is_stored('0', 'even_recs_classified')
         assert self.mystrax.is_stored('0', 'peaks')
+        assert self.mystrax.is_stored('0', 'rec_count')
 
         # Test if saving EXPLICIT works:
         self.mystrax.make('0', 'even_recs_classified', save=('even_recs_classified', ))


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Fixes a bug in our save_when extension introduced in https://github.com/AxFoundation/strax/pull/631. I forgot to check whether "lose-end" data_types like `pulse_counts` are stored properly after inlining plugins. The issue arises from the fact that we return early in [this line of get_components](https://github.com/AxFoundation/strax/blob/ef37118b1c3302b0af49179bd46629f619b3f98a/strax/context.py#L928) for records. 