### PR TITLE
Remove NotImplementedError for multi_output in DownChunkingPlugin

### DIFF
--- a/strax/plugins/down_chunking_plugin.py
+++ b/strax/plugins/down_chunking_plugin.py
@@ -26,13 +26,6 @@ class DownChunkingPlugin(Plugin):
                 "currently does not support parallel processing."
             )
 
-        if self.multi_output:
-            raise NotImplementedError(
-                f'Plugin "{self.__class__.__name__}" is a DownChunkingPlugin which '
-                "currently does not support multiple outputs. Please only provide "
-                "a single data-type."
-            )
-
     def iter(self, iters, executor=None):
         return super().iter(iters, executor)
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Right now it is not possible to have a DownChunkingPlugin with multiple outputs. I would like to add truth information handling in fuse and for that I need a second output in the PMTResponseAndDAQ plugin. 

**Can you briefly describe how it works?**
The PR just removes the `NotImplementedError`.

**Can you give a minimal working example (or illustrate with a figure)?**
It was necessary to change how the PMTResponseAndDAQ yields its results a bit but I found no problems running the fuse simulations with the implemented changes. The corresponding fuse PR can be found here: https://github.com/XENONnT/fuse/pull/99.

