### PR TITLE
Add function to collect `data_type` and `data_kind`

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -429,6 +429,24 @@ class Context:
             if not len(plugins_to_deregister):
                 registry_changed = False
 
+    def get_data_kinds(self) -> ty.Tuple:
+        """Return two dictionaries:
+        1. one with all available data_kind as key and their data_types(list) as values
+        2. one with all available data_type as key and their data_kind(str) as values
+        """
+        data_kind_collection: ty.Dict[str, ty.List] = dict()
+        data_type_collection: ty.Dict[str, str] = dict()
+        for data_type in self._plugin_class_registry.keys():
+            plugin = self.__get_plugin("0", data_type)
+            if isinstance(plugin.data_kind, (dict, immutabledict)):
+                data_kind = plugin.data_kind[data_type]
+            else:
+                data_kind = plugin.data_kind
+            data_kind_collection.setdefault(data_kind, [])
+            data_kind_collection[data_kind].append(data_type)
+            data_type_collection[data_type] = data_kind
+        return data_kind_collection, data_type_collection
+
     def search_field(
         self,
         pattern: str,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -499,3 +499,10 @@ class TestContext(unittest.TestCase):
         )
         comparison_dict["metadata2"].pop("strax_version")
         assert comparison_dict["metadata2"] == old_metadata, "metadata comparison failed"
+
+    def test_get_data_kinds(self):
+        st = self.get_context(True)
+        st.register(Records)
+        st.register(Peaks)
+        st.register(self.get_dummy_peaks_dependency())
+        st.get_data_kinds()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -505,4 +505,17 @@ class TestContext(unittest.TestCase):
         st.register(Records)
         st.register(Peaks)
         st.register(self.get_dummy_peaks_dependency())
-        st.get_data_kinds()
+        data_kind_collection, data_type_collection = st.get_data_kinds()
+        # Assert the expected data kinds and their corresponding data types
+        expected_data_kind_collection = {
+            'records': ['records'],
+            'peaks': ['peaks', 'cut_peaks']
+        }
+        assert data_kind_collection == expected_data_kind_collection
+        # Assert the expected data types and their corresponding data kinds
+        expected_data_type_collection = {
+            'records': 'records',
+            'peaks': 'peaks',
+            'cut_peaks': 'peaks'
+        }
+        assert data_type_collection == expected_data_type_collection

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -507,15 +507,12 @@ class TestContext(unittest.TestCase):
         st.register(self.get_dummy_peaks_dependency())
         data_kind_collection, data_type_collection = st.get_data_kinds()
         # Assert the expected data kinds and their corresponding data types
-        expected_data_kind_collection = {
-            'records': ['records'],
-            'peaks': ['peaks', 'cut_peaks']
-        }
+        expected_data_kind_collection = {"records": ["records"], "peaks": ["peaks", "cut_peaks"]}
         assert data_kind_collection == expected_data_kind_collection
         # Assert the expected data types and their corresponding data kinds
         expected_data_type_collection = {
-            'records': 'records',
-            'peaks': 'peaks',
-            'cut_peaks': 'peaks'
+            "records": "records",
+            "peaks": "peaks",
+            "cut_peaks": "peaks",
         }
         assert data_type_collection == expected_data_type_collection


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Add a function to return the collection of which `data_type` belongs to which `data_kind`.

[slack thread](https://xenonnt.slack.com/archives/C016UJZ090B/p1715695013285269)

**Can you briefly describe how it works?**

Iterate through the `strax.Conetxt._plugin_class_registry` and init plugins by `strax.Conetxt.__get_plugin` to let `strax.Context` to assign the `data_kind`, then collect the results.

**Can you give a minimal working example (or illustrate with a figure)?**

In the test, the function `get_data_kinds` will return:
```
({'records': ['records'], 'peaks': ['peaks', 'cut_peaks']}, {'records': 'records', 'peaks': 'peaks', 'cut_peaks': 'peaks'})
```

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
