### PR TITLE
Patch sharedarray version due to numpy updating

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,3 +1,2 @@
 # File for the requirements of strax with the automated tests
-sharedarray@https://xenon.isi.edu/python/SharedArray-3.2.3.tar.gz # workaround for numpy 2.0.0 build problem, see XENONnT/base_environment#1718
 git+https://github.com/XENONnT/base_environment

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,2 +1,3 @@
 # File for the requirements of strax with the automated tests
+sharedarray@https://xenon.isi.edu/python/SharedArray-3.2.3.tar.gz # workaround for numpy 2.0.0 build problem, see XENONnT/base_environment#1718
 git+https://github.com/XENONnT/base_environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ immutabledict
 lz4
 numba>=0.43.1
 numexpr
-numpy>=1.18.5
+numpy>=1.18.5,<2.0.0
 packaging
 pandas
 pdmongo


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Similar to https://github.com/XENONnT/cutax/pull/439, following https://github.com/XENONnT/base_environment/pull/1718.

Since numpy updated to 2.0.0 and sharedaray does not follow the updates timely, we see error like https://github.com/AxFoundation/strax/actions/runs/9726479771/job/26844965537?pr=849. To fix it, we assign a dedicated sharedarray version. It required `numpy<2.0.0`.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
