### PR TITLE
Change default compressor

### DIFF
--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -57,7 +57,7 @@ class Plugin:
     # indicates such an inheritance.
     child_plugin = False
     
-    compressor = 'blosc'
+    compressor = 'zstd'
 
     rechunk_on_save = True    # Saver is allowed to rechunk
     # How large (uncompressed) should re-chunked chunks be?


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Change the default compressor to zstd. At least for records, this showed to be comparable in speed but quite a bit squeezer than blosc. It's not going to be a huge change, the heaviest datatypes already have this.

Reference:
https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:ivyli:lossless_compression

Maybe we should discuss this a bit, but it only affects newly written data and strax checks the metadata for which compressor was used, so it's a save change.