### PR TITLE
Add a function to directly load file from strax folder

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -131,6 +131,17 @@ class TestStorageType(TestCase):
 
         return (strax.Context(storage=frontends, **self.context_kwargs), frontend_setup)
 
+    def test_dry_load_files(self):
+        """Test that dry_load_files can load the data."""
+        st, frontend_setup = self.get_st_and_fill_frontends()
+        for sf in st.storage:
+            key = st.key_for(self.run_id, self.target)
+            dirname = os.path.join(sf.path, str(key))
+            strax.io.dry_load_files(dirname)
+            strax.io.dry_load_files(dirname, 0)
+            with self.assertRaises(ValueError):
+                strax.io.dry_load_files(dirname, 99)
+
     def test_close_goes_first_md(self):
         """Let's see that if we get the meta-data, it's from the one with the lowest remoteness.
 


### PR DESCRIPTION
Using only information inside the folder

**What is the problem / what does the code in this PR do**

Sometimes we want to directly load the strax file in a folder, without initializing plugins or context.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

```
results = strax.dry_load_files(dirname)
```
this will load all files inside a folder.

```
results = strax.dry_load_files(dirname, 1)
```
this will load the 2nd chunk inside a folder.

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
