### PR TITLE
Remove `strax.plugin`

### DIFF
--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -1,9 +1,0 @@
-# Just to keep these references around
-from plugins import (
-    Plugin,
-    CutPlugin,
-    LoopPlugin,
-    MergeOnlyPlugin,
-    OverlapWindowPlugin,
-    ParallelSourcePlugin,
-)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Previously, `strax.plugin.CutPlugin` or `from strax.plugin import CutPlugin` will cause error:
```
>>> strax.plugin.CutPlugin
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'strax.plugins.plugin' has no attribute 'CutPlugin'
>>> from strax.plugin import CutPlugin
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/xudc/strax/strax/plugin.py", line 2, in <module>
    from plugins import (
ModuleNotFoundError: No module named 'plugins'
```
This means that `strax/plugin.py` is never properly used., so we delete them.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
