### PR TITLE
Deregister partially replaced multi-output plugins

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -9,6 +9,7 @@ import os
 import unittest
 import shutil
 import uuid
+import pytest
 
 
 def _apply_function_to_data(function) -> ty.Tuple[np.ndarray, np.ndarray]:
@@ -223,6 +224,33 @@ class TestContext(unittest.TestCase):
         assert (
             not_cached_plugins.keys() == cached_plugins.keys()
         ), f"_get_plugins returns different plugins if cached!"
+
+    def test_multioutput_deregistration(self):
+        """Test that a multi-output plugin is deregistered once
+        one of its outputs is provided by another plugin"""
+
+        class RecordsPlus(strax.Plugin):
+            depends_on = tuple()
+            data_kind = dict(
+                records='records',
+                plus='plus'
+            )
+            dtype = dict(
+                records=strax.record_dtype(),
+                plus=strax.record_dtype())
+            provides = ('records', 'plus')
+
+        st = self.get_context(False)
+        st.register(RecordsPlus)
+        st.register(Records)
+
+        # Records will make the records, not RecordsPlus
+        plugins = st._get_plugins(('records',), run_id)
+        assert isinstance(plugins['records'], Records)
+
+        # Plus is no longer available.
+        with pytest.raises(KeyError):
+            plugins = st.key_for('plus', run_id)
 
     def test_register_no_defaults(self, runs_default_allowed=False):
         """Test if we only register a plugin with no run-defaults."""

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -226,31 +226,26 @@ class TestContext(unittest.TestCase):
         ), f"_get_plugins returns different plugins if cached!"
 
     def test_multioutput_deregistration(self):
-        """Test that a multi-output plugin is deregistered once
-        one of its outputs is provided by another plugin"""
+        """Test that a multi-output plugin is deregistered once one of its outputs is provided by
+        another plugin."""
 
         class RecordsPlus(strax.Plugin):
             depends_on = tuple()
-            data_kind = dict(
-                records='records',
-                plus='plus'
-            )
-            dtype = dict(
-                records=strax.record_dtype(),
-                plus=strax.record_dtype())
-            provides = ('records', 'plus')
+            data_kind = dict(records="records", plus="plus")
+            dtype = dict(records=strax.record_dtype(), plus=strax.record_dtype())
+            provides = ("records", "plus")
 
         st = self.get_context(False)
         st.register(RecordsPlus)
         st.register(Records)
 
         # Records will make the records, not RecordsPlus
-        plugins = st._get_plugins(('records',), run_id)
-        assert isinstance(plugins['records'], Records)
+        plugins = st._get_plugins(("records",), run_id)
+        assert isinstance(plugins["records"], Records)
 
         # Plus is no longer available.
         with pytest.raises(KeyError):
-            plugins = st.key_for('plus', run_id)
+            plugins = st.key_for("plus", run_id)
 
     def test_register_no_defaults(self, runs_default_allowed=False):
         """Test if we only register a plugin with no run-defaults."""


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Bad things happen if plugin A registers to make X and Y, then B registers to make just X.

For example, strax's will first say B is producing X, as it should. Then you ask who is producing Y, it will say A. But now ask again who is producing X -- strax changes its mind and says A is producing X!

This happens because these 'partial registrations' break the assumptions of the plugin caching system. But that won't be all: if we actually tried to make Y the Processor shouldn't be smart enough to make two X's and throw away the bad one. Even if it was, would a user asking for X and Y really expect them to come from two different plugins?

**Can you briefly describe how it works?**

This PR ensures a plugin is completely deregistered once another plugin is registered to provide one of its outputs instead. In the example above, A would be completely deregistered and datatype Y would be no longer available in the context as soon as B registers to produce X.

**Can you give a minimal working example (or illustrate with a figure)?**

Surprisingly this happens in several places in straxen/cutax. For example:
```python
import cutax
st = cutax.xenonnt_online()
st._get_plugins(['raw_records'], '026195')
```
gives
```
{'raw_records': Fake1TDAQReader,
 'raw_records_diagnostic': Fake1TDAQReader,
 'raw_records_aqmon': Fake1TDAQReader}
 ```
which makes no sense, `Fake1TDAQReader` is an ancient plugin. We only register it temporarily, then overwrite it with the actual `DAQReader`. However, it is still registered for `raw_records_diagnostic`, which does not exist in nT. When cutax asks for the lineage of `raw_records_diagnostic` on intialization, the plugin cache becomes polluted. If you actually try to make raw_records with this context, or even just do storage conversion, you will not go to space today.

A similar thing happens for straxen's `PeakletClassificationSOM` (registers for `som_peaklet_data` and `peaklet_classification`, then another plugin takes over `peaklet_classification`) and several neutron veto cut plugins in cutax (all produce `cut_coincident_events_nv` as well as another datatype that varies per plugin).