### PR TITLE
Add subruns information in `DataKey` of superruns to track metadata

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1290,9 +1290,7 @@ class Context:
         If super or hyperrun is detected, the subruns information are added to the key.
 
         """
-        is_superrun = run_id.startswith("_")
-        is_hyperrun = run_id.startswith("__")
-        if is_superrun or is_hyperrun:
+        if run_id.startswith("_"):
             sub_run_spec = self.run_metadata(run_id, projection=["sub_run_spec"])["sub_run_spec"]
         else:
             sub_run_spec = None

--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -339,7 +339,7 @@ class Plugin:
             data_type=data_type,
             data_kind=self.data_kind_for(data_type),
             dtype=self.dtype_for(data_type),
-            lineage_hash=strax.DataKey(run_id, data_type, self.lineage).lineage_hash,
+            lineage_hash=strax.deterministic_hash(self.lineage),
             compressor=self.compressor,
             lineage=self.lineage,
             chunk_target_size_mb=self.chunk_target_size_mb,

--- a/strax/run_selection.py
+++ b/strax/run_selection.py
@@ -68,7 +68,7 @@ def keys_for_runs(
         # Get the lineage once, for the context specifies that the
         # defaults may not change!
         p = self._get_plugins((target,), run_ids[0])[target]
-        return [strax.DataKey(r, target, p.lineage) for r in run_ids]
+        return [self.get_datakey(r, target, p.lineage) for r in run_ids]
     else:
         return []
 
@@ -398,7 +398,9 @@ def define_run(
     sources = set()
     comments = set()
     for _subrunid in data:
-        doc = self.run_metadata(_subrunid, ["start", "end", "mode", "tags", "source", "comments"])
+        doc = self.run_metadata(
+            _subrunid, projection=["start", "end", "mode", "tags", "source", "comments"]
+        )
         doc.setdefault(
             "tags",
             [

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -39,6 +39,8 @@ class DataKey:
     _lineage_hash: str
 
     def __init__(self, run_id, data_type, lineage, subruns=None):
+        if run_id.startswith("_") and subruns is None:
+            raise ValueError(f"You must assign subruns information for superrun {run_id}!")
         self.run_id = run_id
         self.data_type = data_type
         self.lineage = lineage

--- a/strax/storage/common.py
+++ b/strax/storage/common.py
@@ -38,13 +38,14 @@ class DataKey:
     _lineage: dict
     _lineage_hash: str
 
-    def __init__(self, run_id, data_type, lineage):
+    def __init__(self, run_id, data_type, lineage, subruns=None):
         self.run_id = run_id
         self.data_type = data_type
         self.lineage = lineage
+        self.subruns = subruns
 
     def __repr__(self):
-        return "-".join([self.run_id, self.data_type, self.lineage_hash])
+        return "-".join([self._run_id, self.data_type, self.lineage_hash])
 
     @property
     def lineage(self):
@@ -59,6 +60,14 @@ class DataKey:
     def lineage_hash(self):
         """Deterministic hash of the lineage."""
         return self._lineage_hash
+
+    @property
+    def _run_id(self):
+        if self.subruns is not None:
+            _run_id = self.run_id + "_" + strax.deterministic_hash(self.subruns)
+        else:
+            _run_id = self.run_id
+        return _run_id
 
 
 @export

--- a/strax/storage/files.py
+++ b/strax/storage/files.py
@@ -166,7 +166,7 @@ class DataDirectory(StorageFrontend):
         # Check exact match
         if _data_type != key.data_type:
             return False
-        if not ignore_name and _run_id != key.run_id:
+        if not ignore_name and _run_id != key._run_id:
             return False
 
         # Check fuzzy match

--- a/tests/test_superruns.py
+++ b/tests/test_superruns.py
@@ -145,6 +145,20 @@ class TestSuperRuns(unittest.TestCase):
         assert chunk["first_time"] == subrun_data["time"].min()
         assert chunk["last_endtime"] == np.max(strax.endtime(subrun_data))
 
+    def test_superrun_definition(self):
+        """Test if superrun definition works correctly.
+
+        After redefining the superrun, the DataKey of superrun will be different.
+
+        """
+        self.context.get_array(self.superrun_name, "records")
+        assert self.context.is_stored(self.superrun_name, "records")
+        # After redefining the superrun with only different subruns,
+        # the superrun should not be stored
+        self.context.define_run(self.superrun_name, data=self.subrun_ids[:-1])
+        assert not self.context.is_stored(self.superrun_name, "records")
+        self.context.define_run(self.superrun_name, data=self.subrun_ids)
+
     def test_select_runs(self):
         self.context.select_runs()
         self.context.make(
@@ -266,7 +280,7 @@ class TestSuperRuns(unittest.TestCase):
     def test_storing_with_second_sf(self):
         """Tests if only superrun is written to new sf if subruns already exist in different sf."""
         self.context.storage[0].readonly = True
-        self.context.storage.append(strax.DataDirectory(self.tempdir2))
+        self.context.storage.append(strax.DataDirectory(self.tempdir2, provide_run_metadata=True))
         self.context.make(self.superrun_name, "records")
         superrun_sf = self.context.storage.pop(1)
         # Check if first sf contains superrun, it should not:
@@ -275,9 +289,9 @@ class TestSuperRuns(unittest.TestCase):
         # Now check second sf for which only the superrun should be
         # stored:
         self.context.storage = [superrun_sf]
+        self._create_subruns()
+        self.context.define_run(self.superrun_name, data=self.subrun_ids)
         assert self.context.is_stored(self.superrun_name, "records")
-        for subrun in self.subrun_ids:
-            assert not self.context.is_stored(subrun, "records")
 
     def test_run_selection_with_superruns(self):
         df_runs = self.context.select_runs()


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

The subruns of a superrun is not checked when loading a saved superrun after redefining the superrun. You will find the example in the MWE.

**Can you briefly describe how it works?**

This PR does the following things:

1. Add an argument of `DataKey`: `subruns`, which is loaded from the metadata of superrun. Of course, if there is no metadata, an error will be raised.
2. Add `Context.get_datakey` for the context to get the decorated `DataKey`. Change all direct call of `strax.DataKey` in `Context` to `Context.get_datakey`, including `Context.key_for`.
3. Include the deterministic hash of `subruns` to the `run_id` in `DataKey`, so if everything is the same except `subruns`, the `DataKey.__repr__` will still change.

The motivation that we do not include `subruns` in `lineage` is that we would like to keep the lineage hash of same `data_type` of subruns and superrun the same, like `0-records-j3nd2fjbiq` and `_superrun_test_uzafu3c2wk-records-j3nd2fjbiq`.

**Can you give a minimal working example (or illustrate with a figure)?**

```
#!/usr/bin/env python
# coding: utf-8

import json
import datetime
import pytz
from bson import json_util

import numpy as np

import strax
from strax.testutils import Records, Peaks
import straxen


superrun_name = "_superrun_test"

# Prepare for a context
st = strax.Context(
    storage=[
        strax.DataDirectory(
            "./strax_data", provide_run_metadata=True, readonly=False, deep_scan=True
        )
    ],
    register=[Records, Peaks],
    config={"bonus_area": 42},
)
st.set_context_config({"use_per_run_defaults": False, "write_superruns": True})


def _write_run_doc(context, run_id, time, endtime):
    """Function which writes a dummy run document."""
    run_doc = {"name": run_id, "start": time, "end": endtime}
    with open(context.storage[0]._run_meta_path(str(run_id)), "w") as fp:
        json.dump(run_doc, fp, sort_keys=True, indent=4, default=json_util.default)


# Define run metadata of each subrun
offset_between_subruns = 10
now = datetime.datetime.now()
now.replace(tzinfo=pytz.utc)
subrun_ids = [str(r) for r in range(3)]
for run_id in subrun_ids:
    rr = st.get_array(run_id, "records")
    time = np.min(rr["time"])
    endtime = np.max(strax.endtime(rr))

    _write_run_doc(
        st,
        run_id,
        now + datetime.timedelta(0, int(time)),
        now + datetime.timedelta(0, int(endtime)),
    )

    st.set_config({"secret_time_offset": endtime + offset_between_subruns})  # untracked option
    assert st.is_stored(run_id, "records")

st.define_run(superrun_name, subrun_ids)
print(f"When subruns are: {list(st.run_metadata(superrun_name)['sub_run_spec'].keys())}:")
print(f"Old DataKey is {st.key_for(superrun_name, 'records')}")
st.make(superrun_name, "records")
assert st.is_stored(superrun_name, "records")

# But if you change the metadata definition...
st.define_run(superrun_name, subrun_ids[:-1])
print(f"When subruns are: {list(st.run_metadata(superrun_name)['sub_run_spec'].keys())}:")
print(f"New DataKey is {st.key_for(superrun_name, 'records')}")
assert not st.is_stored(superrun_name, "records")
```

The output will be

```
When subruns are: ['0', '1', '2']:
Old DataKey is _superrun_test_uzafu3c2wk-records-j3nd2fjbiq
When subruns are: ['0', '1']:
New DataKey is _superrun_test_zc44ingvpo-records-j3nd2fjbiq
```

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
