### PR TITLE
Do not call `get_components` in `is_stored`

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1981,7 +1981,7 @@ class Context:
         self._run_defaults_cache[run_id] = defs
         return defs
 
-    def is_stored(self, run_id, target, detailed=True, **kwargs):
+    def is_stored(self, run_id, target, detailed=False, **kwargs):
         """Return whether data type target has been saved for run_id through any of the registered
         storage frontends.
 
@@ -2013,20 +2013,11 @@ class Context:
             save_when = save_when[target]
 
         if save_when < strax.SaveWhen.ALWAYS and detailed:
-            msg = (
+            warnings.warn(
                 f"{target} is not set to always be saved. "
                 "This is probably because it can be trivially made from other data. "
+                f"{target} depends on {plugin.depends_on}. Check if these are stored."
             )
-
-            try:
-                components = self.get_components(run_id, target)
-                targets_plugin_made_from = tuple(components.loaders.keys())
-                msg += f"{target} can be made from: {targets_plugin_made_from}."
-            except strax.DataNotAvailable as e:
-                # Warn that data cannot be made
-                msg += str(e)
-
-            warnings.warn(msg)
 
         return False
 

--- a/tests/test_superruns.py
+++ b/tests/test_superruns.py
@@ -251,17 +251,17 @@ class TestSuperRuns(unittest.TestCase):
 
     def test_superruns_and_save_when(self):
         """Tests if only the highest level for save_when.EXPLICIT plugins is stored."""
-        assert not self.context.is_stored(self.superrun_name, "peaks", detailed=False)
-        assert not self.context.is_stored(self.subrun_ids[0], "peaks", detailed=False)
-        assert not self.context.is_stored(self.subrun_ids[0], "peaks_extension", detailed=False)
-        assert not self.context.is_stored(self.superrun_name, "peaks_extension", detailed=False)
+        assert not self.context.is_stored(self.superrun_name, "peaks")
+        assert not self.context.is_stored(self.subrun_ids[0], "peaks")
+        assert not self.context.is_stored(self.subrun_ids[0], "peaks_extension")
+        assert not self.context.is_stored(self.superrun_name, "peaks_extension")
         self.context._plugin_class_registry["peaks"].save_when = strax.SaveWhen.EXPLICIT
 
         self.context.make(self.superrun_name, "peaks_extension", save=("peaks_extension",))
-        assert not self.context.is_stored(self.superrun_name, "peaks", detailed=False)
-        assert not self.context.is_stored(self.subrun_ids[0], "peaks", detailed=False)
-        assert self.context.is_stored(self.superrun_name, "peaks_extension", detailed=False)
-        assert self.context.is_stored(self.subrun_ids[0], "peaks_extension", detailed=False)
+        assert not self.context.is_stored(self.superrun_name, "peaks")
+        assert not self.context.is_stored(self.subrun_ids[0], "peaks")
+        assert self.context.is_stored(self.superrun_name, "peaks_extension")
+        assert self.context.is_stored(self.subrun_ids[0], "peaks_extension")
 
     def test_storing_with_second_sf(self):
         """Tests if only superrun is written to new sf if subruns already exist in different sf."""


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Further simplify https://github.com/AxFoundation/strax/pull/796. Because `get_components` will call the initialization of `FileSaver`, which will try to make and delete `_temp` folders.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
