### PR TITLE
Filter out duplicated targets in function `get_iter`

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1517,6 +1517,7 @@ class Context:
         # If multiple targets of the same kind, create a MergeOnlyPlugin
         # to merge the results automatically.
         if isinstance(targets, (list, tuple)) and len(targets) > 1:
+            targets = tuple(set(strax.to_str_tuple(targets)))
             plugins = self._get_plugins(targets=targets, run_id=run_id)
             if len(set(plugins[d].data_kind_for(d) for d in targets)) == 1:
                 temp_name = "_temp_" + strax.deterministic_hash(targets)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

 Fix https://github.com/AxFoundation/strax/issues/846

The reason this can work is explained here: https://github.com/AxFoundation/strax/pull/859#issue-2432793166

**Can you briefly describe how it works?**

Remove duplicated targets when `get_iter`.

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
