### PR TITLE
Fix touching window

### DIFF
--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -410,30 +410,20 @@ def _touching_windows(thing_start, thing_end,
                       container_start, container_end,
                       window=0, endtime_sort_kind='mergesort'):
     n = len(thing_start)
-    thing_end_argsort = np.argsort(thing_end, kind=endtime_sort_kind)
-    thing_end_sort = thing_end[thing_end_argsort]
     container_end_argsort = np.argsort(container_end, kind=endtime_sort_kind)
 
     # we search twice, first for the beginning of the interval, then for the end
     left_i = right_i = 0
     result = np.zeros((len(container_start), 2), dtype=np.int32)
 
-    # the smallest index to the right of thing_end_argsort
-    # this is using space to save time complexity
-    min_thing_end_argsort = np.zeros(n + 1, dtype=np.int32)
-    min_thing_end_argsort[-1] = n
-    for i in range(n - 1, -1, -1):
-        min_seen = min_thing_end_argsort[i+1]
-        min_thing_end_argsort[i] = min(min_seen, thing_end_argsort[i])
-
     # first search for the beginning of the interval
     # containers' time is already sorted, but things' endtime is not
     for i, t0 in enumerate(container_start):
-        while left_i <= n - 1 and thing_end_sort[left_i] <= t0 - window:
+        while left_i <= n - 1 and thing_end[left_i] <= t0 - window:
             # left_i ends before the window starts (so it's still outside)
             left_i += 1
         # save the most left index of things touching the container
-        result[i, 0] = min_thing_end_argsort[left_i]
+        result[i, 0] = left_i
 
     # then search for the end of the interval
     # containers' endtime is not sorted but things' endtime is

--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -409,8 +409,7 @@ def touching_windows(things, containers, window=0):
 def _touching_windows(thing_start, thing_end,
                       container_start, container_end,
                       window=0, endtime_sort_kind='mergesort'):
-    thing_n = len(thing_start)
-    container_n = len(container_start)
+    n = len(thing_start)
     thing_end_argsort = np.argsort(thing_end, kind=endtime_sort_kind)
     thing_end_sort = thing_end[thing_end_argsort]
     container_end_argsort = np.argsort(container_end, kind=endtime_sort_kind)
@@ -422,17 +421,17 @@ def _touching_windows(thing_start, thing_end,
     # first search for the beginning of the interval
     # containers' time is already sorted, but things' endtime is not
     for i, t0 in enumerate(container_start):
-        while left_i <= thing_n - 1 and thing_end_sort[left_i] <= t0 - window:
+        while left_i <= n - 1 and thing_end_sort[left_i] <= t0 - window:
             # left_i ends before the window starts (so it's still outside)
             left_i += 1
         # save the most left index of things touching the container
-        result[i, 0] = left_i if left_i == thing_n else min(thing_end_argsort[left_i:])
+        result[i, 0] = left_i if left_i == n else min(thing_end_argsort[left_i:])
 
     # then search for the end of the interval
     # containers' endtime is not sorted but things' endtime is
     for i in container_end_argsort:
         t1 = container_end[i]
-        while right_i <= thing_n - 1 and thing_start[right_i] < t1 + window:
+        while right_i <= n - 1 and thing_start[right_i] < t1 + window:
             # right_i starts before the window ends (so it could be inside)
             right_i += 1
         # now right_i is the last index inside the window or outside the array

--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -413,8 +413,6 @@ def _touching_windows(thing_start, thing_end,
     container_n = len(container_start)
     thing_end_argsort = np.argsort(thing_end, kind=endtime_sort_kind)
     thing_end_sort = thing_end[thing_end_argsort]
-    # append extra element to the end of the array to avoid index out of bound
-    thing_end_argsort = np.append(thing_end_argsort, thing_n)
     container_end_argsort = np.argsort(container_end, kind=endtime_sort_kind)
 
     # we search twice, first for the beginning of the interval, then for the end
@@ -428,7 +426,7 @@ def _touching_windows(thing_start, thing_end,
             # left_i ends before the window starts (so it's still outside)
             left_i += 1
         # save the most left index of things touching the container
-        result[i, 0] = min(thing_end_argsort[left_i:])
+        result[i, 0] = left_i if left_i == thing_n else min(thing_end_argsort[left_i:])
 
     # then search for the end of the interval
     # containers' endtime is not sorted but things' endtime is

--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -419,8 +419,7 @@ def _touching_windows(thing_start, thing_end,
 
     # we search twice, first for the beginning of the interval, then for the end
     left_i = right_i = 0
-    left = np.zeros(container_n, dtype=np.int32)
-    right = np.zeros(container_n, dtype=np.int32)
+    result = np.zeros((len(container_start), 2), dtype=np.int32)
 
     # first search for the beginning of the interval
     # containers' time is already sorted, but things' endtime is not
@@ -429,7 +428,7 @@ def _touching_windows(thing_start, thing_end,
             # left_i ends before the window starts (so it's still outside)
             left_i += 1
         # save the most left index of things touching the container
-        left[i] = min(thing_end_argsort[left_i:])
+        result[i, 0] = min(thing_end_argsort[left_i:])
 
     # then search for the end of the interval
     # containers' endtime is not sorted but things' endtime is
@@ -439,9 +438,7 @@ def _touching_windows(thing_start, thing_end,
             # right_i starts before the window ends (so it could be inside)
             right_i += 1
         # now right_i is the last index inside the window or outside the array
-        right[i] = right_i
-
-    result = np.vstack([left, right]).T
+        result[i, 1] = right_i
 
     return result
 

--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -418,6 +418,14 @@ def _touching_windows(thing_start, thing_end,
     left_i = right_i = 0
     result = np.zeros((len(container_start), 2), dtype=np.int32)
 
+    # the smallest index to the right of thing_end_argsort
+    # this is using space to save time complexity
+    min_thing_end_argsort = np.zeros(n + 1, dtype=np.int32)
+    min_thing_end_argsort[-1] = n
+    for i in range(n - 1, -1, -1):
+        min_seen = min_thing_end_argsort[i+1]
+        min_thing_end_argsort[i] = min(min_seen, thing_end_argsort[i])
+
     # first search for the beginning of the interval
     # containers' time is already sorted, but things' endtime is not
     for i, t0 in enumerate(container_start):
@@ -425,7 +433,7 @@ def _touching_windows(thing_start, thing_end,
             # left_i ends before the window starts (so it's still outside)
             left_i += 1
         # save the most left index of things touching the container
-        result[i, 0] = left_i if left_i == n else min(thing_end_argsort[left_i:])
+        result[i, 0] = min_thing_end_argsort[left_i]
 
     # then search for the end of the interval
     # containers' endtime is not sorted but things' endtime is


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

In some insane cases, where both `endtime` of `things` and `container` are not sorted, like:

```
things = np.array([(0, 1, 1, 0),
                   (1, 5, 1, 0),
                   (2, 1, 1, 0)],
                   dtype=strax.interval_dtype)

containers = np.array([(0, 4, 1, 0), (0, 1, 1, 0)],
                       dtype=strax.interval_dtype)
```

The current algorithm will give wrong results:

```
[[0, 3], [0, 3]]
```

The correct answer is:

```
[[0, 3], [0, 1]]
```

**Can you briefly describe how it works?**

The new algorithm only search for interval when the `time` and `endtime` of `things` and `containers` are sorted. If not, we first sort them and record the `argsort`, then later recover the order following `argsort` of input. 

When `things`' `endtime` are not sorted, we will return the indices of the first and last things which are touching the container. So we return the minimum index in `argsort`. 

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
