### PR TITLE
Improve chunks splitting in `OverlapWindowPlugin`

### DIFF
--- a/strax/plugins/overlap_window_plugin.py
+++ b/strax/plugins/overlap_window_plugin.py
@@ -88,7 +88,7 @@ class OverlapWindowPlugin(Plugin):
                 self.log.debug(
                     f'Inconsistent start times of the cashed chunks after'
                     f' {try_counter}/{max_trials} passes.')
-            invalid_beyond -= min(_potential_invalid_beyond) - 1  # ns
+            invalid_beyond = min(_potential_invalid_beyond) - 1  # ns
         else:
             raise ValueError(f'Buffer start time inconsistency cannot be '
                              f'resolved after {max_trials} tries')

--- a/strax/plugins/overlap_window_plugin.py
+++ b/strax/plugins/overlap_window_plugin.py
@@ -50,7 +50,7 @@ class OverlapWindowPlugin(Plugin):
 
         # Throw away results we already sent out
         _, result = result.split(t=self.sent_until,
-                                 allow_early_split=False)
+                                 allow_early_split=True)
 
         # When does this batch of inputs end?
         ends = [c.end for c in kwargs.values()]

--- a/strax/plugins/overlap_window_plugin.py
+++ b/strax/plugins/overlap_window_plugin.py
@@ -77,7 +77,7 @@ class OverlapWindowPlugin(Plugin):
                 self.log.debug(
                     f'Inconsistent start times of the cashed chunks after'
                     f' {try_counter}/{max_trials} passes.')
-            invalid_beyond = min(result.data['time'][_flag].min()) - 1  # ns
+            invalid_beyond = result.data['time'][_flag].min() - 1  # ns
         else:
             raise ValueError(f'Buffer start time inconsistency cannot be '
                              f'resolved after {max_trials} tries')

--- a/strax/plugins/overlap_window_plugin.py
+++ b/strax/plugins/overlap_window_plugin.py
@@ -84,7 +84,7 @@ class OverlapWindowPlugin(Plugin):
                 self.log.debug(
                     f'Inconsistent start times of the cashed chunks after'
                     f' {try_counter}/{max_trials} passes.')
-            invalid_beyond -= 1000  # ns
+            invalid_beyond -= int(self.get_window_size() / max_trials)  # ns
         else:
             raise ValueError(f'Buffer start time inconsistency cannot be '
                              f'resolved after {max_trials} tries')

--- a/strax/testutils.py
+++ b/strax/testutils.py
@@ -48,7 +48,15 @@ def sorted_bounds(disjoint=False,
         s = s.filter(lambda x: x == list(set(x)))
 
     # Sort intervals and result
-    return s.map(sorted)
+    s = s.map(sorted)
+
+    if not disjoint:
+        # adjacent intervals must overlap!
+        # Remove cases without overlapping intervals
+        s = s.filter(lambda x: all([
+            a[1] > b[0] for a, b in zip(x[:-1], x[1:])]))
+
+    return s
 
 
 ##

--- a/strax/testutils.py
+++ b/strax/testutils.py
@@ -33,12 +33,13 @@ def sorted_bounds(disjoint=False,
     # Select only cases with even-length lists
     s = s.filter(lambda x: len(x) % 2 == 0)
 
-    if not disjoint:
-        s = s.map(sorted)
-
     # Convert to list of 2-tuples
-    s = s.map(lambda x: [tuple(q)
-                         for q in iterutils.chunked(x, size=2)])
+    if disjoint:
+        s = s.map(lambda x: [tuple(q)
+                            for q in iterutils.chunked(sorted(x), size=2)])
+    else:
+        s = s.map(lambda x: [tuple(sorted(q))
+                            for q in iterutils.chunked(x, size=2)])
 
     # Remove cases with zero-length intervals
     s = s.filter(lambda x: all([a[0] != a[1] for a in x]))
@@ -48,15 +49,7 @@ def sorted_bounds(disjoint=False,
         s = s.filter(lambda x: x == list(set(x)))
 
     # Sort intervals and result
-    s = s.map(sorted)
-
-    if not disjoint:
-        # adjacent intervals must overlap!
-        # Remove cases without overlapping intervals
-        s = s.filter(lambda x: all([
-            a[1] > b[0] for a, b in zip(x[:-1], x[1:])]))
-
-    return s
+    return s.map(sorted)
 
 
 ##

--- a/strax/testutils.py
+++ b/strax/testutils.py
@@ -33,9 +33,12 @@ def sorted_bounds(disjoint=False,
     # Select only cases with even-length lists
     s = s.filter(lambda x: len(x) % 2 == 0)
 
+    if disjoint:
+        s = s.map(sorted)
+
     # Convert to list of 2-tuples
     s = s.map(lambda x: [tuple(q)
-                         for q in iterutils.chunked(sorted(x), size=2)])
+                         for q in iterutils.chunked(x, size=2)])
 
     # Remove cases with zero-length intervals
     s = s.filter(lambda x: all([a[0] != a[1] for a in x]))

--- a/strax/testutils.py
+++ b/strax/testutils.py
@@ -33,7 +33,7 @@ def sorted_bounds(disjoint=False,
     # Select only cases with even-length lists
     s = s.filter(lambda x: len(x) % 2 == 0)
 
-    if disjoint:
+    if not disjoint:
         s = s.map(sorted)
 
     # Convert to list of 2-tuples


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

https://github.com/AxFoundation/strax/blob/b35db0a2f27be2746fb30c18d8f7d4b9d9e7722b/strax/plugins/overlap_window_plugin.py#L52-L53 set `allow_early_split=False` to make sure that the chunks are initialized correctly https://github.com/AxFoundation/strax/blob/b35db0a2f27be2746fb30c18d8f7d4b9d9e7722b/strax/chunk.py#L76-L85. 

In real data, we will sometime encounter overlapping peaks when the rate is high, so `result.split` will raise the error. 

**Can you briefly describe how it works?**

The added codes search for splitting time `invalid_beyond` where no items happen in `provides`. 

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
