### PR TITLE
Implement Hyperrun

### DIFF
--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -245,7 +245,7 @@ class Chunk:
         )
 
     @classmethod
-    def concatenate(cls, chunks):
+    def concatenate(cls, chunks, allow_hyperrun=False):
         """Create chunk by concatenating chunks of same data type You can pass None's, they will be
         ignored."""
         chunks = [c for c in chunks if c is not None]
@@ -261,7 +261,7 @@ class Chunk:
 
         run_ids = [c.run_id for c in chunks]
 
-        if len(set(run_ids)) != 1:
+        if len(set(run_ids)) != 1 and not allow_hyperrun:
             raise ValueError(
                 f"Cannot concatenate {data_type} chunks with different run ids: {run_ids}"
             )

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -277,6 +277,12 @@ class Chunk:
                 )
             prev_end = c.end
 
+        # try:
+        #     np.concatenate([c.data for c in chunks])
+        # except:
+        #     import pdb
+        #     pdb.set_trace()
+
         return cls(
             start=chunks[0].start,
             end=chunks[-1].end,

--- a/strax/context.py
+++ b/strax/context.py
@@ -1653,7 +1653,7 @@ class Context:
                 **kwargs,
             )
 
-        if _skip_if_built and self.is_stored(run_id, targets):
+        if _skip_if_built and self.is_stored(run_ids[0], targets):
             return
 
         for _ in self.get_iter(run_ids[0], targets, save=save, max_workers=max_workers, **kwargs):

--- a/strax/context.py
+++ b/strax/context.py
@@ -626,14 +626,23 @@ class Context:
         plugin.setup()
         return plugin
 
+    @staticmethod
+    def hyperrun_id(run_id):
+        if run_id.startswith("__"):
+            _run_id = run_id[2:]
+        else:
+            _run_id = run_id
+        return _run_id
+
     def _set_plugin_config(self, p, run_id, tolerant=True):
         # Explicit type check, since if someone calls this with
         # plugin CLASSES, funny business might ensue
+        _run_id = self.hyperrun_id(run_id)
         assert isinstance(p, strax.Plugin)
         config = self.config.copy()
         for opt in p.takes_config.values():
             try:
-                opt.validate(config, run_id=run_id, run_defaults=self.run_defaults(run_id))
+                opt.validate(config, run_id=_run_id, run_defaults=self.run_defaults(_run_id))
             except strax.InvalidConfiguration:
                 if not tolerant:
                     raise
@@ -731,7 +740,7 @@ class Context:
                 continue
 
             requested_p = plugin.__copy__()
-            requested_p.run_id = run_id
+            requested_p.run_id = self.hyperrun_id(run_id)
 
             # Re-use only one instance if the plugin is multi output
             for provides in strax.to_str_tuple(requested_p.provides):
@@ -801,7 +810,7 @@ class Context:
 
         plugin = self._plugin_class_registry[data_type]()
 
-        plugin.run_id = run_id
+        plugin.run_id = self.hyperrun_id(run_id)
 
         # The plugin may not get all the required options here
         # but we don't know if we need the plugin yet
@@ -967,6 +976,7 @@ class Context:
         save=tuple(),
         time_range=None,
         chunk_number=None,
