### PR TITLE
`np.float` is deprecated

### DIFF
--- a/strax/utils.py
+++ b/strax/utils.py
@@ -462,7 +462,7 @@ def to_numpy_dtype(field_spec):
             dtype.append(x)
         elif len(x) == 1:
             # Omitted type: assume float
-            dtype.append((x, np.float))
+            dtype.append((x, float))
         else:
             raise ValueError(f"Invalid field specification {x}")
     return np.dtype(dtype)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,10 @@ def test_growing_result():
     assert got.dtype == should_get.dtype
 
 
+def test_to_numpy_dtype():
+    strax.to_numpy_dtype(["a", "b"])
+
+
 @hst.composite
 def get_dummy_data(draw, data_length=(0, 10), dt=(1, 10), max_time=(1, 20)):
     """Create some dummy array for testing apply selection. Data may be overlapping.


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

> Using the aliases of builtin types like np.int is deprecated

reference: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

In principle the auto tests in https://github.com/XENONnT/base_environment/pull/1483 will not pass, but the line changed in this PR was never checked:

![image](https://github.com/AxFoundation/strax/assets/40532474/13bc9ff0-5988-4b1d-9262-bf868a739994)

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
