### PR TITLE
Numpy caching of data in online monitor storage

### DIFF
--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -114,7 +114,7 @@ class MongoBackend(StorageBackend):
             chunk_key = doc.get('chunk_i', None)
             if chunk_key is None:
                 # Should not happen because of the projection in find
-                # but let's double check:
+                # but let's double-check:
                 raise ValueError(
                     f'Projection failed, got doc with no "chunk_i":\n{doc}')
             # Update our registry with this chunks info. Use chunk_i as
@@ -136,7 +136,7 @@ class MongoBackend(StorageBackend):
             self._buffered_backend_keys.append(backend_key)
         while (
                 (len(self._buffered_backend_keys) > 1 and
-                 sum(ch.nbytes for ch in self.chunks_registry.values) / 1e6 > self._buff_mb)
+                 sum(ch.nbytes for ch in self.chunks_registry.values()) / 1e6 > self._buff_mb)
                 or len(self._buffered_backend_keys) > self._buff_nruns
             ):
             self._clean_first_key_from_registry()

--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -123,9 +123,8 @@ class MongoBackend(StorageBackend):
                     # Convert JSON to numpy
             chunk_len = len(doc.get('data', []))
             result = np.zeros(chunk_len, dtype=dtype)
-            for i in range(chunk_len):
-                for key in np.dtype(dtype).names:
-                    result[i][key] = doc['data'][i][key]
+            for key in np.dtype(dtype).names:
+                result[key] = [dd['data'][key] for dd in doc]
             self.chunks_registry[backend_key + str(chunk_key)] = result
             del doc
 

--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -54,7 +54,7 @@ class MongoBackend(StorageBackend):
         # the key is not in the registry (will fail below if also not
         # there on rebuild).
         if registry_key not in self.chunks_registry.keys():
-            self._build_chunk_registry(backend_key)
+            self._build_chunk_registry(backend_key, dtype)
 
         # Unpack info about this chunk from the query. Return empty if
         # not available. Use a *string* in the registry to lookup the
@@ -69,18 +69,7 @@ class MongoBackend(StorageBackend):
             raise ValueError(
                 f'Metadata claims chunk{chunk_i} exists but it is unknown to '
                 f'the chunks_registry')
-
-        chunk_doc = doc.get('data', None)
-        if chunk_doc is None:
-            raise ValueError(f'Doc for chunk_{chunk_i} in wrong format:\n{doc}')
-
-        # Convert JSON to numpy
-        chunk_len = len(chunk_doc)
-        result = np.zeros(chunk_len, dtype=dtype)
-        for i in range(chunk_len):
-            for key in np.dtype(dtype).names:
-                result[i][key] = chunk_doc[i][key]
-        return result
+        return doc
 
     def _saver(self, key, metadata, **kwargs):
         """See strax.Backend"""
@@ -103,7 +92,7 @@ class MongoBackend(StorageBackend):
             return doc['metadata']
         raise strax.DataNotAvailable
 
