### PR TITLE
Use parentheses to separate the class name and attributes in the representation of StorageFrontend

### DIFF
--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -166,10 +166,13 @@ class StorageFrontend:
         # List the relevant attributes ('path' is actually for the
         # strax.DataDirectory but it makes more sense to put it here).
         attributes = ("readonly", "path", "exclude", "take_only")
-        representation = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        representation = ""
         for attr in attributes:
             if hasattr(self, attr) and getattr(self, attr):
                 representation += f", {attr}: {getattr(self, attr)}"
+        if representation:
+            representation = " (" + representation[2:] + ")"
+        representation = f"{self.__class__.__module__}.{self.__class__.__name__}" + representation
         return representation
 
     def loader(


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Previously the representation of `StorageFrontend` is somehow confusing:

```
[straxen.storage.rundb.RunDB, readonly: True, strax.storage.files.DataDirectory, readonly: True, path: /dali/lgrandi/xenonnt/raw, take_only: ('raw_records', 'raw_records_he', 'raw_records_aqmon', 'raw_records_nv', 'raw_records_aqmon_nv', 'raw_records_aux_mv', 'raw_records_mv'), strax.storage.files.DataDirectory, readonly: True, path: /dali/lgrandi/xenonnt/processed, strax.storage.files.DataDirectory, readonly: True, path: /project2/lgrandi/xenonnt/processed]
```

This PR use the parentheses to separate the class name and its attributes.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**
