### PR TITLE
Split compare_metadata into utils.compare_meta

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1702,7 +1702,7 @@ class Context:
         else:
             raise ValueError(f"Expected old_metadata as `str` or `dict` got {type(old_metadata)}")
 
-        strax.util.compare_meta(old_metadata, new_metadata)
+        strax.util.compare_dict(old_metadata, new_metadata)
 
     def run_metadata(self, run_id, projection=None) -> dict:
         """

--- a/strax/context.py
+++ b/strax/context.py
@@ -1702,7 +1702,7 @@ class Context:
         else:
             raise ValueError(f"Expected old_metadata as `str` or `dict` got {type(old_metadata)}")
 
-        strax.util.compare_dict(old_metadata, new_metadata)
+        strax.utils.compare_dict(old_metadata, new_metadata)
 
     def run_metadata(self, run_id, projection=None) -> dict:
         """

--- a/strax/context.py
+++ b/strax/context.py
@@ -8,8 +8,6 @@ import time
 import json
 import numpy as np
 import pandas as pd
-import click
-import deepdiff
 import strax
 import inspect
 import types
@@ -1690,9 +1688,6 @@ class Context:
         :param old_metadata: path to metadata to compare, or a dictionary, or a tuple with
             another run_id, target to compare against the metadata of the first id-target pair
         """
-        color_values = lambda oldval, newval: (
-            click.style(oldval, fg='red', bold=True), click.style(newval, fg='green', bold=True))
-        underline = lambda text, bold=True: click.style(text, bold=bold, underline=True)
 
         # new metadata for the given runid + target; fetch from context
         new_metadata = self.get_metadata(run_id, target)
@@ -1707,39 +1702,7 @@ class Context:
         else:
             raise ValueError(f"Expected old_metadata as `str` or `dict` got {type(old_metadata)}")
 
-        differences = deepdiff.DeepDiff(old_metadata, new_metadata)
-        for key, value in differences.items():
-            if key in ['values_changed', 'iterable_item_added', 'iterable_item_removed']:
-                print(underline(f"\n> {key}"))
-                for kk, vv in value.items():
-                    if key == "values_changed":
-                        old_values = vv['old_value']
-                        new_values = vv['new_value']
-                    elif key == "iterable_item_added":
-                        old_values = "-"
-                        new_values = vv
-                    else:  # if key == "iterable_item_removed":
-                        old_values = vv
-                        new_values = "-"
-                    old, new = color_values(old_values, new_values)
-                    click.secho(f"\t in {kk[4:]}", bold=False)
-                    print(f"\t\t{old} -> {new}")
-            elif key in ['dictionary_item_added', 'dictionary_item_removed']:
-                color = "red" if "removed" in key else "green"
-                print(underline(f"\n> {key:25s}"), end="->")
-                click.secho(f"\t{', '.join(value)}", fg=color)
-            elif key in ['type_changes']:
-                print(underline(f"\n> {key}"))
-                for kk, vv in value.items():
-                    click.secho(f"\t{kk}")
-                    oldtype = vv['old_type']
-                    newtype = vv['new_type']
-                    keyold, keynew = color_values('old_type', 'new_type')
-                    valueold, valuenew = color_values(vv['old_value'], vv['new_value'])
-                    print(f"\t\t{keyold:10s} : {oldtype} ({valueold})")
-                    print(f"\t\t{keynew:10s} : {newtype} ({valuenew})")
-            else:
-                raise KeyError(f"Unkown key in comparison {key}")
+        strax.util.compare_meta(old_metadata, new_metadata)
 
     def run_metadata(self, run_id, projection=None) -> dict:
         """


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Split `compare_metadata` into `utils.compare_dict`, to use `utils.compare_dict` somewhere else.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
