### PR TITLE
Multiple output `DownChunkingPlugin`

### DIFF
--- a/strax/plugins/down_chunking_plugin.py
+++ b/strax/plugins/down_chunking_plugin.py
@@ -1,3 +1,5 @@
+from typing import Generator
+
 import strax
 from .plugin import Plugin
 
@@ -26,16 +28,29 @@ class DownChunkingPlugin(Plugin):
                 "currently does not support parallel processing."
             )
 
-        if self.multi_output:
-            raise NotImplementedError(
-                f'Plugin "{self.__class__.__name__}" is a DownChunkingPlugin which '
-                "currently does not support multiple outputs. Please only provide "
-                "a single data-type."
-            )
-
     def _iter_compute(self, chunk_i, **inputs_merged):
         return self.do_compute(chunk_i=chunk_i, **inputs_merged)
 
     def _fix_output(self, result, start, end, _dtype=None):
         """Wrapper around _fix_output to support the return of iterators."""
-        return result
+        if self.multi_output and not isinstance(result, Generator):
+            raise ValueError(
+                f"Plugin {self.__class__.__name__} should return a generator in compute method."
+            )
+
+        for _result in result:
+            if isinstance(_result, dict):
+                values = _result.values()
+            else:
+                if self.multi_output:
+                    raise ValueError(
+                        f"{self.__class__.__name__} is multi-output and should "
+                        "provide a generator of dict output."
+                    )
+                values = [_result]
+            if not all(isinstance(v, strax.Chunk) for v in values):
+                raise ValueError(
+                    f"Plugin {self.__class__.__name__} should yield (dict of) "
+                    "strax.Chunk in compute method."
+                )
+            yield _result

--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -209,7 +209,7 @@ class Plugin:
             if not isinstance(self.dtype, dict):
                 raise ValueError(
                     f"{self.__class__.__name__} has multiple outputs, so its "
-                    "dtype must be specified as a dict: {output: dtype}."
+                    "dtype must be specified as a dict."
                 )
             self.dtype = {k: strax.to_numpy_dtype(dt) for k, dt in self.dtype.items()}
         else:

--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -204,8 +204,7 @@ class Plugin:
             ):
                 raise ValueError(
                     f"{self.__class__.__name__} has multiple outputs and "
-                    "must declare its data kind as a dict: "
-                    "{dtypename: data kind}."
+                    "must declare its data kind as a dict."
                 )
             if not isinstance(self.dtype, dict):
                 raise ValueError(
@@ -625,7 +624,7 @@ class Plugin:
             if not isinstance(result, dict):
                 raise ValueError(
                     f"{self.__class__.__name__} is multi-output and should "
-                    "provide a dict output {dtypename: result}"
+                    "provide a dict output."
                 )
             return {d: self._fix_output(result[d], start, end, _dtype=d) for d in self.provides}
 

--- a/strax/testutils.py
+++ b/strax/testutils.py
@@ -295,12 +295,14 @@ class DownSampleRecords(strax.DownChunkingPlugin):
                 res = records[offset:count]
                 chunk_end = np.max(strax.endtime(res))
                 offset = count
-                chunk = self.chunk(start=last_start, end=chunk_end, data=res)
+                chunk = self.chunk(
+                    start=last_start, end=chunk_end, data=res, data_type=self.provides[0]
+                )
                 last_start = chunk_end
                 yield chunk
 
         res = records[offset : count + 1]
-        chunk = self.chunk(start=last_start, end=end, data=res)
+        chunk = self.chunk(start=last_start, end=end, data=res, data_type=self.provides[0])
         yield chunk
 
 

--- a/tests/test_down_chunk_plugin.py
+++ b/tests/test_down_chunk_plugin.py
@@ -1,3 +1,4 @@
+from immutabledict import immutabledict
 from strax.testutils import RecordsWithTimeStructure, DownSampleRecords, run_id
 import strax
 import numpy as np
@@ -56,6 +57,28 @@ class TestContext(unittest.TestCase):
 
         st.register(TestMultiProcessing)
         with self.assertRaises(NotImplementedError):
+            st.make(run_id, "records_down_chunked", max_workers=2)
+
+    def test_down_chunking_multi_output(self):
+        st = self.get_context(allow_multiprocess=True)
+        st.register(RecordsWithTimeStructure)
+        st.register(DownSampleRecords)
+
+        st.make(run_id, "records", max_workers=1)
+
+        class TestMultiOutput(DownSampleRecords):
+            provides = ("records_down_chunked", "records_down_chunked_copy")
+            data_kind = immutabledict(zip(provides, provides))
+
+            def infer_dtype(self):
+                return {p: DownSampleRecords.dtype for p in self.provides}
+
+            def compute(self, records, start, end):
+                for r in super().compute(records, start, end):
+                    yield r
+
+        st.register(TestMultiOutput)
+        with self.assertRaises(ValueError):
             st.make(run_id, "records_down_chunked", max_workers=2)
 
     def get_context(self, **kwargs):


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

To solve the comment https://github.com/AxFoundation/strax/pull/769/files#r1386797972.

Now we require `strax.DownChunkingPlugin.compute` to output generator of `strax.Chunk` for single output plugin, and generator of dictionary of `strax.Chunk` for multiple output plugin.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
