### PR TITLE
Show waring when the `chunk_number` is not needed

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1088,6 +1088,14 @@ class Context:
             if len(t) == 1:
                 raise ValueError(f"Plugin names must be more than one letter, not {t}")
 
+        _is_superrun = run_id.startswith("_")
+        if len(targets) > 1 and _combining_subruns:
+            raise ValueError("Combining subruns is only supported for a single target")
+        if _is_superrun and chunk_number is not None:
+            raise ValueError("Per chunk processing is only allowed when not processing superrun.")
+        if not _is_superrun and _combining_subruns:
+            raise ValueError("Combining subruns is only supported for superruns.")
+
         sources = set().union(
             *[s for s in (self.get_source(run_id, target) for target in targets) if s is not None]
         )
@@ -1101,14 +1109,6 @@ class Context:
                 )
 
         plugins = self._get_plugins(targets, run_id, chunk_number=chunk_number)
-
-        _is_superrun = run_id.startswith("_")
-        if len(targets) > 1 and _combining_subruns:
-            raise ValueError("Combining subruns is only supported for a single target")
-        if _is_superrun and chunk_number is not None:
-            raise ValueError("Per chunk processing is only allowed when not processing superrun.")
-        if not _is_superrun and _combining_subruns:
-            raise ValueError("Combining subruns is only supported for superruns.")
 
         allow_superruns = [plugins[target_i].allow_superrun for target_i in targets]
         if _is_superrun and sum(allow_superruns) not in [0, len(targets)]:

--- a/strax/context.py
+++ b/strax/context.py
@@ -1,6 +1,5 @@
 import time
 import logging
-import warnings
 import fnmatch
 import itertools
 import json
@@ -370,7 +369,7 @@ class Context:
                 if old_plugin == currently_registered:
                     # Must be equal here, because we are only looking for the remanants which were
                     # not overwritten above.
-                    warnings.warn(
+                    self.log.warning(
                         "Provides of multi-output plugins overlap, deregister old plugins"
                         f" {old_plugin}."
                     )
@@ -1088,6 +1087,18 @@ class Context:
         for t in targets:
             if len(t) == 1:
                 raise ValueError(f"Plugin names must be more than one letter, not {t}")
+
+        sources = set().union(
+            *[s for s in (self.get_source(run_id, target) for target in targets) if s is not None]
+        )
+        if chunk_number is not None:
+            chunk_number_keys = set(chunk_number.keys())
+            if not chunk_number_keys <= sources:
+                self.log.warning(
+                    f"Chunk number is specified for dependencies {chunk_number_keys} "
+                    f"but {targets} are made from stored dependencies {sources}. "
+                    "So some values in chunk_number will be ignored."
+                )
 
         plugins = self._get_plugins(targets, run_id, chunk_number=chunk_number)
 
@@ -2209,7 +2220,7 @@ class Context:
             save_when = save_when[target]
 
         if save_when < strax.SaveWhen.ALWAYS and detailed:
-            warnings.warn(
+            self.log.warning(
                 f"{target} is not set to always be saved. "
                 "This is probably because it can be trivially made from other data. "
                 f"{target} depends on {plugin.depends_on}. Check if these are stored."

--- a/tests/test_superruns.py
+++ b/tests/test_superruns.py
@@ -319,7 +319,7 @@ class TestSuperRuns(unittest.TestCase):
     def test_superrun_chunk_number(self):
         """Test that superrun does not work with chunk_number."""
         with self.assertRaises(ValueError):
-            self.context.get_array(self.superrun_name, "peaks", chunk_number=[0])
+            self.context.get_array(self.superrun_name, "peaks", chunk_number={"raw_records": [0]})
 
     def test_bare_combining_subruns(self):
         """Test that _combining_subruns does not work with non-superrun."""


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Just add a warning.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
