### PR TITLE
Initialize plugin because `depends_on` can be property

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -413,7 +413,7 @@ class Context:
                 all_provides |= set(p.provides)
 
             for p_key, p in self._plugin_class_registry.items():
-                requires = set(strax.to_str_tuple(p.depends_on))
+                requires = set(strax.to_str_tuple(p().depends_on))
                 if not requires.issubset(all_provides):
                     plugins_to_deregister.append(p_key)
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Bug observed if:
```
import strax

st = strax.Context()

class A(strax.Plugin):
    @property
    def depends_on(self):
        self._depends_on = tuple()
        return self._depends_on

    @depends_on.setter
    def depends_on(self, str_or_tuple):
        self._depends_on = strax.to_str_tuple(str_or_tuple)

st.register((A,))

st.deregister_plugins_with_missing_dependencies()
```
error:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[1], line 17
     13         self._depends_on = strax.to_str_tuple(str_or_tuple)
     15 st.register((A,))
---> 17 st.deregister_plugins_with_missing_dependencies()

File ~/strax/strax/context.py:416, in Context.deregister_plugins_with_missing_dependencies(self)
    413     all_provides |= set(p.provides)
    415 for p_key, p in self._plugin_class_registry.items():
--> 416     requires = set(strax.to_str_tuple(p.depends_on))
    417     if not requires.issubset(all_provides):
    418         plugins_to_deregister.append(p_key)

File ~/strax/strax/utils.py:268, in to_str_tuple(x)
    266 elif isinstance(x, np.ndarray):
    267     return tuple(x.tolist())
--> 268 raise TypeError(f"Expected string or tuple of strings, got {type(x)}")

TypeError: Expected string or tuple of strings, got <class 'property'>
```

Because the `depends_on` of `A` is a property but not attribute.

**Can you briefly describe how it works?**
Initialize plugin instance inside `deregister_plugins_with_missing_dependencies`.

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
