### PR TITLE
Simpler chunk length check, avoid recursion limit crash

### DIFF
--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -1,5 +1,4 @@
 import typing as ty
-from functools import wraps
 
 import numpy as np
 import numba

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -420,26 +420,3 @@ def _update_subruns_in_chunk(chunks):
             else:
                 subruns[subrun_id] = subrun_start_end
     return subruns
-
-
-@export
-def check_chunk_n(f):
-    @wraps(f)
-    def wrapper(self, *args, **kwargs):
-        # assume chunk_info is the second argument
-        if "chunk_info" not in kwargs:
-            raise ValueError(
-                "chunk_info not passed to function, check_chunk_n ",
-                "can only be used with functions that take chunk_info as an argument, ",
-                "usually it is the strax.StorageBackend._read_chunk method.",
-            )
-        chunk_info = kwargs["chunk_info"]
-        chunk = f(self, *args, **kwargs)
-        if len(chunk) != chunk_info["n"]:
-            raise strax.DataCorrupted(
-                f"Chunk {chunk_info['filename']} of {chunk_info['run_id']} has {len(chunk)} items, "
-                f"but chunk_info {chunk_info} says {chunk_info['n']}"
-            )
-        return chunk
-
-    return wrapper

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -165,7 +165,7 @@ class TestStorageType(TestCase):
             #     self.assertNotEqual(len_from_compare, len_from_main_st)
 
     def test_check_chunk_n(self):
-        """Check that check_chunk_n can detect when metadata is lying."""
+        """Check that StorageBackend detects when metadata is lying."""
         st, frontend_setup = self.get_st_and_fill_frontends()
 
         sf = st.storage[0]


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

This fixes a crash @cfuselli always sees after restrax for some time.

**Can you briefly describe how it works?**

In #758 we made StorageBackend check that the chunk length matches the length specified in the metadata. We wrap the class attribute _read_chunk in `__new__`. But `__new__` runs every time we make a new instance. Applications that make backends many times (like a running restrax session) end up with many layers of wrappings, and eventually hit python's recursion limit.

This keeps the check (and its unit test) but implements it more simply. Since `_read_chunk` is only used in `StorageBackend._read_and_format_chunk`, we can just add the check there. It will still apply to every storage backend.

@dachengx please let me know if I missed a specific reason behind the implementation in #758!

