### PR TITLE
Save multiple output when iteration stops in `PostOffice`

### DIFF
--- a/strax/processors/single_thread.py
+++ b/strax/processors/single_thread.py
@@ -42,7 +42,7 @@ class SingleThreadProcessor(BaseProcessor):
 
         dtypes_built = {d: p for p in components.plugins.values() for d in p.provides}
         for d, savers in components.savers.items():
-            for s_i, saver in enumerate(savers):
+            for saver in savers:
                 if d in dtypes_built:
                     rechunk = dtypes_built[d].can_rechunk(d) and allow_rechunk
                 else:


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

When testing `SingleThreadProcessor`, run the codes below:

```
import os
os.environ["CUDA_VISIBLE_DEVICES"] = "-1"

import straxen
from straxen.test_utils import nt_test_run_id

st = straxen.test_utils.nt_test_context()

assert st.is_stored(nt_test_run_id, 'raw_records')
# st.make(nt_test_run_id, 'records')
st.make(nt_test_run_id, 'event_info', processor='single_thread')
```

In `strax_test_data/012882-pulse_counts-exzzquvjyt_temp`, run `ls -lah`,

```
total 12K
drwxr-xr-x  2 xudc xudc 4.0K Jul  1 17:17 .
drwxrwxrwx 23 xudc xudc 4.0K Jul  1 17:18 ..
-rw-r--r--  1 xudc xudc 1.7K Jul  1 17:17 pulse_counts-exzzquvjyt-metadata.json
```

So no chunk is saved. This is because after a `topic` stops its iteration and if it is from a multiple output plugin like [`PulseProcessing`](https://github.com/XENONnT/straxen/blob/7a4edcebac5b6fc165b71de79ae19ede6e7a52d6/straxen/plugins/records/records.py#L43), other provided `data_types` are not saved: https://github.com/AxFoundation/strax/blob/40f85a36311388d3c56aedc95dcbfbf357cd28cb/strax/processors/post_office.py#L244

**Can you briefly describe how it works?**

I made `PostOffice._multi_output_topics` a dictionary. The keys of it are the topics, and the values of it are all the provides of the plugin which provides the `topic`. Whenever a `StopIteration` is encountered `PostOffice._fetch_new`, all messages(outputs) will be sent to `PostOffice._ack_topic_exhausted`.

**Can you give a minimal working example (or illustrate with a figure)?**

As the codes above shown, after this PR, in `strax_test_data/012882-pulse_counts-exzzquvjyt`, run `ls -lah`,

```
total 16K
drwxr-xr-x  2 xudc xudc 4.0K Jun 29 17:06 .
drwxrwxrwx 23 xudc xudc 4.0K Jun 29 17:06 ..
-rw-r--r--  1 xudc xudc 3.9K Jun 29 17:06 pulse_counts-exzzquvjyt-000000
-rw-r--r--  1 xudc xudc 2.2K Jun 29 17:06 pulse_counts-exzzquvjyt-metadata.json
```

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
