### PR TITLE
Prevent start being negative

### DIFF
--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -71,6 +71,8 @@ class Chunk:
             raise ValueError(
                 f"Attempt to create chunk {self} with data of {dtype}, should be {expected_dtype}"
             )
+        if self.start < 0:
+            raise ValueError(f"Attempt to create chunk {self} with negative start time")
         if self.start > self.end:
             raise ValueError(f"Attempt to create chunk {self} with negative length")
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Negative `start` is not compatible with https://github.com/AxFoundation/strax/blob/9454279b1f25c5992fe7103f8a63080aa3047869/strax/plugins/overlap_window_plugin.py#L25 and https://github.com/AxFoundation/strax/blob/9454279b1f25c5992fe7103f8a63080aa3047869/strax/chunk.py#L270

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