+        multi_run_progress_bar=False,
     ) -> strax.ProcessorComponents:
         """Return components for setting up a processor.
 
@@ -981,6 +991,10 @@ class Context:
                 raise ValueError(f"Plugin names must be more than one letter, not {t}")
 
         plugins = self._get_plugins(targets, run_id)
+
+        allow_hyperruns = [plugins[target_i].allow_hyperrun for target_i in targets]
+        if sum(allow_hyperruns) != 0 and sum(allow_hyperruns) != len(targets):
+            raise ValueError("Cannot mix plugins that allow hyperruns with those that do not.")
 
         # Get savers/loaders, and meanwhile filter out plugins that do not
         # have to do computation. (their instances will stick around
@@ -1007,17 +1021,26 @@ class Context:
                 key, chunk_number=chunk_number, time_range=time_range
             )
 
-            _is_superrun = run_id.startswith("_") and not target_plugin.provides[0].startswith(
-                "_temp"
-            )
-            if not loader and _is_superrun:
+            _is_temp = not target_plugin.provides[0].startswith("_temp")
+            _is_superrun = run_id.startswith("_") and _is_temp
+            _is_hyperrun = run_id.startswith("__") and _is_temp
+            # hyperrun is always superrun
+            allow_hyperrun = plugins[target_i].allow_hyperrun
+            if not loader and (
+                (_is_superrun and not _is_hyperrun) or (_is_hyperrun and not allow_hyperrun)
+            ):
                 if time_range is not None:
                     raise NotImplementedError("time range loading not yet supported for superruns")
 
                 sub_run_spec = self.run_metadata(run_id, "sub_run_spec")["sub_run_spec"]
 
                 # Make subruns if they do not exist.
-                self.make(list(sub_run_spec.keys()), target_i, save=(target_i,))
+                self.make(
+                    list(sub_run_spec.keys()),
+                    target_i,
+                    save=(target_i,),
+                    multi_run_progress_bar=multi_run_progress_bar,
+                )
 
                 ldrs = []
                 for subrun in sub_run_spec:
@@ -1115,7 +1138,7 @@ class Context:
                 and not self.context_config["storage_converter"]
             ):
                 if len(target_plugin.provides) > 1:
-                    # In case the plugin has more then a single provides we also have to check
+                    # In case the plugin has more than a single provides we also have to check
                     # whether any of the other data_types should be stored. Hence only remove
                     # the current traget from the list of plugins_to_savers.
                     current_plugin_to_savers = []
@@ -1142,13 +1165,15 @@ class Context:
                 return
 
             # Save the target and any other outputs of the plugin.
-            if _is_superrun:
+            if _is_superrun and not _is_hyperrun:
                 # In case of a superrun we are only interested in the specified targets
                 # and not any other stuff provided by the corresponding plugin.
                 savers = self._add_saver(
-                    savers, target_i, target_plugin, _is_superrun, loading_this_data
+                    savers, target_i, run_id, target_plugin, _is_superrun, loading_this_data
                 )
-            else:
+            elif not _is_hyperrun or allow_hyperrun:
+                # only save if we are not in a hyperrun or the plugin allows hyperruns
+                # otherwise we will see error at Chunk.concatenate
                 for d_to_save in set(current_plugin_to_savers + list(target_plugin.provides)):
                     key = self.key_for(run_id, d_to_save)
                     loader = self._get_partial_loader_for(
@@ -1167,7 +1192,7 @@ class Context:
                         continue
 
                     savers = self._add_saver(
-                        savers, d_to_save, target_plugin, _is_superrun, loading_this_data
+                        savers, d_to_save, run_id, target_plugin, _is_superrun, loading_this_data
                     )
 
         for target_i in targets:
@@ -1204,6 +1229,7 @@ class Context:
         self,
         savers: dict,
         d_to_save: str,
+        run_id,
         target_plugin: strax.Plugin,
         _is_superrun: bool,
         loading_this_data: bool,
@@ -1220,7 +1246,7 @@ class Context:
         :return: Updated savers dictionary.
 
         """
-        key = strax.DataKey(target_plugin.run_id, d_to_save, target_plugin.lineage)
+        key = strax.DataKey(run_id, d_to_save, target_plugin.lineage)
         for sf in self._sorted_storage:
             if sf.readonly:
                 continue
@@ -1244,7 +1270,7 @@ class Context:
             try:
                 saver = sf.saver(
                     key,
-                    metadata=target_plugin.metadata(target_plugin.run_id, d_to_save),
+                    metadata=target_plugin.metadata(run_id, d_to_save),
                     saver_timeout=self.context_config["saver_timeout"],
                 )
                 # Now that we are surely saving, make an entry in savers
@@ -1392,6 +1418,7 @@ class Context:
         drop_columns=None,
         allow_multiple=False,
         progress_bar=True,
+        multi_run_progress_bar=True,
         _chunk_number=None,
         **kwargs,
     ) -> ty.Iterator[strax.Chunk]:
@@ -1447,7 +1474,12 @@ class Context:
                 raise RuntimeError(f"Cannot allow_multiple in lazy mode or with long timeouts.")
 
         components = self.get_components(
-            run_id, targets=targets, save=save, time_range=time_range, chunk_number=_chunk_number
+            run_id,
+            targets=targets,
+            save=save,
+            time_range=time_range,
+            chunk_number=_chunk_number,
+            multi_run_progress_bar=multi_run_progress_bar,
         )
 
         # Cleanup the temp plugins

--- a/strax/plugins/overlap_window_plugin.py
+++ b/strax/plugins/overlap_window_plugin.py
@@ -43,7 +43,9 @@ class OverlapWindowPlugin(Plugin):
         # Add cached inputs to compute arguments
         for data_kind, chunk in kwargs.items():
             if len(self.cached_input):
