### PR TITLE
Allow splitting in rechunking

### DIFF
--- a/bin/rechunker
+++ b/bin/rechunker
@@ -38,7 +38,7 @@ def parse_args():
         '--target_size_mb', '--target-size-mb',
         dest='target_size_mb',
         type=int,
-        default=strax.default_chunk_size_mb,
+        default=strax.DEFAULT_CHUNK_SIZE_MB,
         help="Target size MB (uncompressed) of the rechunked data")
     parser.add_argument(
         '--write_stats_to', '--write-stats-to',

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -436,6 +436,8 @@ def _split_subruns_in_chunk(subruns, t):
     Updates also their start/ends too.
 
     """
+    if not subruns:
+        return None, None
     subruns_first_chunk = {}
     subruns_second_chunk = {}
     for subrun_id, subrun_start_end in subruns.items():

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -444,8 +444,8 @@ def _split_subruns_in_chunk(subruns, t):
         if t < subrun_start_end["start"]:
             subruns_second_chunk[subrun_id] = subrun_start_end
         elif subrun_start_end["start"] <= t < subrun_start_end["end"]:
-            subruns_first_chunk[subrun_id] = {"start": subrun_start_end["start"], "end": t}
-            subruns_second_chunk[subrun_id] = {"start": t, "end": subrun_start_end["end"]}
+            subruns_first_chunk[subrun_id] = {"start": subrun_start_end["start"], "end": int(t)}
+            subruns_second_chunk[subrun_id] = {"start": int(t), "end": subrun_start_end["end"]}
         elif subrun_start_end["end"] <= t:
             subruns_first_chunk[subrun_id] = subrun_start_end
     return subruns_first_chunk, subruns_second_chunk

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -464,18 +464,21 @@ class Rechunker:
         # Split the cache into chunks and return list of chunks
         chunks = []
         for index in split_indices:
-            output, self.cache = self.cache.split(
+            _chunk, self.cache = self.cache.split(
                 t=self.cache.data["time"][index] - int(DEFAULT_CHUNK_SPLIT // 2),
                 allow_early_split=False,
             )
-            chunks.append(output)
+            chunks.append(_chunk)
         return chunks
 
     def flush(self) -> list:
         """Flush the cache and return the remaining chunk in a list."""
-        result = self.cache
-        self.cache = None
-        return [result]
+        if self.cache is None:
+            return []
+        else:
+            result = self.cache
+            self.cache = None
+            return [result]
 
     @staticmethod
     def get_splits(data, target_size, min_gap=DEFAULT_CHUNK_SPLIT):

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -445,7 +445,7 @@ class Rechunker:
             chunk = strax.transform_chunk_to_superrun_chunk(self.run_id, chunk)
         if not self.rechunk:
             # We aren't rechunking
-            return chunk
+            return [chunk]
 
         if self.cache is not None:
             # We have an old chunk, so we need to concatenate

--- a/strax/config.py
+++ b/strax/config.py
@@ -205,7 +205,7 @@ class Option:
         if self.name in config:
             value = config[self.name]
             if self.type is not OMITTED and not isinstance(value, self.type):
-                # TODO replace back with InvalidConfiguration
+                # TODO: replace back with InvalidConfiguration
                 UserWarning(
                     f"Invalid type for option {self.name}. "
                     f"Excepted a {self.type}, got a {type(value)}"

--- a/strax/context.py
+++ b/strax/context.py
@@ -2211,7 +2211,7 @@ class Context:
                 f"Cannot select {target_frontend_id}-th frontend as "
                 f"we only have {len(self.storage)} frontends!"
             )
-        if rechunk and rechunk_to_mb == strax.default_chunk_size_mb:
+        if rechunk and rechunk_to_mb == strax.DEFAULT_CHUNK_SIZE_MB:
             self.log.warning("No <rechunk_to_mb> specified!")
 
     def copy_to_frontend(
@@ -2221,7 +2221,7 @@ class Context:
         target_frontend_id: ty.Optional[int] = None,
         target_compressor: ty.Optional[str] = None,
         rechunk: bool = False,
-        rechunk_to_mb: int = strax.default_chunk_size_mb,
+        rechunk_to_mb: int = strax.DEFAULT_CHUNK_SIZE_MB,
     ):
         """Copy data from one frontend to another.
 

--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -71,7 +71,7 @@ class Plugin:
     rechunk_on_save = True  # Saver is allowed to rechunk
     # How large (uncompressed) should re-chunked chunks be?
     # Meaningless if rechunk_on_save is False
-    chunk_target_size_mb = strax.default_chunk_size_mb
+    chunk_target_size_mb = strax.DEFAULT_CHUNK_SIZE_MB
 
     # For a source with online input (e.g. DAQ readers), crash if no new input
     # has appeared for this many seconds

--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -80,6 +80,15 @@ def _overload_endtime(x):
 
 @export
 @numba.jit(nopython=True, nogil=True, cache=True)
+def diff(data):
+    """Return time differences between items in data."""
+    if len(data) == 0:
+        return np.zeros(0, dtype=np.int64)
+    return data["time"][1:] - strax.endtime(data)[:-1]
+
+
+@export
+@numba.jit(nopython=True, nogil=True, cache=True)
 def from_break(x, safe_break, not_before=0, left=True, tolerant=False):
     """Return records on side of a break at least safe_break long If there is no such break, return
     the best break found."""

--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -82,6 +82,8 @@ def _overload_endtime(x):
 @numba.jit(nopython=True, nogil=True, cache=True)
 def diff(data):
     """Return time differences between items in data."""
+    if len(data) == 0:
+        return np.zeros(0, dtype=data.dtype["time"])
     results = np.zeros(len(data) - 1, dtype=data.dtype["time"])
     max_endtime = strax.endtime(data[0])
     for i, (time, endtime) in enumerate(zip(data["time"][1:], strax.endtime(data)[:-1])):

--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -88,8 +88,8 @@ def diff(data):
     results = np.zeros(len(data) - 1, dtype=np.int64)
     max_endtime = strax.endtime(data[0])
     for i, (time, endtime) in enumerate(zip(data["time"][1:], strax.endtime(data)[:-1])):
-        results[i] = time - max_endtime
         max_endtime = max(max_endtime, endtime)
+        results[i] = time - max_endtime
     return results
 
 

--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -82,9 +82,10 @@ def _overload_endtime(x):
 @numba.jit(nopython=True, nogil=True, cache=True)
 def diff(data):
     """Return time differences between items in data."""
+    # we are sure that time is np.int64
     if len(data) == 0:
-        return np.zeros(0, dtype=data.dtype["time"])
-    results = np.zeros(len(data) - 1, dtype=data.dtype["time"])
+        return np.zeros(0, dtype=np.int64)
+    results = np.zeros(len(data) - 1, dtype=np.int64)
     max_endtime = strax.endtime(data[0])
     for i, (time, endtime) in enumerate(zip(data["time"][1:], strax.endtime(data)[:-1])):
         results[i] = time - max_endtime

--- a/strax/processing/general.py
+++ b/strax/processing/general.py
@@ -82,9 +82,12 @@ def _overload_endtime(x):
 @numba.jit(nopython=True, nogil=True, cache=True)
 def diff(data):
     """Return time differences between items in data."""
-    if len(data) == 0:
-        return np.zeros(0, dtype=np.int64)
-    return data["time"][1:] - strax.endtime(data)[:-1]
+    results = np.zeros(len(data) - 1, dtype=data.dtype["time"])
+    max_endtime = strax.endtime(data[0])
+    for i, (time, endtime) in enumerate(zip(data["time"][1:], strax.endtime(data)[:-1])):
+        results[i] = time - max_endtime
+        max_endtime = max(max_endtime, endtime)
+    return results
 
 
 @export

--- a/strax/processors/post_office.py
+++ b/strax/processors/post_office.py
@@ -147,9 +147,9 @@ class PostOffice:
         self._readers_done[topic] = []
 
     def register_spy(self, spy: Spy, topic: str):
-        """Register spy to recieve all messages on topic.
+        """Register spy to receive all messages on topic.
 
-        spy.recieve(msg) will be called for each message, and spy.close() when the topic is
+        spy.receive(msg) will be called for each message, and spy.close() when the topic is
         exhausted.
 
         """

--- a/strax/processors/single_thread.py
+++ b/strax/processors/single_thread.py
@@ -95,6 +95,8 @@ class SaverSpy(Spy):
 
     def _save_chunk(self, chunks):
         for chunk in chunks:
+            if chunk is None:
+                continue
             self.saver.save(chunk, self.chunk_number)
             self.chunk_number += 1
 

--- a/strax/processors/single_thread.py
+++ b/strax/processors/single_thread.py
@@ -93,8 +93,8 @@ class SaverSpy(Spy):
     def receive(self, chunk):
         self._save_chunk(self.rechunker.receive(chunk))
 
-    def _save_chunk(self, chunk):
-        if chunk is not None:
+    def _save_chunk(self, chunks):
+        for chunk in chunks:
             self.saver.save(chunk, self.chunk_number)
             self.chunk_number += 1
 

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -485,7 +485,7 @@ class StorageBackend:
             data_type=metadata["data_type"],
             data_kind=metadata["data_kind"],
             dtype=dtype,
-            target_size_mb=metadata.get("chunk_target_size_mb", strax.default_chunk_size_mb),
+            target_size_mb=metadata.get("chunk_target_size_mb", strax.DEFAULT_CHUNK_SIZE_MB),
         )
 
         required_chunk_metadata_fields = "start end run_id".split()
@@ -571,7 +571,7 @@ class StorageBackend:
 
     def saver(self, key, metadata, **kwargs):
         """Return saver for data described by key."""
-        metadata.setdefault("compressor", "blosc")  # TODO wrong place?
+        metadata.setdefault("compressor", "blosc")  # TODO: wrong place?
         metadata["strax_version"] = strax.__version__
         if "dtype" in metadata:
             metadata["dtype"] = metadata["dtype"].descr.__repr__()
@@ -648,22 +648,18 @@ class Saver:
 
         try:
             while not exhausted:
-                chunk = None
-
                 try:
-                    chunk = rechunker.receive(next(source))
+                    chunks = rechunker.receive(next(source))
                 except StopIteration:
                     exhausted = True
-                    chunk = rechunker.flush()
+                    chunks = rechunker.flush()
 
-                if chunk is None:
-                    continue
-
-                new_f = self.save(chunk=chunk, chunk_i=chunk_i, executor=executor)
-                pending = [f for f in pending if not f.done()]
-                if new_f is not None:
-                    pending += [new_f]
-                chunk_i += 1
+                for chunk in chunks:
+                    new_f = self.save(chunk=chunk, chunk_i=chunk_i, executor=executor)
+                    pending = [f for f in pending if not f.done()]
+                    if new_f is not None:
+                        pending += [new_f]
+                    chunk_i += 1
 
         except strax.MailboxKilled:
             # Write exception (with close), but exit gracefully.

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -298,7 +298,7 @@ class TestRechunking(TestCase):
             dest_directory=target_path.name if not replace else None,
             replace=True,
             compressor=compressor,
-            target_size_mb=strax.default_chunk_size_mb * 2,
+            target_size_mb=strax.DEFAULT_CHUNK_SIZE_MB * 2,
             parallel=parallel,
             max_workers=4,
             _timeout=5,

--- a/tests/test_superruns.py
+++ b/tests/test_superruns.py
@@ -204,10 +204,6 @@ class TestSuperRuns(unittest.TestCase):
 
         """
 
-        # Set to zero to force rechunking
-        default_chunk_split_ns = strax.chunk.DEFAULT_CHUNK_SPLIT_NS
-        strax.chunk.DEFAULT_CHUNK_SPLIT_NS = 0
-
         self.context.set_config({"recs_per_chunk": 500})  # Make chunks > 1 MB
 
         rr = self.context.get_array(self.subrun_ids, "records")
@@ -235,15 +231,7 @@ class TestSuperRuns(unittest.TestCase):
         rr_superrun = self.context.get_array("_superrun_test_rechunking", "records")
         rr_subruns = self.context.get_array(self.subrun_ids, "records")
 
-        chunks = [chunk for chunk in self.context.get_iter("_superrun_test_rechunking", "records")]
-        assert len(chunks) > 1, (
-            "Number of chunks should be larger 1. "
-            f"{chunks[0].target_size_mb, chunks[0].nbytes / 1e6}"
-        )
         assert np.all(rr_superrun["time"] == rr_subruns["time"])
-
-        # Set back to default
-        strax.chunk.DEFAULT_CHUNK_SPLIT_NS = default_chunk_split_ns
 
     def test_superrun_triggers_subrun_processing(self):
         """Tests if superrun processing can trigger subrun processing.


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Previously, "rechunk" in strax is equivalent to merging. Say, data_type A depends on B. When the chunk of B is very large, inevitability A will be large and even larger than `target_size_mb`, which will make `target_size_mb` not working.

This PR allows the chunks to be split. It ALSO allows the chunks of superruns to be split, which might cause inconsistency, so I suggest a minor or even major bump.

TODOs:

- More tests need to be done to validate that the results are the same before and after the PR.
- Change straxen to inherit from `strax.chunk.DEFAULT_CHUNK_SPLIT_NS` instead of hardcoded `safe_break_in_pulses`.

**Can you briefly describe how it works?**

There are several things changed to make this happen:

1. Return a list of chunks in functions: `Rechunker.receive` and `Rechunker.flush`, because the splitting happens.
2. Change the behavior of `Saver.save_from` to accept a list of chunks from `Rechunker.receive` and `Rechunker.flush`.
3. Change the behavior of `SaverSpy._save_chunk` to accept a list of chunks from `Rechunker.receive`.
4. Add function `_split_subruns_in_chunk` to split the information of subruns.
5. Add a variable `DEFAULT_CHUNK_SPLIT_NS` (default: 1000, from [straxen](https://github.com/XENONnT/straxen/blob/4d6c2b7ba2954ceaa2601a7680c67b169e8c132c/straxen/plugins/raw_records/daqreader.py#L76)) which is the required gap between items when splitting. Actually, this is only strictly needed by `raw_records`.

The splitting and merging will both happen to make sure that the size of a chunk is similar to the `target_size_mb`.

**Can you give a minimal working example (or illustrate with a figure)?**

By running:

```
import straxen
from straxen.test_utils import nt_test_run_id


run_id = nt_test_run_id
st = straxen.test_utils.nt_test_context()

source_directory = os.path.join(st.get_source_sf(nt_test_run_id, 'raw_records')[0].path, str(st.key_for(nt_test_run_id, 'raw_records')))

strax.rechunker(
    source_directory=source_directory,
    dest_directory=source_directory.replace('strax_test_data', 'strax_test_data_split'),
    replace=False,
    target_size_mb=3,  # when setting `target_size_mb` to 1, `CannotSplit` will occur
    parallel=False,
)
```

You will get split chunks in `./strax_test_data_split/012882-raw_records-z7q2d2ye2t`;

```
total 4.4M
drwxrwxr-x 2 xudc xudc 4.0K Aug  8 14:46 .
drwxrwxr-x 3 xudc xudc 4.0K Aug  8 14:46 ..
-rw-rw-r-- 1 xudc xudc 1.6M Aug  8 14:46 raw_records-z7q2d2ye2t-000000
-rw-rw-r-- 1 xudc xudc 1.5M Aug  8 14:46 raw_records-z7q2d2ye2t-000001
-rw-rw-r-- 1 xudc xudc 1.5M Aug  8 14:46 raw_records-z7q2d2ye2t-000002
-rw-rw-r-- 1 xudc xudc 2.4K Aug  8 14:46 raw_records-z7q2d2ye2t-metadata.json
```

in `raw_records-z7q2d2ye2t-metadata.json`:

```
"chunks": [
    {
        "chunk_i": 0,
        "end": 1874999060,
        "filename": "raw_records-z7q2d2ye2t-000000",
        "filesize": 1611567,
        "first_endtime": 125000600,
        "first_time": 124999590,
        "last_endtime": 1625812250,
        "last_time": 1625811240,
        "n": 12278,
        "nbytes": 2995832,
        "run_id": "012882",
        "start": 124900000,
        "subruns": null
    },
    {
        "chunk_i": 1,
        "end": 3376217870,
        "filename": "raw_records-z7q2d2ye2t-000001",
        "filesize": 1471147,
        "first_endtime": 1875000660,
        "first_time": 1874999560,
        "last_endtime": 3375000880,
        "last_time": 3375000850,
        "n": 11002,
        "nbytes": 2684488,
        "run_id": "012882",
        "start": 1874999060,
        "subruns": null
    },
    {
        "chunk_i": 2,
        "end": 4876677420,
        "filename": "raw_records-z7q2d2ye2t-000002",
        "filesize": 1470734,
        "first_endtime": 3376219380,
        "first_time": 3376218370,
        "last_endtime": 4876676730,
        "last_time": 4876676080,
        "n": 11165,
        "nbytes": 2724260,
        "run_id": "012882",
        "start": 3376217870,
        "subruns": null
    }
],
```

To test whether they are the same:

```
import numpy as np

raw_records = strax.dry_load_files('./strax_test_data/012882-raw_records-z7q2d2ye2t')
raw_records_split = strax.dry_load_files('./strax_test_data_split/012882-raw_records-z7q2d2ye2t')

for name in raw_records.dtype.names:
    assert np.all(raw_records[name] == raw_records_split[name])
```

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