-    def _build_chunk_registry(self, backend_key):
+    def _build_chunk_registry(self, backend_key, dtype):
         """
         Build chunk info in a single registry using only one query to
         the database. This is much faster as one does not have to do
@@ -131,7 +120,14 @@ class MongoBackend(StorageBackend):
             # Update our registry with this chunks info. Use chunk_i as
             # chunk_key. Make it a *string* to avoid potential key-error
             # issues or json-encoding headaches.
-            self.chunks_registry[backend_key + str(chunk_key)] = doc.copy()
+                    # Convert JSON to numpy
+            chunk_len = len(doc.get('data', []))
+            result = np.zeros(chunk_len, dtype=dtype)
+            for i in range(chunk_len):
+                for key in np.dtype(dtype).names:
+                    result[i][key] = doc['data'][i][key]
+            self.chunks_registry[backend_key + str(chunk_key)] = result
+            del doc
 
         # Some bookkeeping to make sure we don't buffer too much in this
         # backend. We still need to return at least one hence the 'and'.

--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -124,7 +124,7 @@ class MongoBackend(StorageBackend):
             chunk_len = len(doc.get('data', []))
             result = np.zeros(chunk_len, dtype=dtype)
             for key in np.dtype(dtype).names:
-                result[key] = [dd['data'][key] for dd in doc]
+                result[key] = [dd[key] for dd in doc['data']]
             self.chunks_registry[backend_key + str(chunk_key)] = result
             del doc
 

--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -120,7 +120,6 @@ class MongoBackend(StorageBackend):
             # Update our registry with this chunks info. Use chunk_i as
             # chunk_key. Make it a *string* to avoid potential key-error
             # issues or json-encoding headaches.
-                    # Convert JSON to numpy
             chunk_len = len(doc.get('data', []))
             result = np.zeros(chunk_len, dtype=dtype)
             for key in np.dtype(dtype).names:

--- a/tests/test_mongo_frontend.py
+++ b/tests/test_mongo_frontend.py
@@ -238,22 +238,23 @@ class TestMongoFrontend(unittest.TestCase):
         assert self.is_stored_in_mongo
 
         # Allow the frontend to cache a lof of runs, but only little data
-        self.mongo_sf.backends[0]._buff_mb = one_run.nbytes/1e6
-        self.mongo_sf.backends[0]._buff_nruns = make_n_runs
+        mongo_backend = self.mongo_sf.backends[0]
+        mongo_backend._buff_mb = one_run.nbytes/1e6
+        mongo_backend._buff_nruns = make_n_runs
 
         self.st.make(list(str(i) for i in range(make_n_runs)), self.mongo_target)
 
         # We should have at most 1 run (assuming all are the same number of bytes)
-        assert len(self.mongo_sf._buffered_backend_keys) <= 2
+        assert len(mongo_backend._buffered_backend_keys) <= 2
 
         # Allow the frontend to cache a lof of runs, but only little data
-        self.mongo_sf.backends[0]._buff_mb = 10 * one_run.nbytes / 1e6
-        self.mongo_sf.backends[0]._buff_nruns = 1
+        mongo_backend._buff_mb = 10 * one_run.nbytes / 1e6
+        mongo_backend._buff_nruns = 1
 
         self.st.make(list(str(i) for i in range(make_n_runs)), self.mongo_target)
 
         # We should have exactly one run cached
-        assert len(self.mongo_sf._buffered_backend_keys) == 1
+        assert len(mongo_backend._buffered_backend_keys) == 1
 
     @staticmethod
     def _return_file_info(file: dict,

--- a/tests/test_mongo_frontend.py
+++ b/tests/test_mongo_frontend.py
@@ -226,6 +226,35 @@ class TestMongoFrontend(unittest.TestCase):
         self.st.make(self.test_run_id, self.mongo_target)
         assert self.is_stored_in_mongo
 
+    def test_clear_cache(self, make_n_runs=10):
+        """
+        Test that the caches in the mongo backend get cleared appropriately
+        :param make_n_runs: The number of runs to make
+        :return:
+        """
+        # We need to know how large one run is. We'll make sure that we clear the cache if more
+        # data gets stored here than the content of one run
+        one_run = self.st.get_array(self.test_run_id, self.mongo_target)
+        assert self.is_stored_in_mongo
+
+        # Allow the frontend to cache a lof of runs, but only little data
+        self.mongo_sf.backends[0]._buff_mb = one_run.nbytes/1e6
+        self.mongo_sf.backends[0]._buff_nruns = make_n_runs
+
+        self.st.make(list(str(i) for i in range(make_n_runs)), self.mongo_target)
+
+        # We should have at most 1 run (assuming all are the same number of bytes)
+        assert len(self.mongo_sf._buffered_backend_keys) <= 2
+
+        # Allow the frontend to cache a lof of runs, but only little data
+        self.mongo_sf.backends[0]._buff_mb = 10 * one_run.nbytes / 1e6
+        self.mongo_sf.backends[0]._buff_nruns = 1
+
+        self.st.make(list(str(i) for i in range(make_n_runs)), self.mongo_target)
+
+        # We should have exactly one run cached
+        assert len(self.mongo_sf._buffered_backend_keys) == 1
+
     @staticmethod
     def _return_file_info(file: dict,
                           save_properties=('number',


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
In https://github.com/AxFoundation/strax/issues/346, we uttered the prophetic words
```It's just the backend-buffer that is sitting otherwise idle in the background eating your RAM that needs clearing.```
We now learned that this is true when we have longer than usual runs and data with large volumes.

We also should have known that the `sys.getsizeof` wasn't taking the total size of the document but only of the dictionary.

This PR fixes both with using numpy for the buffers such that the max size of buffers is respected by the backend.



