### PR TITLE
Fix cache of Rechunker, zero chunk is not None

### DIFF
--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -445,7 +445,7 @@ class Rechunker:
         if not self.rechunk:
             # We aren't rechunking
             return chunk
-        if self.cache:
+        if self.cache is not None:
             # We have an old chunk, so we need to concatenate
             chunk = strax.Chunk.concatenate([self.cache, chunk])
         if chunk.data.nbytes >= chunk.target_size_mb * 1e6:


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

This PR solves the error we see in straxen testing GitHub action: https://github.com/XENONnT/straxen/actions/runs/9516464741/job/26232816323

When the length of a chunk is zero, this line returns `False`:
https://github.com/AxFoundation/strax/blob/d92e64bd887bb6af7d71795ff4753a8174c8f5d6/strax/chunk.py#L448

Which is not intended. The intended behavior is to concatenate the cache and a new chunk if the cache is not None. This PR fix it.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
