### PR TITLE
Find the frontends which stored the targets

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1990,6 +1990,26 @@ class Context:
         # None of the frontends has the data
         return False
 
+    def find_stored_frontend(self, run_id, target):
+        """Return the frontends that has the data for run_id and targets.
+
+        If target is a tuple or list, return the frontends that has all the data types in the
+        target.
+
+        """
+
+        if isinstance(target, (tuple, list)):
+            if len(target) == 0:
+                raise ValueError("Cannot find stored frontend for empty target!")
+            frontends_list = [self.find_stored_frontend(run_id, t) for t in target]
+            return list(set.intersection(*map(set, frontends_list)))
+
+        frontends = []
+        for sf in self._sorted_storage:
+            if self._is_stored_in_sf(run_id, target, sf):
+                frontends.append(sf)
+        return frontends
+
     def _check_forbidden(self):
         """Check that the forbid_creation_of config is of tuple type.
 

--- a/strax/context.py
+++ b/strax/context.py
@@ -1990,26 +1990,6 @@ class Context:
         # None of the frontends has the data
         return False
 
-    def find_stored_frontend(self, run_id, target):
-        """Return the frontends that has the data for run_id and targets.
-
-        If target is a tuple or list, return the frontends that has all the data types in the
-        target.
-
-        """
-
-        if isinstance(target, (tuple, list)):
-            if len(target) == 0:
-                raise ValueError("Cannot find stored frontend for empty target!")
-            frontends_list = [self.find_stored_frontend(run_id, t) for t in target]
-            return list(set.intersection(*map(set, frontends_list)))
-
-        frontends = []
-        for sf in self._sorted_storage:
-            if self._is_stored_in_sf(run_id, target, sf):
-                frontends.append(sf)
-        return frontends
-
     def _check_forbidden(self):
         """Check that the forbid_creation_of config is of tuple type.
 
@@ -2105,7 +2085,7 @@ class Context:
             target_sf = [self.storage[target_frontend_id]]
 
         # Figure out which of the frontends has the data. Raise error when none
-        source_sf = self._get_source_sf(run_id, target, should_exist=True)
+        source_sf = self.get_source_sf(run_id, target, should_exist=True)[0]
 
         # Keep frontends that:
         #  1. don't already have the data; and
@@ -2295,22 +2275,37 @@ class Context:
         except strax.DataNotAvailable:
             return False
 
-    def _get_source_sf(self, run_id, target, should_exist=False):
-        """Get the source storage frontend for a given run_id and target.
+    def get_source_sf(self, run_id, target, should_exist=False):
+        """Get the source storage frontends for a given run_id and target.
 
         :param run_id, target: run_id, target
         :param should_exist: Raise a ValueError if we cannot find one (e.g. we already checked the
             data is stored)
-        :return: strax.StorageFrontend or None (when raise_error is False)
+        :return: list of strax.StorageFrontend (when should_exist is False)
 
         """
+        if isinstance(target, (tuple, list)):
+            if len(target) == 0:
+                raise ValueError("Cannot find stored frontend for empty target!")
+            frontends_list = [
+                self.get_source_sf(
+                    run_id,
+                    t,
+                    should_exist=should_exist,
+                )
+                for t in target
+            ]
+            return list(set.intersection(*map(set, frontends_list)))
+
+        frontends = []
         for sf in self._sorted_storage:
             if self._is_stored_in_sf(run_id, target, sf):
-                return sf
-        if should_exist:
+                frontends.append(sf)
+        if should_exist and not frontends:
             raise ValueError(
                 "This cannot happen, we just checked that this run should be stored?!?"
             )
+        return frontends
 
     def get_save_when(self, target: str) -> ty.Union[strax.SaveWhen, int]:
         """For a given plugin, get the save when attribute either being a dict or a number."""

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -178,6 +178,8 @@ def test_copy_to_frontend():
 
             # Add the second frontend
             context.storage += [strax.DataDirectory(temp_dir_2)]
+            # Test get_source_sf
+            context.get_source_sf(run_id, ["records", "records"])
             context.copy_to_frontend(run_id, "records", target_compressor="lz4")
 
             # Make sure both frontends have the same data.


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Update `_get_source_sf` to `get_source_sf` to return a list of frontends that store the target(s).

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
