### PR TITLE
Waveform attributes

### DIFF
--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -102,7 +102,7 @@ def compute_widths(peaks, select_peaks_indices=None):
     peaks['area_decile_from_midpoint'][select_peaks_indices] = fr_times[:, ::2] - fr_times[:, i].reshape(-1,1)
 
 @export
-@numba.njit(nopython=True, cache=True)
+#@numba.njit(nopython=True, cache=True)
 def compute_wf_attributes(data, sample_length, n_samples: int, downsample_wf=False):
     """
     Compute waveform attribures
@@ -111,15 +111,18 @@ def compute_wf_attributes(data, sample_length, n_samples: int, downsample_wf=Fal
     i.e. n_samples = 10, then quantiles are equivalent deciles 
     Waveforms: downsampled waveform to n_samples
     :param data: waveform e.g. peaks or peaklets
-    :param n_samples: number of samples 
+    :param n_samples: compute quantiles for a given number of samples 
     :return: waveforms and quantiles of size n_samples
     """    
     assert len(data) == len(sample_length), "ararys must have same size"
 
+    num_samples = data.shape[1]
+
     waveforms = np.zeros((len(data), n_samples), dtype=np.float64)
     quantiles = np.zeros((len(data), n_samples), dtype=np.float64)
+    # Cannot compute with with more samples than actual waveform sample
+    assert num_samples > n_samples, "cannot compute with more samples than the actual waveform"
 
-    num_samples = data.shape[1]
     step_size = int(num_samples / n_samples)
     steps = np.arange(0, num_samples + 1, step_size)
     inter_points = np.linspace(0., 1. - (1. / n_samples), n_samples)

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -102,7 +102,7 @@ def compute_widths(peaks, select_peaks_indices=None):
     peaks['area_decile_from_midpoint'][select_peaks_indices] = fr_times[:, ::2] - fr_times[:, i].reshape(-1,1)
 
 @export
-#@numba.njit(nopython=True, cache=True)
+@numba.jit(nopython=True, cache=True)
 def compute_wf_attributes(data, sample_length, n_samples: int, downsample_wf=False):
     """
     Compute waveform attribures

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -120,8 +120,11 @@ def compute_wf_attributes(data, sample_length, n_samples: int, downsample_wf=Fal
 
     waveforms = np.zeros((len(data), n_samples), dtype=np.float64)
     quantiles = np.zeros((len(data), n_samples), dtype=np.float64)
+
+    assert np.all(data == 0), "cannot compute a zero waveform"
     # Cannot compute with with more samples than actual waveform sample
     assert num_samples > n_samples, "cannot compute with more samples than the actual waveform"
+
 
     step_size = int(num_samples / n_samples)
     steps = np.arange(0, num_samples + 1, step_size)
@@ -134,17 +137,15 @@ def compute_wf_attributes(data, sample_length, n_samples: int, downsample_wf=Fal
         # reset buffers
         frac_of_cumsum[:] = 0
         cumsum_steps[:] = 0
-
         frac_of_cumsum[1:] = np.cumsum(samples)
         frac_of_cumsum[1:] = frac_of_cumsum[1:] / frac_of_cumsum[-1]
-
         cumsum_steps[:-1] = np.interp(inter_points, frac_of_cumsum, sample_number_div_dt * dt)
         cumsum_steps[-1] = sample_number_div_dt[-1] * dt
         quantiles[i] = cumsum_steps[1:] - cumsum_steps[:-1]
-    
-        for j in range(n_samples if downsample_wf else 0):
-            waveforms[i][j] = np.sum(samples[steps[j]:steps[j + 1]])
-        waveforms[i] /= (step_size * dt)
-
+   
+        if downsample_wf:
+            
+            for j in range(n_samples):
+                waveforms[i][j] = np.sum(samples[steps[j]:steps[j + 1]])
+            waveforms[i] /= (step_size * dt)
     return quantiles, waveforms
-    

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -114,14 +114,13 @@ def compute_wf_attributes(data, sample_length, n_samples: int, downsample_wf=Fal
     :param n_samples: compute quantiles for a given number of samples 
     :return: waveforms and quantiles of size n_samples
     """    
