### PR TITLE
Do not change channel when sort_by_time

### DIFF
--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -16,15 +16,15 @@ def sort_by_time(x):
     """
     if len(x) == 0:
         return x
-    
+
     if 'channel' in x.dtype.names:
         min_channel = x['channel'].min()
-        channel = x['channel']
+        channel = x['channel'].copy()
         if min_channel < 0:
             channel -= min_channel
     else:
         channel = np.ones(len(x))
-        
+
     max_time_difference = (np.iinfo(np.int64).max - 10) / (channel.max()+1)
     # Subtract 10 to have some extra margin, just in case.
     # Use absolute to account for peaks which are channel -1.


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

`'channel'` was changed in https://github.com/AxFoundation/strax/blob/b0e7fdcd21d2f4b5c141b528b448dd0bd4b7583a/strax/processing/general.py#L21-L24. 

So use `x['channel'].copy()` to make a copy of `x['channel']` to avoid this bug. 

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
