### PR TITLE
Set `lineage` and `lineage_hash` simultaneously

### DIFF
--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -36,14 +36,12 @@ class DataKey:
     run_id: str
     data_type: str
     _lineage: dict
-
-    # Do NOT use directly, use the lineage_hash method
-    _lineage_hash = ""
+    _lineage_hash: str
 
     def __init__(self, run_id, data_type, lineage):
         self.run_id = run_id
         self.data_type = data_type
-        self._lineage = lineage
+        self.lineage = lineage
 
     def __repr__(self):
         return "-".join([self.run_id, self.data_type, self.lineage_hash])
@@ -54,17 +52,12 @@ class DataKey:
 
     @lineage.setter
     def lineage(self, value):
-        raise AttributeError(
-            f"Attribute lineage of {self.__class__.__name__} is immutable and cannot be changed."
-        )
+        self._lineage = value
+        self._lineage_hash = strax.deterministic_hash(value)
 
     @property
     def lineage_hash(self):
         """Deterministic hash of the lineage."""
-        # We cache the hash computation to benefit tight loops calling
-        # this property
-        if self._lineage_hash == "":
-            self._lineage_hash = strax.deterministic_hash(self.lineage)
         return self._lineage_hash
 
 

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -35,7 +35,7 @@ class DataKey:
 
     run_id: str
     data_type: str
-    lineage: dict
+    _lineage: dict
 
     # Do NOT use directly, use the lineage_hash method
     _lineage_hash = ""
@@ -43,10 +43,20 @@ class DataKey:
     def __init__(self, run_id, data_type, lineage):
         self.run_id = run_id
         self.data_type = data_type
-        self.lineage = lineage
+        self._lineage = lineage
 
     def __repr__(self):
         return "-".join([self.run_id, self.data_type, self.lineage_hash])
+
+    @property
+    def lineage(self):
+        return self._lineage
+
+    @lineage.setter
+    def lineage(self, value):
+        raise AttributeError(
+            f"Attribute lineage of {self.__class__.__name__} is immutable and cannot be changed."
+        )
 
     @property
     def lineage_hash(self):


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

It is very dangerous to change the `lineage` attribute of `DataKey` because it will make `lineage` and `lineage_hash` inconsistent.

So this PR makes sure they are assigned at the same time.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
