### PR TITLE
Stop assigning dependabot to Joran

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "monthly"
-    assignees:
-      - JoranAngevaare
   # Maintain the requirements requirements folder
   - package-ecosystem: "pip"
     directory: "/extra_requirements"
@@ -19,5 +17,3 @@ updates:
       # Check for updates to requirements every week
       interval: "monthly"
     open-pull-requests-limit: 15
-    assignees:
-      - JoranAngevaare


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Stop assigning dependabot to Joran
