### PR TITLE
Change endtime - time >= 0 to endtime >= time

### DIFF
--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -448,7 +448,7 @@ def _check_time_is_sorted(time):
 @numba.jit(nopython=True, nogil=True, cache=True)
 def _check_objects_non_negative_length(objects):
     """Checks if objects have non-negative length"""
-    mask = np.all(strax.endtime(objects) - objects['time'] >= 0)
+    mask = np.all(strax.endtime(objects) >= objects['time'])
     assert mask
 
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
`strax._check_objects_non_negative_length` checks to see if there are any data entries such that endtime-time >=0. However, when there is an error in the endtime such that endtime is very negative, endtime - time sees an overflow error, and native python would have endtime - time >0. Such an example can be seen in pema (see PR: [#333](https://github.com/XENONnT/pema/pull/333)) As such, native python would not detect such cases using _check_objects_non_negative_length. In actuality, it seems that numba has a check which somehow bypasses this overflow error, and detects such cases anyway but this is an instance of unexpected behavior.

**Can you briefly describe how it works?**
Simply change the statement `np.all(strax.endtime(things) - things['time'] >=0)` to `np.all(strax.endtime(things) >= things['time'])` .

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
