### PR TITLE
Also copy dps and remove redundant checks.

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -689,6 +689,10 @@ class Context:
             for provides in strax.to_str_tuple(requested_p.provides):
                 requested_plugins[provides] = requested_p
 
+        # Finally, fix the dtype.
+        for plugin in requested_plugins.values():
+            plugin.fix_dtype()
+
         requested_plugins = {i: v for i, v in requested_plugins.items() if i in targets}
         return requested_plugins
 

--- a/strax/context.py
+++ b/strax/context.py
@@ -667,16 +667,6 @@ class Context:
         for target, plugin in plugins.items():
             self._fixed_plugin_cache[context_hash][target] = plugin
 
-    def _fix_dependency(self, plugin_registry: dict, end_plugin: str):
-        """Starting from end-plugin, fix the dtype until there is nothing left to fix.
-
-        Keep in mind that dtypes can be chained.
-
-        """
-        for go_to in plugin_registry[end_plugin].depends_on:
-            self._fix_dependency(plugin_registry, go_to)
-        plugin_registry[end_plugin].fix_dtype()
-
     def __get_requested_plugins_from_cache(
         self,
         run_id: str,
@@ -685,8 +675,8 @@ class Context:
         # Doubly underscored since we don't do any key-checks etc here
         """Load requested plugins from the plugin_cache."""
         requested_plugins = {}
-        cached_plugins = self._fixed_plugin_cache[self._context_hash()]
-        for target, plugin in cached_plugins.items():  # type: ignore
+        cached_plugins = self._fixed_plugin_cache[self._context_hash()]  # type: ignore
+        for target, plugin in cached_plugins.items():
             if target in requested_plugins:
                 # If e.g. target is already seen because the plugin is
                 # multi output

--- a/strax/context.py
+++ b/strax/context.py
@@ -677,7 +677,11 @@ class Context:
             self._fix_dependency(plugin_registry, go_to)
         plugin_registry[end_plugin].fix_dtype()
 
-    def __get_plugins_from_cache(self, run_id: str) -> ty.Dict[str, strax.Plugin]:
+    def __get_requested_plugins_from_cache(
+        self,
+        run_id: str,
+        targets: ty.Tuple[str],
+    ) -> ty.Dict[str, strax.Plugin]:
         # Doubly underscored since we don't do any key-checks etc here
         """Load requested plugins from the plugin_cache."""
         requested_plugins = {}
@@ -703,15 +707,20 @@ class Context:
             plugin.deps = {
                 dependency: requested_plugins[dependency] for dependency in plugin.depends_on
             }
+
         # Finally, fix the dtype. Since infer_dtype may depend on the
         # entire deps chain, we need to start at the last plugin and go
         # all the way down to the lowest level.
-        for final_plugins in self._get_end_targets(requested_plugins):
-            self._fix_dependency(requested_plugins, final_plugins)
+        for target_plugins in targets:
+            self._fix_dependency(requested_plugins, target_plugins)
+
+        requested_plugins = {i: v for i, v in requested_plugins.items() if i in targets}
         return requested_plugins
 
     def _get_plugins(
-        self, targets: ty.Union[ty.Tuple[str], ty.List[str]], run_id: str
+        self,
+        targets: ty.Union[ty.Tuple[str], ty.List[str]],
+        run_id: str,
     ) -> ty.Dict[str, strax.Plugin]:
         """Return dictionary of plugin instances necessary to compute targets from scratch.
 
@@ -719,21 +728,6 @@ class Context:
         referenced under multiple keys in the output dict.
 
         """
-        if self._plugins_are_cached(targets):
-            cached_plugins = self.__get_plugins_from_cache(run_id)
-            plugins = {}
-            targets = list(targets)
-            while targets:
-                target = targets.pop(0)
-                if target in plugins:
-                    continue
-
-                target_plugin = cached_plugins[target]
-                for provides in target_plugin.provides:
-                    plugins[provides] = target_plugin
-                targets += list(target_plugin.depends_on)
-            return plugins
-
         # Check all config options are taken by some registered plugin class
         # (helps spot typos)
         all_opts = set().union(*[
@@ -743,98 +737,126 @@ class Context:
             if not (k in all_opts or k in self.context_config["free_options"]):
                 self.log.warning(f"Option {k} not taken by any registered plugin")
 
-        # Initialize plugins for the entire computation graph
-        # (most likely far further down than we need)
-        # to get lineages and dependency info.
-        def get_plugin(data_type):
-            nonlocal non_local_plugins
+        plugins = {}
+        targets = list(targets)
+        safety_counter = 0
+        while targets and safety_counter < 10_000:
+            safety_counter += 1
+            targets = list(set(targets))  # Remove duplicates from list.
+            target = targets.pop(0)
+            if target in plugins:
+                continue
 
-            if data_type not in self._plugin_class_registry:
-                raise KeyError(f"No plugin class registered that provides {data_type}")
+            target_plugin = self.__get_plugin(run_id, target)
+            for provides in target_plugin.provides:
+                plugins[provides] = target_plugin
+            targets += list(target_plugin.depends_on)
 
-            plugin = self._plugin_class_registry[data_type]()
+        _not_all_plugins_initalized = (safety_counter == 10_000) & len(targets)
+        if _not_all_plugins_initalized:
+            raise ValueError(
+                "Could not initalize all plugins to compute target from scratch. "
+                f"The reamining targets missing are: {targets}"
+            )
 
-            d_provides = None  # just to make codefactor happy
-            for d_provides in plugin.provides:
-                non_local_plugins[d_provides] = plugin
+        return plugins
 
-            plugin.run_id = run_id
+    def __get_plugin(self, run_id: str, data_type: str):
+        """Get single plugin either from cache or initialize it."""
+        # Check if plugin for data_type is already cached
+        if self._plugins_are_cached((data_type,)):
+            cached_plugins = self.__get_requested_plugins_from_cache(run_id, (data_type,))
+            target_plugin = cached_plugins[data_type]
+            return target_plugin
 
-            # The plugin may not get all the required options here
-            # but we don't know if we need the plugin yet
-            self._set_plugin_config(plugin, run_id, tolerant=True)
+        if data_type not in self._plugin_class_registry:
+            raise KeyError(f"No plugin class registered that provides {data_type}")
 
-            plugin.deps = {d_depends: get_plugin(d_depends) for d_depends in plugin.depends_on}
+        plugin = self._plugin_class_registry[data_type]()
 
-            last_provide = d_provides
+        plugin.run_id = run_id
 
-            if plugin.child_plugin:
-                # Plugin is a child of another plugin, hence we have to
-                # drop the parents config from the lineage
-                configs = {}
+        # The plugin may not get all the required options here
+        # but we don't know if we need the plugin yet
+        self._set_plugin_config(plugin, run_id, tolerant=True)
 
-                # Getting information about the parent:
-                parent_class = plugin.__class__.__bases__[0]
-                # Get all parent options which are overwritten by a child:
-                parent_options = [
-                    option.parent_option_name
-                    for option in plugin.takes_config.values()
-                    if option.child_option
-                ]
+        plugin.deps = {
+            d_depends: self.__get_plugin(run_id, d_depends) for d_depends in plugin.depends_on
+        }
 
-                for option_name, v in plugin.config.items():
-                    # Looping over all settings, option_name is either the option name of the
-                    # parent or the child.
-                    if option_name in parent_options:
-                        # In case it is the parent we continue
-                        continue
+        self.__add_lineage_to_plugin(run_id, plugin)
 
-                    if plugin.takes_config[option_name].track:
-                        # Add all options which should be tracked:
-                        configs[option_name] = v
-
-                # Also adding name and version of the parent to the lineage:
-                configs[parent_class.__name__] = parent_class.__version__
-
-                plugin.lineage = {
-                    last_provide: (plugin.__class__.__name__, plugin.version(run_id), configs)
-                }
+        if not hasattr(plugin, "data_kind") and not plugin.multi_output:
+            if len(plugin.depends_on):
+                # Assume data kind is the same as the first dependency
+                first_dep = plugin.depends_on[0]
+                plugin.data_kind = plugin.deps[first_dep].data_kind_for(first_dep)
             else:
-                plugin.lineage = {
-                    last_provide: (
-                        plugin.__class__.__name__,
-                        plugin.version(run_id),
-                        {
-                            option: setting
-                            for option, setting in plugin.config.items()
-                            if plugin.takes_config[option].track
-                        },
-                    )
-                }
-            for d_depends in plugin.depends_on:
-                plugin.lineage.update(plugin.deps[d_depends].lineage)
+                # No dependencies: assume provided data kind and
+                # data type are synonymous
+                plugin.data_kind = plugin.provides[0]
 
-            if not hasattr(plugin, "data_kind") and not plugin.multi_output:
-                if len(plugin.depends_on):
-                    # Assume data kind is the same as the first dependency
-                    first_dep = plugin.depends_on[0]
-                    plugin.data_kind = plugin.deps[first_dep].data_kind_for(first_dep)
-                else:
-                    # No dependencies: assume provided data kind and
-                    # data type are synonymous
-                    plugin.data_kind = plugin.provides[0]
+        plugin.fix_dtype()
 
-            plugin.fix_dtype()
+        # Add plugin to cache
+        self._plugins_to_cache({data_type: plugin for data_type in plugin.provides})
 
-            return plugin
+        return plugin
 
-        non_local_plugins = {}
-        for t in targets:
-            p = get_plugin(t)
-            non_local_plugins[t] = p
+    def __add_lineage_to_plugin(self, run_id, plugin):
+        """Adds lineage to plugin in place.
 
-        self._plugins_to_cache(non_local_plugins)
-        return non_local_plugins
+        Also adds parent infromation in case of a child plugin.
+
+        """
+        last_provide = [d_provides for d_provides in plugin.provides][-1]
+
+        if plugin.child_plugin:
+            # Plugin is a child of another plugin, hence we have to
+            # drop the parents config from the lineage
+            configs = {}
+
+            # Getting information about the parent:
+            parent_class = plugin.__class__.__bases__[0]
+            # Get all parent options which are overwritten by a child:
+            parent_options = [
+                option.parent_option_name
+                for option in plugin.takes_config.values()
+                if option.child_option
+            ]
+
+            for option_name, v in plugin.config.items():
+                # Looping over all settings, option_name is either the option name of the
+                # parent or the child.
+                if option_name in parent_options:
+                    # In case it is the parent we continue
+                    continue
+
+                if plugin.takes_config[option_name].track:
+                    # Add all options which should be tracked:
+                    configs[option_name] = v
+
+            # Also adding name and version of the parent to the lineage:
+            configs[parent_class.__name__] = parent_class.__version__
+
+            plugin.lineage = {
+                last_provide: (plugin.__class__.__name__, plugin.version(run_id), configs)
+            }
+        else:
+            plugin.lineage = {
+                last_provide: (
+                    plugin.__class__.__name__,
+                    plugin.version(run_id),
+                    {
+                        option: setting
+                        for option, setting in plugin.config.items()
+                        if plugin.takes_config[option].track
+                    },
+                )
+            }
+
+        for d_depends in plugin.depends_on:
+            plugin.lineage.update(plugin.deps[d_depends].lineage)
 
     def _per_run_default_allowed_check(self, option_name, option):
         """Check if an option of a registered plugin is allowed."""

--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -150,7 +150,15 @@ class Plugin:
         # As explained in PR #485 only copy attributes whereof we know
         # don't depend on the run_id (for use_per_run_defaults == False).
         # Otherwise we might copy run-dependent things like to_pe.
-        for attribute in ["dtype", "lineage", "takes_config", "__version__", "config", "data_kind"]:
+        for attribute in [
+            "dtype",
+            "lineage",
+            "takes_config",
+            "__version__",
+            "config",
+            "data_kind",
+            "deps",
+        ]:
             source_value = getattr(self, attribute)
             if _deep_copy:
                 plugin_copy.__setattr__(attribute, deepcopy(source_value))


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
In this follow up PR for https://github.com/AxFoundation/strax/pull/768 we change a bit the plugin caching. The plugin caching was introduced in https://github.com/AxFoundation/strax/pull/483 followed by two fixes in https://github.com/AxFoundation/strax/pull/485 and https://github.com/AxFoundation/strax/pull/545. In https://github.com/AxFoundation/strax/pull/483 it was decided to sacrifice a bit performance over reliability, and thus do not cache for example the `plugin.deps` which also required to rerun `fix_dtype` when loading plugins from cache.

In this PR we add `deps` to the cached plugins and remove the `deps` computation and `_fix_dependency` which calls `fix_dtype` from `__get_requested_plugins_from_cache`.  The change should be justified because we cache all plugins using a deterministic context hash based on the current `_plugin_class_registry`. Thus, if a plugin changes, which potentially changes the `deps` of the plugins, all plugins need to be cached again anyhow. 