### PR TITLE
Add `ExhaustPlugin` that exhausts all chunks when fetching data

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -506,7 +506,7 @@ class Context:
                                 # 'type'
                                 # >>> A().__class__.__name__
                                 # 'A'
-                                plug = plug()
+                                plug = plug()  # type: ignore
                             result += [f"{plug.__class__.__name__}.{attribute_name}"]
                             # Likely to be used several other times
                             break

--- a/strax/plugins/__init__.py
+++ b/strax/plugins/__init__.py
@@ -5,3 +5,4 @@ from .merge_only_plugin import *
 from .overlap_window_plugin import *
 from .parrallel_source_plugin import *
 from .down_chunking_plugin import *
+from .exhaust_plugin import *

--- a/strax/plugins/exhaust_plugin.py
+++ b/strax/plugins/exhaust_plugin.py
@@ -1,0 +1,18 @@
+from .plugin import Plugin
+
+
+class ExhaustPlugin(Plugin):
+    """Plugin that exhausts all chunks when fetching data."""
+
+    def _fetch_chunk(self, d, iters, check_end_not_before=None):
+        while super()._fetch_chunk(d, iters, check_end_not_before=check_end_not_before):
+            pass
+        return False
+
+    def do_compute(self, chunk_i=None, **kwargs):
+        if chunk_i != 0:
+            raise RuntimeError(
+                f"{self.__class__.__name__} is an ExhaustPlugin. "
+                "It should read all chunks together can process them together."
+            )
+        return super().do_compute(chunk_i=chunk_i, **kwargs)

--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -57,8 +57,8 @@ class Plugin:
     data_kind: typing.Union[str, immutabledict, dict]
     dtype: typing.Union[tuple, np.dtype, immutabledict, dict]
 
-    depends_on: tuple
-    provides: tuple
+    depends_on: typing.Union[str, tuple, list]
+    provides: typing.Union[str, tuple, list]
     input_buffer: typing.Dict[str, strax.Chunk]
 
     # Needed for plugins which are inherited from an already existing plugins,

--- a/tests/test_exhaust_plugin.py
+++ b/tests/test_exhaust_plugin.py
@@ -1,0 +1,75 @@
+from typing import Tuple
+import numpy as np
+import strax
+import straxen
+from strax import Plugin, ExhaustPlugin
+
+
+class ToExhaust(Plugin):
+    depends_on: Tuple = tuple()
+    provides: str = "to_exhaust"
+
+    dtype = strax.time_fields
+
+    n_chunks = straxen.URLConfig(default=10)
+    n_items = straxen.URLConfig(default=10)
+
+    source_done = False
+
+    def compute(self, chunk_i):
+        data = np.empty(self.n_items, dtype=self.dtype)
+        data["time"] = np.arange(self.n_items) + chunk_i * self.n_items
+        data["endtime"] = data["time"]
+
+        if chunk_i == self.n_chunks - 1:
+            self.source_done = True
+
+        return self.chunk(
+            data=data,
+            start=int(data[0]["time"]),
+            end=int(strax.endtime(data[-1])) + 1,  # to make sure that data is continuous
+        )
+
+    def source_finished(self):
+        return self.source_done
+
+    def is_ready(self, chunk_i):
+        if "ready" not in self.__dict__:
+            self.ready = False
+        self.ready ^= True  # Flip
+        return self.ready
+
+
+class Exhausted(ExhaustPlugin):
+    depends_on: str = "to_exhaust"
+    provides: str = "exhausted"
+
+    dtype = strax.time_fields
+
+    n_chunks = straxen.URLConfig(default=10)
+    n_items = straxen.URLConfig(default=10)
+
+    def compute(self, to_exhaust):
+        return to_exhaust
+
+    def _fetch_chunk(self, d, iters, check_end_not_before=None):
+        flag = self.input_buffer[d] is None  # only check if we have not read anything yet
+        super()._fetch_chunk(d, iters, check_end_not_before=check_end_not_before)
+        if flag and (len(self.input_buffer[d]) != self.n_chunks * self.n_items):
+            raise RuntimeError("Exhausted plugin did not read all chunks!")
+        return False
+
+
+def test_exhaust_plugin():
+    """Test the ExhaustPlugin, about whether it can really exhaust the data or not."""
+    st = strax.Context(storage=[])
+    st.register((ToExhaust, Exhausted))
+    st.storage = [
+        strax.DataDirectory(
+            "./strax_data",
+            provide_run_metadata=True,
+        )
+    ]
+    run_id = "000000"
+    st.make(run_id, "to_exhaust")
+    st.get_array(run_id, "exhausted")


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

It is useful when you want to load inputs together.

It is actually used here: https://github.com/dachengx/axidence/blob/e3acf58970d11d06b9ebb4830511cca408aa5d28/axidence/plugins/pairing/peaks_paired.py#L17

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
