### PR TITLE
Prevent float/int funkyness in hitlet processing

### DIFF
--- a/strax/processing/hitlets.py
+++ b/strax/processing/hitlets.py
@@ -14,8 +14,8 @@ NO_FWXM = -42  # Value in case FWXM cannot be found.
 def create_hitlets_from_hits(hits,
                              save_outside_hits,
                              channel_range,
-                             chunk_start=0,
-                             chunk_end=np.inf,):
+                             chunk_start=None,
+                             chunk_end=None,):
     """
     Function which creates hitlets from a bunch of hits.
 
@@ -29,6 +29,14 @@ def create_hitlets_from_hits(hits,
 
     :return: Hitlets with temporary fields (data, max_goodness_of_split...)
     """
+    # There is no such thing as an int('inf'), let's take the min/max
+    # for an 64bit-int. Floats would give funny business in
+    # _concat_overlapping_hits! github.com/AxFoundation/strax/pull/694
+    if chunk_start is None:
+        chunk_start = np.iinfo(np.int64).min
+    if chunk_end is None:
+        chunk_end = np.iinfo(np.int64).max
+
     # Merge concatenate overlapping  within a channel. This is important
     # in case hits were split by record boundaries. In case we
     # accidentally concatenate two PMT signals we split them later again.


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
The default method for create hitlets from hits returns bad results. Comparing ints and floats in numba is not recommendable, I suspect that the compare [between them did not work well on this line](https://github.com/AxFoundation/strax/blob/6aa0a4d0d33f73650139e2a2ebc162d0f0e27c89/strax/processing/hitlets.py#L107).

**Can you briefly describe how it works?**
So now, lets just take the largest and smallest numbers in `np.int64`

**Can you give a minimal working example (or illustrate with a figure)?**
See the issue here:
![afbeelding](https://user-images.githubusercontent.com/22295914/168566062-316e95a5-f8fa-4683-9d05-ca1b867fb449.png)
And the difference between ints and floats (the default was np.inf) for the `chunk_end`
![afbeelding](https://user-images.githubusercontent.com/22295914/168566024-e414ff34-1e80-45d8-857a-c5f477d49a8e.png)
