### PR TITLE
fixed delta peak timestamp problem

### DIFF
--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -162,7 +162,6 @@ def add_lone_hits(peaks, lone_hits, to_pe):
 
         # Add lone hit as delta pulse to waveform:
         index = (lh_i['time'] - p['time'])//p['dt']
-        # index = (p['time'] - lh_i['time']) // p['dt']
         if index < 0 or index > len(p['data']):
             raise ValueError('Hit outside of full containment!')
         p['data'][index] += lh_area

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -162,4 +162,7 @@ def add_lone_hits(peaks, lone_hits, to_pe):
 
         # Add lone hit as delta pulse to waveform:
         index = (lh_i['time'] - p['time'])//p['dt']
+        # index = (p['time'] - lh_i['time']) // p['dt']
+        if index < 0 or index > len(p['data']):
+            raise ValueError('Hit outside of full containment!')
         p['data'][index] += lh_area

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -161,5 +161,5 @@ def add_lone_hits(peaks, lone_hits, to_pe):
         p['area_per_channel'][lh_i['channel']] += lh_area
 
         # Add lone hit as delta pulse to waveform:
-        index = (p['time'] - lh_i['time'])//p['dt']
+        index = (lh_i['time'] - p['time'])//p['dt']
         p['data'][index] += lh_area


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
The (lone hits) delta peaks added to `merged_s2s` waveforms have wrong time stamp. For example, in the example `merged_s2s` waveforms below, the red shadow marks peaklets while the blue shadow marks where we expect the lone hits, given the time stamps directly from `lone_hits` datatype. You can see the lone hits show up in the wrong time.
![image](https://user-images.githubusercontent.com/47046530/195763776-6198d6a9-40e3-4ce6-8f17-8220844bc567.png)
![image](https://user-images.githubusercontent.com/47046530/195763785-8daa372b-faf1-4138-8849-d47586048979.png)
![image](https://user-images.githubusercontent.com/47046530/195763793-ad2701e9-5df6-467e-872c-5465c9125c3b.png)

This PR did a minimal fix to this issue.

**Can you briefly describe how it works?**
```
index = (p['time'] - lh_i['time'])//p['dt']
```
is the problem. Apparently, lone hits' time should show up only after `merged_s2s` start. This implementation means that `index` is always negative, leading to a reversed ordering thus mirrored relative timestamp.

**Can you give a minimal working example (or illustrate with a figure)?**
I think this fix is simple enough to skip this part...

