### PR TITLE
Only save combined `data_type` in only-combining mode

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1337,7 +1337,7 @@ class Context:
             targets=strax.to_str_tuple(final_plugin),
         )
 
-    def get_datakey(self, run_id, target, lineage):
+    def get_data_key(self, run_id, target, lineage):
         """Get datakey for a given run_id, target and lineage.
 
         If super is detected, the subruns information are added to the key.
@@ -1370,7 +1370,7 @@ class Context:
         :return: Updated savers dictionary.
 
         """
-        key = self.get_datakey(run_id, d_to_save, target_plugin.lineage)
+        key = self.get_data_key(run_id, d_to_save, target_plugin.lineage)
         for sf in self._sorted_storage:
             if sf.readonly:
                 continue
@@ -2024,7 +2024,7 @@ class Context:
             plugins = self._get_plugins((target,), run_id, chunk_number=chunk_number)
 
         lineage = plugins[target].lineage
-        return self.get_datakey(run_id, target, lineage)
+        return self.get_data_key(run_id, target, lineage)
 
     def get_meta(self, run_id, target, chunk_number=None) -> dict:
         """Return metadata for target for run_id, or raise DataNotAvailable if data is not yet

--- a/strax/context.py
+++ b/strax/context.py
@@ -1274,7 +1274,11 @@ class Context:
                 # only save if we are not in a superrun or the plugin allows superruns
                 # otherwise we will see error at Chunk.concatenate
                 # but anyway the data is should already been made
-                for d_to_save in set(current_plugin_to_savers + list(target_plugin.provides)):
+                if not _combining_subruns:
+                    data_type_to_save = set(current_plugin_to_savers + list(target_plugin.provides))
+                else:
+                    data_type_to_save = set(current_plugin_to_savers)
+                for d_to_save in data_type_to_save:
                     key = self.key_for(run_id, d_to_save, chunk_number=chunk_number)
                     # Here we just check the availability of key,
                     # chunk_number for _get_partial_loader_for can be None

--- a/strax/run_selection.py
+++ b/strax/run_selection.py
@@ -68,7 +68,7 @@ def keys_for_runs(
         # Get the lineage once, for the context specifies that the
         # defaults may not change!
         p = self._get_plugins((target,), run_ids[0])[target]
-        return [self.get_datakey(r, target, p.lineage) for r in run_ids]
+        return [self.get_data_key(r, target, p.lineage) for r in run_ids]
     else:
         return []
 

--- a/tests/test_superruns.py
+++ b/tests/test_superruns.py
@@ -337,6 +337,8 @@ class TestSuperRuns(unittest.TestCase):
         The test also shows the difference between the two.
 
         """
+        self.context.tree
+        self.context.inversed_tree
         self.context.check_superrun()
         sum_super = self.context.get_array(self.superrun_name, "sum")
         _sum_super = self.context.get_array(self.superrun_name, "sum", _combining_subruns=True)

--- a/tests/test_superruns.py
+++ b/tests/test_superruns.py
@@ -126,7 +126,9 @@ class TestSuperRuns(unittest.TestCase):
             self.superrun_name, "peak_classification", _combining_subruns=True
         )
         assert len(components.loaders) == 1
+        assert len(components.savers) == 1
         assert "peak_classification" in components.loaders
+        assert "peak_classification" in components.savers
 
         with self.assertRaises(ValueError):
             self.context.get_components(


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Close https://github.com/AxFoundation/strax/issues/876.

The reason for this PR is in the issue description.

**Can you briefly describe how it works?**

If `_combining_subruns` is `True`, only save the targeted `data_type`.

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
