### PR TITLE
Add small selection functions

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1205,6 +1205,7 @@ class Context:
                  seconds_range=None,
                  time_within=None,
                  time_selection='fully_contained',
+                 selection=None,
                  selection_str=None,
                  keep_columns=None,
                  drop_columns=None,
@@ -1306,6 +1307,7 @@ class Context:
                     result.data = strax.apply_selection(
                         result.data,
                         selection_str=selection_str,
+                        selection=selection,
                         keep_columns=keep_columns,
                         drop_columns=drop_columns,
                         time_range=time_range,
@@ -2110,7 +2112,10 @@ class Context:
 
 
 select_docs = """
-:param selection_str: Query string or sequence of strings to apply.
+:param selection: Query string, sequence of strings, or simple function to apply.
+    The function must take a single argument which represents the structure 
+    numpy array of the loaded data.
+:param selection_str: Same as selection (deprecated)
 :param keep_columns: Array field/dataframe column names to keep. 
     Useful to reduce amount of data in memory. (You can only specify 
     either keep or drop column.)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -115,7 +115,29 @@ def test_selection_str(d):
     mask = (d['data'] > mean_data) & (d['data'] < max_data)
     selections_str = [f'data > {mean_data}', 
                       f'data < {max_data}']
-    selected_data = strax.apply_selection(d, selection_str=selections_str)
+    selected_data = strax.apply_selection(d, selection=selections_str)
+    assert np.all(selected_data == d[mask])
+
+
+@settings(deadline=None)
+@given(get_dummy_data(
+    data_length=(1, 10),
+    dt=(1, 10),
+    max_time=(1, 20)))
+def test_selection_function(d):
+    """
+    Test selection string. We are going for this example check that
+        selecting the data based on the data field is the same as if we
+        were to use a mask NB: data must have some length!
+
+    :param d: test-data from get_dummy_data
+    :return: None
+    """
+    mean_data = np.mean(d['data'])
+    max_data = np.max(d['data'])
+    mask = (d['data'] > mean_data) & (d['data'] < max_data)
+    selections_function = lambda data: (data['data'] > mean_data) & (d['data'] < max_data)
+    selected_data = strax.apply_selection(d, selection=selections_function)
     assert np.all(selected_data == d[mask])
 
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
In this PR we extend the selection_str feature to allow to pass arbitrary small or more complex functions for the data selection, e.g., one could pass a function like:

```python
def s2_width_cut(events):
    ....
st.get_array(run, 'event_info', selection=s2_width_cut)
``` 

The selection function must take only a single argument which represents the data array itself. For example functions which take additional parameters must be reduced first:

```python
def s2_width_cut(events, para1, para2):
    ....
st.get_array(run, 'event_info', selection=lambda x: s2_width_cut(x, para1=1, para2=2))
```