### PR TITLE
Only replace `"_temp"` in folder name by `""` if saved successfully

### DIFF
--- a/strax/mailbox.py
+++ b/strax/mailbox.py
@@ -73,7 +73,7 @@ class Mailbox:
     # In strax, these are overriden by context options
     # 'timeout' and 'max_messages'. They are here only to support
     # creating mailboxes directly without strax.
-    DEFAULT_TIMEOUT = 300
+    DEFAULT_TIMEOUT = -1
     DEFAULT_MAX_MESSAGES = 4
 
     def __init__(self, name="mailbox", timeout=None, lazy=False, max_messages=None):
@@ -244,8 +244,11 @@ class Mailbox:
 
         # Everyone is waiting for the new chunk or not at all.
         # Fetch only if a driver is waiting.
-        for _i, waiting_for in enumerate(self._subscriber_waiting_for):
-            if self._subscriber_can_drive[_i] and waiting_for is not None:
+        for can_drive, waiting_for in zip(
+            self._subscriber_can_drive,
+            self._subscriber_waiting_for,
+        ):
+            if can_drive and waiting_for is not None:
                 return True
         return False
 

--- a/strax/mailbox.py
+++ b/strax/mailbox.py
@@ -73,7 +73,7 @@ class Mailbox:
     # In strax, these are overriden by context options
     # 'timeout' and 'max_messages'. They are here only to support
     # creating mailboxes directly without strax.
-    DEFAULT_TIMEOUT = -1
+    DEFAULT_TIMEOUT = 300
     DEFAULT_MAX_MESSAGES = 4
 
     def __init__(self, name="mailbox", timeout=None, lazy=False, max_messages=None):

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -675,7 +675,7 @@ class Saver:
         except strax.MailboxKilled:
             # Write exception (with close), but exit gracefully.
             # One traceback on screen is enough
-            self.close(wait_for=pending)
+            self.close(wait_for=pending, successful=False)
 
         except Exception as e:
             # log exception for the final check
@@ -721,7 +721,7 @@ class Saver:
         self._save_chunk_metadata(chunk_info)
         return future
 
-    def close(self, wait_for: typing.Union[list, tuple] = tuple()):
+    def close(self, wait_for: typing.Union[list, tuple] = tuple(), successful=True):
         if self.closed:
             raise RuntimeError(f"{self.md} saver already closed")
 
@@ -745,7 +745,7 @@ class Saver:
 
         self.md["writing_ended"] = time.time()
 
-        self._close()
+        self._close(successful=successful)
 
     ##
     # Abstract methods (to override in child)
@@ -762,5 +762,5 @@ class Saver:
     def _save_chunk_metadata(self, chunk_info):
         raise NotImplementedError
 
-    def _close(self):
+    def _close(self, successful=True):
         raise NotImplementedError

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -306,7 +306,7 @@ class FileSaver(strax.Saver):
             print(f"Removing data in {dirname} to overwrite")
             shutil.rmtree(dirname)
         if os.path.exists(self.tempdirname):
-            print(f"Removing old incomplete data in {dirname}")
+            print(f"Removing old incomplete data in {self.tempdirname}")
             shutil.rmtree(self.tempdirname)
         os.makedirs(self.tempdirname)
         self._flush_metadata()

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -363,7 +363,7 @@ class FileSaver(strax.Saver):
             if self._flush_md_for_every_chunk:
                 self._flush_metadata()
 
-    def _close(self):
+    def _close(self, successful=True):
         if not os.path.exists(self.tempdirname):
             raise RuntimeError(
                 f"{self.tempdirname} was already renamed to {self.dirname}. "
@@ -379,7 +379,8 @@ class FileSaver(strax.Saver):
 
         self._flush_metadata()
 
-        os.rename(self.tempdirname, self.dirname)
+        if successful:
+            os.rename(self.tempdirname, self.dirname)
 
 
 @export


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Before this PR, when an error happens when computing a data_type, the folder of that data_type will be renamed from `0-data_type-lineage_temp` to `0-data_type-lineage`. This will confuse users about whether the data_type is successfully made if users can not access their error log.

In this PR, only if all data are successfully saved, the rename will be performed.

**Can you briefly describe how it works?**

Add a keyword argument `successful` to `_close` method of backends. So later when not successfully exits, the `successful` will be False.

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
