### PR TITLE
Use warning also in `abs_time_to_prev_next_interval`

### DIFF
--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -384,7 +384,7 @@ def touching_windows(things, containers, window=0):
         warnings.warn(
             'endtime of things is not sorted! '
             'touching_windows will return the indices of the '
-            'first and last things which are touching the container')
+            'first and last things which are touching the container.')
     try:
         _check_time_is_sorted(containers['time'])
     except Exception:
@@ -470,29 +470,42 @@ def abs_time_to_prev_next_interval(things, intervals):
     :returns: Two integer arrays with the time difference to the 
         previous and next intervals. 
     """
-    _things_do_not_overlap = (strax.endtime(things)[:-1] - things['time'][1:]) <= 0
-    assert np.all(_things_do_not_overlap), 'Things overlap!'
+    try:
+        _check_time_is_sorted(things['time'])
+    except Exception:
+        raise ValueError('time of things should be sorted!')
+    try:
+        _check_time_is_sorted(strax.endtime(things))
+    except Exception:
+        warnings.warn(
+            'endtime of things is not sorted! '
+            'times_to_next returned by abs_time_to_prev_next_interval '
+            'might be larger than expected.')
+    try:
+        _check_time_is_sorted(intervals['time'])
+    except Exception:
+        raise ValueError('time of intervals should be sorted!')
 
     times_to_prev = np.ones(len(things), dtype=np.int64) * -1
     times_to_next = np.ones(len(things), dtype=np.int64) * -1
-    
+
     _empty_events_or_intervals = ((len(things) == 0) 
-                                  or (len(intervals)== 0))
+                                  or (len(intervals) == 0))
     if _empty_events_or_intervals:
         return times_to_prev, times_to_next
-        
+
     _abs_time_to_prev_next(things, intervals, times_to_prev, times_to_next)
-    
+
     return times_to_prev, times_to_next
+
 
 @numba.njit
 def _abs_time_to_prev_next(things, intervals, times_to_prev, times_to_next):
     veto_intervals_seen = 0
-    last_thing_end = 0
     for thing_ind, thing_i in enumerate(things):
         current_event_time = thing_i['time']
         current_event_endtime = strax.endtime(thing_i)
-        
+
         # Exploit the fact that events cannot overlap...
         # Loop over veto intervals until:
         #   - current veto interval endtime starts overlapping with 
@@ -505,14 +518,14 @@ def _abs_time_to_prev_next(things, intervals, times_to_prev, times_to_next):
             _interval_start_after_thing = veto_interval['time'] >= current_event_time
             if _interval_start_after_thing:             
                 break
-            
+
             # Always update endtime until it becomes negative:
             dt = current_event_time - strax.endtime(veto_interval)
             _ends_befor_event = dt >= 0
             if _ends_befor_event:
                 times_to_prev[thing_ind] = dt
                 veto_intervals_seen += 1
-        
+
         # Now check if current veto is still within event or already after it:
         for veto_interval in intervals[veto_intervals_seen:]:
             _current_interval_before_thing_ends = veto_interval['time'] < current_event_endtime
@@ -520,7 +533,7 @@ def _abs_time_to_prev_next(things, intervals, times_to_prev, times_to_next):
                 continue
 
             # Now current veto is after event so store time:
-            times_to_next[thing_ind] = veto_interval['time']  - current_event_endtime
+            times_to_next[thing_ind] = veto_interval['time'] - current_event_endtime
             break
-            
+
         veto_intervals_seen = max(0, veto_intervals_seen-1)

--- a/tests/test_general_processing.py
+++ b/tests/test_general_processing.py
@@ -322,33 +322,24 @@ def test_sort_by_time(time, channel):
     assert np.all(res1 == res2)
 
     _test_sort_by_time_peaks(time)
-    
-    
+
+
 def _test_sort_by_time_peaks(time):
-    """Explicit test to check if peaks a re sorted correctly.
+    """
+    Explicit test to check if peaks a re sorted correctly.
     """
     dummy_array = np.zeros(len(time), strax.time_fields 
                             + [(('dummy_channel_number', 'channel'), np.int16)]
                            )
     dummy_array['time'] = time
     dummy_array['channel'] = -1
