### PR TITLE
Auto version, fix #217

### DIFF
--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -242,13 +242,14 @@ class Plugin:
 
         Activate with setting __version__ to None
         """
-        attributes = [attr for attr in self.__dir__() if not attr.startswith('__')]
+        attributes = [attr for attr in self.__dir__()
+                      if not attr.startswith('__')]
 
         def _return_hashable(attr):
-            obj = getattr(self, attr)
-            if attr in ['takes_config']:
-                # handled by context
+            if attr in ['takes_config', '_auto_version']:
+                # handled by context (or not worth tracking)
                 return
+            obj = getattr(self, attr)
             try:
                 return strax.deterministic_hash(inspect.getsource(obj))
             except TypeError:

--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -43,7 +43,7 @@ class Plugin:
     You should NOT instantiate plugins directly.
     Do NOT add unpickleable things (e.g. loggers) as attributes.
     """
-    __version__ = '0.0.0'
+    __version__: typing.Optional[str] = '0.0.0'
 
     # For multi-output plugins these should be (immutable)dicts
     data_kind: typing.Union[str, immutabledict, dict]
@@ -177,7 +177,7 @@ class Plugin:
             if isinstance(self.takes_config[name], strax.Config):
                 return self.takes_config[name].__get__(self)
             return self.config[name]
-            
+
 
         raise AttributeError(f'{self.__class__.__name__} instance has no attribute {name}')
 
@@ -234,12 +234,40 @@ class Plugin:
         # implementing all abstract methods...
         raise RuntimeError("No infer dtype method defined")
 
+    @property
+    def _auto_version(self):
+        """
+        Generate some auto-incremented version for the context hashing
+        system, see github.com/AxFoundation/strax/issues/217
+
+        Activate with setting __version__ to None
+        """
+        attributes = [attr for attr in self.__dir__() if not attr.startswith('__')]
+
+        def _return_hashable(attr):
+            obj = getattr(self, attr)
+            if attr in ['takes_config']:
+                # handled by context
+                return
+            try:
+                return strax.deterministic_hash(inspect.getsource(obj))
+            except TypeError:
+                pass
+            try:
+                return strax.deterministic_hash(obj)
+            except TypeError:
+                return str(obj)
+        res = {attr: _return_hashable(attr) for attr in attributes}
+        return 'auto_' + strax.deterministic_hash(res)
+
     def version(self, run_id=None):
         """Return version number applicable to the run_id.
         Most plugins just have a single version (in .__version__)
         but some may be at different versions for different runs
         (e.g. time-dependent corrections).
         """
+        if self.__version__ is None:
+            return self._auto_version
         return self.__version__
 
     def __repr__(self):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -397,6 +397,47 @@ class TestContext(unittest.TestCase):
         assert all(r in records_run_ids for r in make_runs)
         assert set(runs) - set(make_runs) not in records_run_ids
 
+    def test_auto_lineage(self):
+        """
+        Test that auto inferring a lineage from the plugin code works
+
+        Set auto-inferring version by setting __version__ = None for
+        a plugin.
+        """
+        st = self.get_context(True)
+        class DevelopRecords(Records):
+            __version__ = None
+        st.register(DevelopRecords)
+        key = st.key_for(run_id, 'records')
+        plugin = st.get_single_plugin(run_id, 'records')
+        # Check that the version is auto-inferred
+        assert plugin.version().startswith('auto_')
+
+        # Check that loading and saving works as expected
+        st.make(run_id, 'records')
+        assert st.is_stored(run_id, 'records')
+        st.set_context_config(dict(forbid_creation_of='*'))
+        st.get_array(run_id, 'records')
+
+        # Plugin version (and therefore lineage) should not change when
+        # making a new class. Let's try:
+        class DevelopRecords(DevelopRecords):
+            # New class, same properties (class name is encoded in
+            # lineage!)
+            pass
+
+        st2 = st.new_context(register=DevelopRecords)
+        assert key.lineage == st2.key_for(run_id, 'records').lineage
+
+        # When changing the class to have a different code, it should
+        # get a new version and therefore a different lineage.
+        class DevelopRecords(DevelopRecords):
+            def compute(self, **kwargs):
+                res = super().compute(**kwargs)
+                return res
+
+        st3 = st.new_context(register=DevelopRecords)
+        assert key.lineage != st3.key_for(run_id, 'records').lineage
 
 
     @staticmethod


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Add auto-inferring option to plugin by setting `__version__ = None`. Fixes #217

**Can you briefly describe how it works?**
Generate a hash on the fly by hashing the plugin class.

**Can you give a minimal working example (or illustrate with a figure)?**
Please see the appended test for a use case.

**Catches and pitfalls**
With https://github.com/AxFoundation/strax/issues/688 around, this would lead to some ambiguous results in the affected methods.

 