-                kwargs[data_kind] = strax.Chunk.concatenate([self.cached_input[data_kind], chunk])
+                kwargs[data_kind] = strax.Chunk.concatenate(
+                    [self.cached_input[data_kind], chunk], self.allow_hyperrun
+                )
 
         # Compute new results
         result = super().do_compute(chunk_i=chunk_i, **kwargs)

--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -103,6 +103,8 @@ class Plugin:
     compute_takes_chunk_i = False  # Autoinferred, no need to set yourself
     compute_takes_start_end = False
 
+    allow_hyperrun = False
+
     def __init__(self):
         if not hasattr(self, "depends_on"):
             raise ValueError(f"depends_on not provided for {self.__class__.__name__}")
@@ -376,7 +378,9 @@ class Plugin:
         """
         try:
             # print(f"Fetching {d} in {self}, hope to see {hope_to_see}")
-            self.input_buffer[d] = strax.Chunk.concatenate([self.input_buffer[d], next(iters[d])])
+            self.input_buffer[d] = strax.Chunk.concatenate(
+                [self.input_buffer[d], next(iters[d])], self.allow_hyperrun
+            )
             # print(f"Fetched {d} in {self}, "
             #      f"now have {self.input_buffer[d]}")
             return True
@@ -477,7 +481,8 @@ class Plugin:
                                 t=this_chunk_end, allow_early_split=True
                             )
                             self.input_buffer[d] = strax.Chunk.concatenate(
-                                [back_to_buffer, self.input_buffer[d]]
+                                [back_to_buffer, self.input_buffer[d]],
+                                self.allow_hyperrun,
                             )
                         max_passes_left -= 1
                     else:

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -636,7 +636,7 @@ class Saver:
         chunk_i = 0
 
         run_id = self.md["run_id"]
-        _is_superrun = run_id.startswith("_")
+        _is_superrun = run_id.startswith("_") and not run_id.startswith("__")
         try:
             while not exhausted:
                 chunk = None

--- a/tests/test_hyperruns.py
+++ b/tests/test_hyperruns.py
@@ -1,0 +1,143 @@
+import os
+import re
+import json
+import datetime
+import pytz
+from bson import json_util
+import tempfile
+import unittest
+import shutil
+import numpy as np
+import strax
+from strax import Plugin, ExhaustPlugin
+
+
+@strax.takes_config(
+    strax.Option("n_chunks", type=int, default=1, track=True),
+    strax.Option("chunks_length", type=int, default=10, track=True),
+    strax.Option("zero_offset", type=int, default=0, track=False),
+)
+class Ranges(Plugin):
+    provides = "ranges"
+    depends_on: tuple = tuple()
+    dtype = [
+        (("Numbers in order", "data"), np.int32),
+    ] + strax.time_dt_fields
+
+    rechunk_on_save = False
+
+    def source_finished(self):
+        return True
+
+    def is_ready(self, chunk_i):
+        return chunk_i < self.config["n_chunks"]
+
+    def compute(self, chunk_i):
+        length = self.config["chunks_length"]
+        r = np.zeros(length, self.dtype)
+        t0 = self.config["zero_offset"]
+        r["time"] = np.arange(length) + t0
+        r["length"] = r["dt"] = 1
+        r["data"] = r["time"]
+        return self.chunk(start=t0, end=t0 + length, data=r)
+
+
+class Sum(ExhaustPlugin):
+    provides = "sum"
+    depends_on = "ranges"
+    dtype = [
+        (("Sum of numbers", "sum"), np.int32),
+    ] + strax.time_dt_fields
+    allow_hyperrun = True
+
+    def compute(self, ranges):
+        s = np.zeros(len(ranges), self.dtype)
+        s["time"] = ranges["time"]
+        s["length"] = ranges["length"]
+        s["dt"] = ranges["dt"]
+        # if data is in order, and uniform, sum will only have one value
+        s["sum"] = ranges["data"] + ranges["data"][::-1]
+        return s
+
+
+class TestHyperRuns(unittest.TestCase):
+    def setUp(self):
+        self.offset_between_subruns = 10
+        self.superrun_name = "_000000"
+        self.hyperrun_name = "__000000"
+        # Temp directory for storing record data for the tests.
+        # Will be removed during TearDown.
+        self.tempdir = tempfile.mkdtemp()
+        # with two storage frontends
+        self.context = strax.Context(
+            storage=[
+                strax.DataDirectory(
+                    self.tempdir, provide_run_metadata=True, readonly=False, deep_scan=True
+                )
+            ],
+            register=[Ranges, Sum],
+            config={
+                "n_chunks": 1,
+                "chunks_length": 10,
+            },
+        )
+        self.context.set_context_config({"write_superruns": True, "use_per_run_defaults": False})
+
+        logger = self.context.log
+
+        lambda s: not logger.addFilter(
+            re.match(".*Could not estimate run start and end time.*", s.getMessage())
+        )
+        self.context._plugin_class_registry["ranges"].chunk_target_size_mb = 1
+        self._create_subruns()
+        self.context.define_run(self.superrun_name, data=self.subrun_ids)  # Define superrun
+        self.context.define_run(self.hyperrun_name, data=self.subrun_ids)  # Define hyperrun
+
+    def tearDown(self):
+        if os.path.exists(self.tempdir):
+            shutil.rmtree(self.tempdir)
+
+    def _create_subruns(self, n_subruns=3):
+        self.now = datetime.datetime.now()
+        self.now.replace(tzinfo=pytz.utc)
+        self.subrun_ids = [str(r) for r in range(n_subruns)]
+
+        for run_id in self.subrun_ids:
+            rg = self.context.get_array(run_id, "ranges")
+            time = np.min(rg["time"])
+            endtime = np.max(strax.endtime(rg))
+
+            self._write_run_doc(
+                run_id,
+                self.now + datetime.timedelta(0, int(time)),
+                self.now + datetime.timedelta(0, int(endtime)),
+            )
+
+            self.context.set_config(
+                {"zero_offset": (int(run_id) + 1) * self.context.config["chunks_length"]}
+            )
+            assert self.context.is_stored(run_id, "ranges")
+
+    def _write_run_doc(self, run_id, time, endtime):
+        """Function which writes a dummy run document."""
+        run_doc = {
+            "name": run_id,
+            "start": time,
+            "end": endtime,
+        }
+        with open(self.context.storage[0]._run_meta_path(str(run_id)), "w") as fp:
+            json.dump(run_doc, fp, sort_keys=True, indent=4, default=json_util.default)
+
+    def test_load_superruns_and_hyperruns(self):
+        """Test loading superruns and hyperruns.
+
+        The test also shows the difference between the two.
+
+        """
+        sum_super = self.context.get_array(self.superrun_name, "sum")
+        sum_hyper = self.context.get_array(self.hyperrun_name, "sum")
+
+        # superruns will still load and make subruns separately
+        assert np.unique(sum_super["sum"]).size != 1
+        # hyperruns will load and make subruns together
+        assert np.unique(sum_hyper["sum"]).size == 1


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Hyperruns. Hyperruns are superruns, also processing of hyperruns depends on `run_metadata` defined similarly to https://straxen.readthedocs.io/en/latest/tutorials/SuperrunsExample.html#Define-a-superrun:.

If a hyperrun has run_id `__000000`, the `plugin.run_id` of the plugins used in processing will be `000000`, and the subruns of the hyperrun will be mixed(concatenated) while processing.

A new attribute `allow_hyperrun` of `strax.Plugin` class is added. The `allow_hyperrun` of `data_type` depends on the `data_type` whose `allow_hyperrun` is `True` can only be `True`. So this means, your father is `True`, so you must be `True`.

**Can you briefly describe how it works?**

The key feature of hyperrun is that the chunks of subruns can be loaded together.

For superruns, the subruns are still made and loaded separately. For hyperrun, we can really treat the combination of subruns as a single run in the context of processing.

For example, in the added test., the data_type `sum` deepens on `ranges`. The `"data"` in `ranges` are just sequence of numbers in order with an offset, like `[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]` and `[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]`. The `sum` will sum the `"data"` in `ranges` by `ranges["data"] + ranges["data"][::-1]`, so you will get `[0] * 10` or `[29] * 10`.

Frist, note that we will have 3 runs. And the `"data"` in the `ranges` of 3 subruns are assigned to be `[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]`, `[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]`, and `[20, 21, 22, 23, 24, 25, 26, 27, 28, 29]`

1. If the loaded `sum` is from a superrun, the `sum` will be `[9] * 10 + [29] * 10 + [49] * 10`. Just because the subruns will still be calculated separately.
2. If the loaded `sum` is from a hyperrun, the `sum` will be `[29] * 30`. Because the subruns will still be first combined into `"data"` whose length is 30, then `ranges["data"] + ranges["data"][::-1]` run. So the subruns are really loaded as if they are the same run.

**Can you give a minimal working example (or illustrate with a figure)?**

The example is in the added test.

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
