### PR TITLE
Include `chunk_number` in lineage: Per chunk storage

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -906,6 +906,22 @@ class Context:
 
         return plugin
 
+    @staticmethod
+    def _check_chunk_number(chunk_number: ty.List[int]):
+        """Check if the chunk_number is a list of consecutive integers."""
+        mask = isinstance(chunk_number, list)
+        mask &= all([isinstance(x, int) for x in chunk_number])
+        if not mask:
+            raise ValueError(f"chunk_number should be a list of integers, but got {chunk_number}")
+
+        # Check if the difference between adjacent elements is exactly one
+        for i in range(len(chunk_number) - 1):
+            if chunk_number[i + 1] - chunk_number[i] != 1:
+                raise ValueError(
+                    "chunk_number should be a list of consecutive integers, "
+                    f"but got {chunk_number}"
+                )
+
     def __add_lineage_to_plugin(
         self,
         run_id,
@@ -962,8 +978,7 @@ class Context:
                         raise ValueError(
                             f"Chunk number for {d_depends} is already set in the lineage"
                         )
-                    if not isinstance(chunk_number[d_depends], list):
-                        raise ValueError("chunk_number should be a list of integers")
+                    self._check_chunk_number(chunk_number[d_depends])
                     configs["chunk_number"][d_depends] = chunk_number[d_depends]
 
         plugin.lineage = {

--- a/strax/context.py
+++ b/strax/context.py
@@ -745,7 +745,7 @@ class Context:
         if (
             self.context_config["use_per_run_defaults"]
             or self._fixed_plugin_cache is None
-            or chunk_number
+            or chunk_number is not None
         ):
             # There is no point in caching if plugins (lineage) can
             # change per run or the cache is empty.
@@ -762,7 +762,7 @@ class Context:
         plugins: dict,
         chunk_number: ty.Optional[ty.Dict[str, ty.Union[int, ty.Tuple[str], ty.List[str]]]] = None,
     ) -> None:
-        if self.context_config["use_per_run_defaults"] or chunk_number:
+        if self.context_config["use_per_run_defaults"] or chunk_number is not None:
             # There is no point in caching if plugins (lineage) can change per run
             return
         context_hash = self._context_hash()
@@ -952,7 +952,7 @@ class Context:
                 if plugin.takes_config[option].track
             }
 
-        if chunk_number:
+        if chunk_number is not None:
             for d_depends in plugin.depends_on:
                 if d_depends in chunk_number:
                     configs[f"{d_depends}_chunk_number"] = chunk_number[d_depends]
@@ -1093,7 +1093,7 @@ class Context:
             loading_this_data = False
             key = self.key_for(run_id, target_i, chunk_number=chunk_number)
 
-            if chunk_number and target_i in chunk_number:
+            if chunk_number is not None and target_i in chunk_number:
                 _chunk_number = chunk_number[target_i]
             else:
                 _chunk_number = None
@@ -1130,7 +1130,7 @@ class Context:
                         _subrun_time_range = None
                     else:
                         _subrun_time_range = sub_run_spec[subrun]
-                    if chunk_number and target_i in chunk_number:
+                    if chunk_number is not None and target_i in chunk_number:
                         _chunk_number = chunk_number[target_i]
                     else:
                         _chunk_number = None
@@ -1266,7 +1266,7 @@ class Context:
                 # but anyway the data is should already been made
                 for d_to_save in set(current_plugin_to_savers + list(target_plugin.provides)):
                     key = self.key_for(run_id, d_to_save, chunk_number=chunk_number)
-                    if chunk_number and d_to_save in chunk_number:
+                    if chunk_number is not None and d_to_save in chunk_number:
                         _chunk_number = chunk_number[d_to_save]
                     else:
                         _chunk_number = None

