### PR TITLE
Allow `_chunk_number` to be list or tuple

### DIFF
--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -498,8 +498,12 @@ class StorageBackend:
 
             # Chunk number constraint
             if chunk_number is not None:
-                if i != chunk_number:
-                    continue
+                if isinstance(chunk_number, (list, tuple)):
+                    if i not in chunk_number:
+                        continue
+                elif isinstance(chunk_number, int):
+                    if i != chunk_number:
+                        continue
 
             # Time constraint
             if time_range:


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

This is helpful when you just want to process several chunks for testing.

`_chunk_number` will be propagated from `get_iter`: https://github.com/AxFoundation/strax/blob/bb23240c199276656fe9bd1dda7e9f5cf90bb127/strax/context.py#L1481

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