-    
+
     res1 = strax.sort_by_time(dummy_array)
     res2 = np.sort(dummy_array, order='time')
     assert np.all(res1 == res2)
 
-    
+
 class Test_abs_time_to_prev_next_interval(unittest.TestCase):
-
-    def test_overlapping_raises_error(self):
-        events = np.zeros(2, strax.time_fields)
-        vetos = np.zeros(1, strax.time_fields)
-
-        events['time'] = [5, 10]
-        events['endtime'] = [15, 20]
-        self.assertRaises(AssertionError, strax.abs_time_to_prev_next_interval, events, vetos)
-
-        
     def test_empty_inputs(self):
         events = np.zeros(1, strax.time_fields)
         vetos = np.zeros(0, strax.time_fields)
@@ -373,10 +364,9 @@ class Test_abs_time_to_prev_next_interval(unittest.TestCase):
         vetos = np.zeros(0, strax.time_fields)
         res_prev, res_next = strax.abs_time_to_prev_next_interval(events, vetos)
 
-    
     def test_with_dt_fields(self):
         pass
-    
+
     @hypothesis.given(things=
                       hyp_numpy.arrays(np.int64,
                     hypothesis.strategies.integers(1, 10),
@@ -388,7 +378,7 @@ class Test_abs_time_to_prev_next_interval(unittest.TestCase):
                        elements=hypothesis.strategies.integers(0, 100),
                        unique=True),
         )
-    
+
     @hypothesis.settings(deadline=None)
     def test_correct_time_delays(self, things, intervals):
         _things, _intervals = self._make_correct_things_and_intervals(things, intervals)
@@ -399,37 +389,37 @@ class Test_abs_time_to_prev_next_interval(unittest.TestCase):
             dt_prev = e['time'] - _intervals['endtime'] 
             dt_prev[dt_prev < 0] = 99999
             dt_prev = np.min(dt_prev)
-            
+
             msg = (f'Found {res_prev[thing_i]}, but expected {dt_prev}'
             f' for thing number {thing_i} of things: {_things} and intervals: {_intervals}')
             if res_prev[thing_i] != -1:
                 assert dt_prev == res_prev[thing_i], msg
             else:
                 assert dt_prev == 99999, msg
-            
+
             dt_next = _intervals['time']  - e['endtime'] 
             dt_next[dt_next < 0] = 99999
             dt_next = np.min(dt_next)
-            
+
             msg = (f'Found {res_next[thing_i]}, but expected {dt_next}'
             f' for thing number {thing_i} of things: {_things} and intervals: {_intervals}')
             if res_next[thing_i] != -1:
                 assert dt_next == res_next[thing_i], msg
             else:
                 assert dt_next == 99999, msg
-                
+
     def _make_correct_things_and_intervals(self, things, intervals):
         _things = np.zeros(len(things), strax.time_fields)
         _things['time'] = things
         _things['endtime'] = things + 100
-        
+
         _intervals = np.zeros(len(intervals), strax.time_fields)
         _intervals['time'] = intervals
         _intervals['endtime'] = intervals + 10
-        
+
         _things = strax.sort_by_time(_things)
         _intervals = strax.sort_by_time(_intervals)
-        
+
         # Cut down overlapping _things and remove empty intervals to not 
         # trigger overlapping error:
         dt = _things['endtime'][:-1] - _things['time'][1:]
@@ -437,5 +427,5 @@ class Test_abs_time_to_prev_next_interval(unittest.TestCase):
         _things['endtime'][:-1] = _things['endtime'][:-1] - dt
         _is_not_empty_interval =( _things['endtime'] - _things['time']) > 0
         _things = _things[_is_not_empty_interval]
-        
+
         return _things, _intervals    


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Sometimes `things` in `abs_time_to_prev_next_interval` might be overlapping, or the `endtime` might be not sorted. So throw warning instead of error, following the logic of `touching_windows`. 

**Can you briefly describe how it works?**

Just change the warning logic, the algorithm is not changed. 

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
