### PR TITLE
Deprecate the usage of `XENONnT/ax_env`

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,4 +1,4 @@
 # File for the requirements of strax with the automated tests
-git+https://github.com/XENONnT/ax_env
+git+https://github.com/XENONnT/base_environment
 deepdiff
 ipython==8.12.1


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Use `base_environment` for pytest, following https://github.com/XENONnT/base_environment/pull/1487.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**
