### PR TITLE
Mandatorily wrap `_read_chunk` in a `check_chunk_n` decorator

### DIFF
--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -403,6 +403,13 @@ class StorageBackend:
     these have to be hardcoded (or made part of the key).
     """
 
+    def __new__(cls, *args, **kwargs):
+        """Mandatorily wrap _read_chunk in a check_chunk_n decorator"""
+        if '_read_chunk' in cls.__dict__:
+            method = getattr(cls, '_read_chunk')
+            setattr(cls, '_read_chunk', strax.check_chunk_n(method))
+        return super(StorageBackend, cls).__new__(cls)
+
     def loader(self,
                backend_key,
                time_range=None,

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -251,7 +251,6 @@ class FileSytemBackend(strax.StorageBackend):
             chunk.target_size_mb = self.set_chunk_size_mb
         return chunk
 
-    @strax.check_chunk_n
     def _read_chunk(self, dirname, chunk_info, dtype, compressor):
         fn = osp.join(dirname, chunk_info['filename'])
         return strax.load_file(fn, dtype=dtype, compressor=compressor)

--- a/strax/storage/mongo.py
+++ b/strax/storage/mongo.py
@@ -45,7 +45,6 @@ class MongoBackend(StorageBackend):
         self._buff_mb = DEFAULT_MONGO_BACKEND_BUFFER_MB
         self._buff_nruns = DEFAULT_MONGO_BACKEND_BUFFER_NRUNS
 
-    @strax.check_chunk_n
     def _read_chunk(self, backend_key, chunk_info, dtype, compressor):
         """See strax.Backend"""
         chunk_i = chunk_info["chunk_i"]

--- a/strax/storage/zipfiles.py
+++ b/strax/storage/zipfiles.py
@@ -104,8 +104,6 @@ class ZipDirectory(strax.StorageFrontend):
 
 @export
 class ZipFileBackend(strax.StorageBackend):
-
-    @strax.check_chunk_n
     def _read_chunk(self, zipn_and_dirn, chunk_info, dtype, compressor):
         zipn, dirn = zipn_and_dirn
         with zipfile.ZipFile(zipn) as zp:


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

To ease the workflow of developing a new `StorageBackend`, the PR mandatorily wraps `_read_chunk` in a `check_chunk_n` decorator instead.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