--- a/strax/context.py
+++ b/strax/context.py
@@ -739,7 +739,7 @@ class Context:
     def _plugins_are_cached(
         self,
         targets: ty.Union[ty.Tuple[str], ty.List[str]],
-        chunk_number: ty.Optional[ty.Dict[str, ty.Union[int, ty.Tuple[str], ty.List[str]]]] = None,
+        chunk_number: ty.Optional[ty.Dict[str, ty.Union[int, ty.Tuple[int], ty.List[int]]]] = None,
     ) -> bool:
         """Check if all the requested targets are in the _fixed_plugin_cache."""
         if (
@@ -760,7 +760,7 @@ class Context:
     def _plugins_to_cache(
         self,
         plugins: dict,
-        chunk_number: ty.Optional[ty.Dict[str, ty.Union[int, ty.Tuple[str], ty.List[str]]]] = None,
+        chunk_number: ty.Optional[ty.Dict[str, ty.Union[int, ty.Tuple[int], ty.List[int]]]] = None,
     ) -> None:
         if self.context_config["use_per_run_defaults"] or chunk_number is not None:
             # There is no point in caching if plugins (lineage) can change per run
@@ -814,7 +814,7 @@ class Context:
         self,
         targets: ty.Union[ty.Tuple[str], ty.List[str]],
         run_id: str,
-        chunk_number: ty.Optional[ty.Dict[str, ty.Union[int, ty.Tuple[str], ty.List[str]]]] = None,
+        chunk_number: ty.Optional[ty.Dict[str, ty.Union[int, ty.Tuple[int], ty.List[int]]]] = None,
     ) -> ty.Dict[str, strax.Plugin]:
         """Return dictionary of plugin instances necessary to compute targets from scratch.
 
@@ -859,7 +859,7 @@ class Context:
         self,
         run_id: str,
         data_type: str,
-        chunk_number: ty.Optional[ty.Dict[str, ty.Union[int, ty.Tuple[str], ty.List[str]]]] = None,
+        chunk_number: ty.Optional[ty.Dict[str, ty.Union[int, ty.Tuple[int], ty.List[int]]]] = None,
     ):
         """Get single plugin either from cache or initialize it."""
         # Check if plugin for data_type is already cached
@@ -909,7 +909,7 @@ class Context:
         self,
         run_id,
         plugin,
-        chunk_number: ty.Optional[ty.Dict[str, ty.Union[int, ty.Tuple[str], ty.List[str]]]] = None,
+        chunk_number: ty.Optional[ty.Dict[str, ty.Union[int, ty.Tuple[int], ty.List[int]]]] = None,
     ):
         """Adds lineage to plugin in place.
 
@@ -2365,6 +2365,87 @@ class Context:
                     "do you have two storage frontends writing to the same place?"
                 )
 