-    assert len(data) == len(sample_length), "ararys must have same size"
+    assert data.shape[0] == len(sample_length), "ararys must have same size"
 
     num_samples = data.shape[1]
 
     waveforms = np.zeros((len(data), n_samples), dtype=np.float64)
     quantiles = np.zeros((len(data), n_samples), dtype=np.float64)
 
-    assert np.all(data == 0), "cannot compute a zero waveform"
     # Cannot compute with with more samples than actual waveform sample
     assert num_samples > n_samples, "cannot compute with more samples than the actual waveform"
 
@@ -132,8 +131,9 @@ def compute_wf_attributes(data, sample_length, n_samples: int, downsample_wf=Fal
     cumsum_steps = np.zeros(n_samples + 1, dtype=np.float64)
     frac_of_cumsum = np.zeros(num_samples + 1)
     sample_number_div_dt = np.arange(0, num_samples + 1, 1)
-
     for i, (samples, dt) in enumerate(zip(data, sample_length)):
+        if np.sum(samples) == 0: 
+            continue
         # reset buffers
         frac_of_cumsum[:] = 0
         cumsum_steps[:] = 0

--- a/tests/test_peak_properties.py
+++ b/tests/test_peak_properties.py
@@ -100,7 +100,9 @@ def test_compute_wf_attributes(peak_length, data_length, n_widths):
 
     try:        
         q, wf = strax.compute_wf_attributes(peaks['data'], peaks['dt'], 10, True)
+    except AssertionError:
+        print("cannot compute with a zero waveform")
     except AssertionError: 
         print("cannot compute with more samples than the actual waveform") 
-            
+
     assert np.all(~np.isnan(q)) and np.all(~np.isnan(wf)), "attributes contains NaN values"

--- a/tests/test_peak_properties.py
+++ b/tests/test_peak_properties.py
@@ -79,3 +79,14 @@ def test_compute_widths(peak_length, data_length, n_widths):
         mess = ("Highly unlikely that from at least 10 positive area peaks "
                 "none were able to compute the width")
         assert np.any(peaks['width'] != pre_peaks['width']), mess
+
+def test_compute_wf_attributes(data, sample_length, n_samples):
+    """
+    Test strax.compute_wf_attribute
+    """
+    peaks = get_filled_peaks(peak_length, data_length, n_widths)
+
+    d, wf = strax.compute_wf_attribures(peaks['data'], peaks['dt'], 10, True)
+    assert d.size > 0  and wf.size > 0, "Emtpy arrays"
+
+    assert np.all(~np.isnan(d)) and np.all(~np.isnan(wf)), "attributes contains NaN values"

--- a/tests/test_peak_properties.py
+++ b/tests/test_peak_properties.py
@@ -100,9 +100,10 @@ def test_compute_wf_attributes(peak_length, data_length, n_widths):
 
     try:        
         q, wf = strax.compute_wf_attributes(peaks['data'], peaks['dt'], 10, True)
-    except AssertionError:
-        print("cannot compute with a zero waveform")
-    except AssertionError: 
-        print("cannot compute with more samples than the actual waveform") 
+    except AssertionError as e:
+        if "zero waveform" in str(e):
+            print("cannot compute with a zero waveform")
+        elif "more samples than the actual waveform" in str(e):
+            print("cannot compute with more samples than the actual waveform")
 
     assert np.all(~np.isnan(q)) and np.all(~np.isnan(wf)), "attributes contains NaN values"


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
this function computes quantiles and can downsample waveforms, either for records, peaklets, peak
**Can you briefly describe how it works?**
Compute waveform attribures
Quantiles: represent the amount of time elapsed for a given fraction of the total waveform area to be observed in n_samples  i.e. n_samples = 10, then quantiles are equivalent deciles
**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
