### PR TITLE
Use plugin.version, fix #688

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -2031,7 +2031,7 @@ class Context:
         :return: dictionary of provided dtypes with their corresponding
             lineage hash, save_when, version
         """
-        dtypes = tuple(self._plugin_class_registry.key())
+        dtypes = tuple(self._plugin_class_registry.keys())
         plugins = self._get_plugins(targets=dtypes, run_id=run_id)
         hashes = set([
             (data_type,

--- a/strax/context.py
+++ b/strax/context.py
@@ -700,10 +700,9 @@ class Context:
                         configs[option_name] = v
 
                 # Also adding name and version of the parent to the lineage:
-                parent_plugin = self.get_single_plugin(
-                    run_id,
-                    strax.to_str_tuple(parent_class.provides)[0])
-                configs[parent_class.__name__] = parent_plugin.version(run_id)
+                # NB: tracking the parents Plugin.__version__, not the
+                # run_id dependent Plugin.version
+                configs[parent_class.__name__] = parent_class.__version__
 
                 plugin.lineage = {last_provide: (
                     plugin.__class__.__name__,

--- a/strax/context.py
+++ b/strax/context.py
@@ -550,7 +550,9 @@ class Context:
         # Despite github.com/AxFoundation/strax/issues/688, we use
         # __version__ here. This might cause ambiguity _only_ when one
         # re-registers a new plugin with a different method for
-        # Plugin.version.
+        # Plugin.version. Additionally, we only add up in this piece of
+        # logic if we don't allow per-run defaults. So we really
+        # shouldn't have run_id dependent versions in the first place.
         base_hash_on_config.update(
             {data_type: (plugin.__version__, plugin.compressor, plugin.input_timeout)
              for data_type, plugin in self._plugin_class_registry.items()


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
See #688 .

I did not change the _context_cache as I explained in the comment. It would be solving a problem that is so unlikely to which would potentially lead to very slow data availability checks that I'm not in favor of chaining it. When someone is really insisting, I could add a check that check that the `Plugin.version` method cannot be overwritten when `use_per_run_defaults` is deactivated.

**Can you briefly describe how it works?**
Get a plugin instance to compute the version number based on a run-id.