+    def merge_per_chunk_storage(
+        self,
+        run_id: str,
+        target: str,
+        per_chunked_dependency: str,
+        rechunk=True,
+        chunk_number_group: ty.Optional[ty.List[ty.Union[int, ty.Tuple[int], ty.List[int]]]] = None,
+    ):
+        """Merge the per-chunked data from the per-chunked dependency into the target storage."""
+
+        if chunk_number_group is not None:
+            combined_chunk_numbers = []
+            for c in chunk_number_group:
+                if isinstance(c, int):
+                    combined_chunk_numbers.append(c)
+                elif isinstance(c, (tuple, list)):
+                    combined_chunk_numbers.extend(c)
+                else:
+                    raise ValueError(f"Invalid chunk number: {c} found in {chunk_number_group}")
+            if len(combined_chunk_numbers) != len(set(combined_chunk_numbers)):
+                raise ValueError(f"Duplicate chunk numbers found in {chunk_number_group}")
+            _chunk_number = {per_chunked_dependency: combined_chunk_numbers}
+        else:
+            # if no chunk numbers are given, use information from the dependency
+            chunks = self.get_meta(run_id, per_chunked_dependency)["chunks"]
+            chunk_number_group = [c["chunk_i"] for c in chunks]
+            _chunk_number = None
+
+        # Usually we want to save in the same storage frontend
+        # Here we assume that the target is stored chunk by chunk of the dependency
+        target_sf = source_sf = self.get_source_sf(
+            run_id,
+            target,
+            chunk_number={per_chunked_dependency: chunk_number_group[0]},
+            should_exist=True,
+        )[0]
+
+        def wrapped_loader():
+            """Wrapped loader for changing the target_size_mb."""
+            for chunk_number in chunk_number_group:
+                # Mostly copied from self.copy_to_frontend
+                # Get the info from the source backend (s_be) that we need to fill
+                # the target backend (t_be) with
+                assert self.is_stored(
+                    run_id, target, chunk_number={per_chunked_dependency: chunk_number}
+                )
+                data_key = self.key_for(
+                    run_id, target, chunk_number={per_chunked_dependency: chunk_number}
+                )
+                # This should never fail, we just tried
+                s_be_str, s_be_key = source_sf.find(data_key)
+                s_be = source_sf._get_backend(s_be_str)
+                md = s_be.get_metadata(s_be_key)
+
+                loader = s_be.loader(s_be_key)
+                try:
+                    while True:
+                        # pylint: disable=cell-var-from-loop
+                        data = next(loader)
+                        # Update target chunk size for re-chunking
+                        data.target_size_mb = md["chunk_target_size_mb"]
+                        yield data
+                except StopIteration:
+                    continue
+
+        # Fill the target buffer
+        data_key = self.key_for(run_id, target, chunk_number=_chunk_number)
+        t_be_str, t_be_key = target_sf.find(data_key, write=True)
+        target_be = target_sf._get_backend(t_be_str)
+        target_plugin = self.__get_plugin(
+            run_id,
+            target,
+            chunk_number=_chunk_number,  # type: ignore
+        )
+        target_md = target_plugin.metadata(run_id, target)
+        # Copied from StorageBackend.saver
+        if "dtype" in target_md:
+            target_md["dtype"] = target_md["dtype"].descr.__repr__()
+        saver = target_be._saver(t_be_key, target_md)
+        saver.save_from(wrapped_loader(), rechunk=rechunk)
+
     def get_source(
         self,
         run_id: str,
@@ -2474,7 +2555,7 @@ class Context:
         run_id,
         target,
         storage_frontend: strax.StorageFrontend,
-        chunk_number: ty.Optional[ty.Dict[str, ty.Union[int, ty.Tuple[str], ty.List[str]]]] = None,
+        chunk_number: ty.Optional[ty.Dict[str, ty.Union[int, ty.Tuple[int], ty.List[int]]]] = None,
     ) -> bool:
         """Check if the storage frontend has the requested datakey for the run_id and target.
 

--- a/strax/run_selection.py
+++ b/strax/run_selection.py
@@ -53,7 +53,7 @@ def keys_for_runs(
     self, target: str, run_ids: ty.Union[np.ndarray, list, tuple, str]
 ) -> ty.List[strax.DataKey]:
     """Get the data-keys for a multitude of runs. If use_per_run_defaults is False which it
-    preferably is (#246), getting many keys should be fast as we only only compute the lineage once.
+    preferably is (#246), getting many keys should be fast as we only compute the lineage once.
 
     :param run_ids: Runs to get datakeys for
     :param target: datatype requested


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

The `chunk_number` was passed to `Context.get_iter` to only load a specific chunk. But the previous implementation has weaknesses:

1. The `chunk_number` is not tracked by lineage so if you process twice with a different `chunk_number`, though the lineage is the same, the results are not.
2. Can not assign which `data_type` to load by chunk number.

This PR makes sure that the `chunk_number` is tracked by lineage, and you can assign which chunk to load which data_type.

This PR is designed following plan: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:analysis:analysis_tools_team:sr2_processing. We will later make [outsource](https://github.com/XENONnT/outsource) more compatible with strax via this PR.

Depends on https://github.com/AxFoundation/strax/pull/856

**Can you briefly describe how it works?**

Functionality not implemented:

1. The `chunk_number` will not be passed to run selection, because we will not send the metadata including `chunk_number` to DB.
2. Change `Context.__add_lineage_to_plugin` to add `chunk_number` as a configuration of `Plugin`.
3. `chunk_number` is set to be `chunk_number: ty.Optional[ty.Dict[str, ty.List[int]]] = None` as argument in functions, e.g. it can be `{"raw_records": [0, 1]}` or `{"peaklets": [1], "lone_hits": [0]}`. The latter example is means this PR adds the functionality.
4. Add a function `Context.merge_per_chunk_storage` to combine the per chunk storage into normal storage(where `chunk_number` is not a configuration of `Plugin`).

Vulnerability of this PR:

1. When the chunking of dependencies changes, the result will also change. But this change can not be reflected in lineage.

**Can you give a minimal working example (or illustrate with a figure)?**

```
st.make("0", "peaklets", chunk_number={"raw_records": [0]})
st.make("0", "peak_basics", chunk_number={"peaklets": [1], "lone_hits": [0]})
```

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
