### PR TITLE
Digitize full WF

### DIFF
--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -126,7 +126,10 @@ def find_peaks(hits, adc_to_pe,
 
 @export
 @numba.jit(nopython=True, nogil=True, cache=True)
-def store_downsampled_waveform(p, wv_buffer, store_in_data_top=False,
+def store_downsampled_waveform(p,
+                               wv_buffer,
+                               max_endtime=0,
+                               store_in_data_top=False,
                                wv_buffer_top=np.ones(1, dtype=np.float32)):
     """Downsample the waveform in buffer and store it in p['data'] and
     in p['data_top'] if indicated to do so.
@@ -135,11 +138,13 @@ def store_downsampled_waveform(p, wv_buffer, store_in_data_top=False,
     Note that p['dt'] is adjusted to match the downsampling.
     :param wv_buffer: numpy array containing sum waveform during the peak
     at the input peak's sampling resolution p['dt'].
+    :param max_endtime: the start time of the next peak, if nothing is
+    specified, we have to truncate the sum wf which leads to dataloss
     :param store_in_data_top: Boolean which indicates whether to also store
     into p['data_top']
 
     When downsampling results in a fractional number of samples, the peak is
-    shortened rather than extended. This causes data loss, but it is
+    shortened IF max_endtime is spefified. This causes data loss, but it is
     necessary to prevent overlaps between peaks.
     """
 
@@ -148,8 +153,15 @@ def store_downsampled_waveform(p, wv_buffer, store_in_data_top=False,
     downsample_factor = int(np.ceil(p['length'] / n_samples))
     if downsample_factor > 1:
         # Compute peak length after downsampling.
-        # Do not ceil: see docstring!
-        p['length'] = int(np.floor(p['length'] / downsample_factor))
+        if max_endtime:
+            p['length'] = int(np.ceil(p['length'] / downsample_factor))
+            if p['dt']*p['length']+p['time']>max_endtime:
+                # We HAVE to truncate this wf to prevent overlapping to the next peak
+                p['length'] -= 1
+        else:
+            # We truncate this wf to prevent overlapping to the next
+            # peak because otherwise we might overlap
+            p['length'] = int(np.floor(p['length'] / downsample_factor))
         if store_in_data_top:
             p['data_top'][:p['length']] = \
                     wv_buffer_top[:p['length'] * downsample_factor] \
@@ -298,10 +310,14 @@ def sum_waveform(peaks, hits, records, record_links, adc_to_pe, n_top_channels=0
             area_per_channel[ch] += area_pe
             p['area'] += area_pe
 
+        nest_peak_start = peaks[peak_i+1] if len(peaks) >= peak_i+1 else np.iinfo(np.int64).max
         if n_top_channels > 0:
-            store_downsampled_waveform(p, swv_buffer, True, twv_buffer)
+            store_downsampled_waveform(p, swv_buffer,
+                                       max_endtime=nest_peak_start,
+                                       store_in_data_top=True,
+                                       twv_buffer=twv_buffer)
         else:
-            store_downsampled_waveform(p, swv_buffer)
+            store_downsampled_waveform(p, swv_buffer, max_endtime=nest_peak_start)
 
         p['n_saturated_channels'] = p['saturated_channel'].sum()
         p['area_per_channel'][:] = area_per_channel

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -310,12 +310,12 @@ def sum_waveform(peaks, hits, records, record_links, adc_to_pe, n_top_channels=0
             area_per_channel[ch] += area_pe
             p['area'] += area_pe
 
-        nest_peak_start = peaks[peak_i+1] if len(peaks) >= peak_i+1 else np.iinfo(np.int64).max
+        nest_peak_start = peaks[peak_i+1]['time'] if len(peaks) >= peak_i+1 else np.iinfo(np.int64).max
         if n_top_channels > 0:
             store_downsampled_waveform(p, swv_buffer,
                                        max_endtime=nest_peak_start,
                                        store_in_data_top=True,
-                                       twv_buffer=twv_buffer)
+                                       wv_buffer_top=twv_buffer)
         else:
             store_downsampled_waveform(p, swv_buffer, max_endtime=nest_peak_start)
 

--- a/strax/testutils.py
+++ b/strax/testutils.py
@@ -19,6 +19,7 @@ import strax
 def sorted_bounds(disjoint=False,
                   max_value=50,
                   max_len=10,
+                  min_size=0,
                   remove_duplicates=False):
     if disjoint:
         # Since we accumulate later:
@@ -26,7 +27,7 @@ def sorted_bounds(disjoint=False,
 
     s = strategies.lists(strategies.integers(min_value=0,
                                              max_value=max_value),
-                         min_size=0, max_size=20)
+                         min_size=min_size, max_size=20)
     if disjoint:
         s = s.map(accumulate).map(list)
 
@@ -69,6 +70,7 @@ disjoint_sorted_intervals = sorted_bounds(disjoint=True).\
 
 fake_hits = sorted_bounds().map(partial(bounds_to_intervals,
                                         dtype=strax.hit_dtype))
+
 
 ##
 # Fake pulses with 0 or 1 as waveform (e.g. to test hitfinder)

--- a/tests/test_peak_merging.py
+++ b/tests/test_peak_merging.py
@@ -2,7 +2,8 @@ import hypothesis
 import numpy as np
 
 import strax
-from strax.testutils import disjoint_sorted_intervals, fake_hits
+from strax.testutils import disjoint_sorted_intervals, fake_hits, sorted_bounds, bounds_to_intervals
+from functools import partial
 
 
 @hypothesis.given(disjoint_sorted_intervals,
@@ -48,6 +49,68 @@ def test_replace_merged(intervals, merge_instructions):
         assert x in result, "Didn't put in merged"
     for x in result:
         assert np.isin(x, merged_itvs) or np.isin(x, kept_itvs), "Invented itv"
+
+def bounds_to_intervals_w_data(bs, dt_max=10, dtype=strax.interval_dtype):
+    """Similar to bounds_to_intervals from strax.testutils but with a data field"""
+    x = np.zeros(len(bs), dtype=dtype)
+    x['time'] = [x[0] for x in bs]
+    x['dt'] = np.random.randint(1, dt_max, size=len(x))
+    # Remember: exclusive right bound...
+    x['length'] = [(x[1] - x[0]) // dt for x, dt in zip(bs, x['dt'])]
+    # Clip length to be at least shorter than the 'data' field
+    x['length'] = np.clip(x['length'], 0, x['data'].shape[1])
+    for x_i in x:
+        x_i['data'][:x_i['length']] = np.random.random(size=x_i['length'])
+    return x
+
+
+def get_peaks(min_peaks=2, **dtype_kwargs):
+    """return some fake peaks"""
+    s = sorted_bounds(min_size=min_peaks, disjoint=True).map(
+        partial(bounds_to_intervals_w_data, dtype=strax.peak_dtype(**dtype_kwargs)))
+    # Make sure we got at least <min_peaks> after the filtering
+    s = s.filter(lambda x: len(x) >= min_peaks)
+    return s
+
+
+@hypothesis.example(
+    peaks=np.array([
+        (0, 0, 6, 0, 0, [0., 0., 0.], 0., [], 0, [0., 0., 0.],
+         [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.], [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.], [], 0, 0, 0, 0.),
+        (2, 3, 1, 0, 0, [0., 0., 0.], 0., [], 0, [0.60276335, 0.5448832, 0.4236548],
+         [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.], [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.], [], 0, 0, 0, 0.)],
+        dtype=[(('Start time since unix epoch [ns]', 'time'), '<i8'),
+               (('Length of the interval in samples', 'length'), '<i4'),
+               (('Width of one sample [ns]', 'dt'), '<i4'),
+               (('Channel/PMT number', 'channel'), '<i2'),
+               (('Classification of the peak(let)', 'type'), 'i1'),
+               (('Waveform data in PE/sample (not PE/ns!), top array', 'data_top'), '<f4', (3,)),
+               (('Integral across channels [PE]', 'area'), '<f4'),
+               (('Integral per channel [PE]', 'area_per_channel'), '<f4', (0,)),
+               (('Number of hits contributing at least one sample to the peak ', 'n_hits'), '<i4'),
+               (('Waveform data in PE/sample (not PE/ns!)', 'data'), '<f4', (3,)),
+               (('Peak widths in range of central area fraction [ns]', 'width'), '<f4', (11,)),
+               (('Peak widths: time between nth and 5th area decile [ns]', 'area_decile_from_midpoint'), '<f4', (11,)),
+               (('Does the channel reach ADC saturation?', 'saturated_channel'), 'i1', (0,)),
+               (('Total number of saturated channels', 'n_saturated_channels'), '<i2'),
+               (('Channel within tight range of mean', 'tight_coincidence'), '<i2'),
+               (('Largest gap between hits inside peak [ns]', 'max_gap'), '<i4'),
+               (('Maximum interior goodness of split', 'max_goodness_of_split'), '<f4')])
+)
+@hypothesis.settings(deadline=None, max_examples=1_000)
+@hypothesis.given(get_peaks(n_sum_wv_samples=3, n_channels=0))
+def test_data_field(peaks):
+    """
+    Test https://github.com/AxFoundation/strax/issues/704
+    merge all the peaks - which should give us a similarly large peak as all the input peaks
+    """
+    new_peaks = strax.merge_peaks(peaks,
+                                  np.array([0]),
+                                  np.array([len(peaks)]),
+                                  len(peaks['data']) * len(peaks) * 10
+                                  )
+
+    np.testing.assert_allclose(peaks['data'].sum(), new_peaks['data'].sum(), atol=0, rtol=1e-6)
 
 
 @hypothesis.given(fake_hits,


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
See #704 

The sum WF is always conservative by truncating the peak when downsampling. While probably some loss is acceptable, having O(3%) differences between `p['data'].sum()` and `p['area']` might be a bit more confusing than what we'd 

**Can you briefly describe how it works?**
Rather than being conservative with the clipping of the data-field, use the time if there is any after the peak. This is computed by checking if the next peak is far away enough that we can claim the bit of extra time that would be needed for the extra sample

There may still be a chance that there is another peak directly after another peak that would prevent us from filling the entire buffer. There are a couple of things we could do about that:
 - just ignore it - the chances that this happens is extremely small - especially for smaller peaks where this last sample might make any difference
 - add the data of that last sample that doesn't fit within the time interval to the second to last sample
 - rewrite tons of code to support overlapping peaks
