### PR TITLE
Fix urllib3 version to 1.26.15

### DIFF
--- a/extra_requirements/requirements-docs.txt
+++ b/extra_requirements/requirements-docs.txt
@@ -5,4 +5,5 @@ nbsphinx
 recommonmark
 graphviz
 m2r
-mistune==0.8.4 
+mistune==0.8.4
+urllib3==1.26.15


### PR DESCRIPTION
Similar to https://github.com/XENONnT/straxen/pull/1177

**What is the problem / what does the code in this PR do**

Because from `2.0.0` urllib3 does not support OpenSSL versions older than 1.1.1. So triggered this failure: https://readthedocs.org/projects/straxen/builds/20440356/. Reference: https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#what-are-the-important-changes. 

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
