### PR TITLE
Add `combining` into the `DataKey`

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1964,7 +1964,7 @@ class Context:
                     run_id,
                     target,
                     chunk_number=kwargs.get("chunk_number", None),
-                    combining=kwargs.get("combining", None),
+                    combining=kwargs.get("combining", False),
                 )
                 INSERTED[run_id] = dict(start_idx=idx, end_idx=idx, lineage_hash=key.lineage_hash)
                 for chunk in self.get_iter(run_id, target, progress_bar=progress_bar, **kwargs):

--- a/strax/context.py
+++ b/strax/context.py
@@ -1244,7 +1244,7 @@ class Context:
             # Now we should check whether we meet the saving requirements.
             current_plugin_to_savers = [target_i]
             if not self._target_should_be_saved(target_plugin, target_i, targets, save):
-                if target_plugin.multi_output > 1:
+                if target_plugin.multi_output:
                     # In case the plugin has more than a single provides we also have to check
                     # whether any of the other data_types should be stored. Hence only remove
                     # the current traget from the list of plugins_to_savers.

--- a/strax/context.py
+++ b/strax/context.py
@@ -1279,7 +1279,7 @@ class Context:
                 key = self.key_for(run_id, d_to_save, chunk_number=chunk_number)
                 # Here we just check the availability of key,
                 # chunk_number for _get_partial_loader_for can be None
-                if self._get_partial_loader_for(key, time_range=time_range, chunk_number=None):
+                if self._get_partial_loader_for(key, time_range=time_range):
                     return
 
                 if not self._target_should_be_saved(

--- a/strax/context.py
+++ b/strax/context.py
@@ -1283,7 +1283,7 @@ class Context:
                 # Here we just check the availability of key,
                 # chunk_number for _get_partial_loader_for can be None
                 if self._get_partial_loader_for(key, time_range=time_range):
-                    return
+                    continue
 
                 if not self._target_should_be_saved(
                     target_plugin, d_to_save, targets, save

--- a/tests/test_superruns.py
+++ b/tests/test_superruns.py
@@ -123,7 +123,7 @@ class TestSuperRuns(unittest.TestCase):
         # When we make superrun, subruns of the targeted data_type should
         # be first made individually and combined.
         components = self.context.get_components(
-            self.superrun_name, "peak_classification", _combining_subruns=True
+            self.superrun_name, "peak_classification", combining=True
         )
         assert len(components.loaders) == 1
         assert len(components.savers) == 1
@@ -132,7 +132,7 @@ class TestSuperRuns(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             self.context.get_components(
-                self.superrun_name, ("peaks", "peak_classification"), _combining_subruns=True
+                self.superrun_name, ("peaks", "peak_classification"), combining=True
             )
 
     def test_create_and_load_superruns(self):
@@ -305,7 +305,7 @@ class TestSuperRuns(unittest.TestCase):
         """Tests if only superrun is written to new sf if subruns already exist in different sf."""
         self.context.storage[0].readonly = True
         self.context.storage.append(strax.DataDirectory(self.tempdir2, provide_run_metadata=True))
-        self.context.make(self.superrun_name, "peaks", _combining_subruns=True)
+        self.context.make(self.superrun_name, "peaks")
         superrun_sf = self.context.storage.pop(1)
         # Check if first sf contains superrun, it should not:
         assert not self.context.is_stored(self.superrun_name, "peaks")
@@ -322,9 +322,9 @@ class TestSuperRuns(unittest.TestCase):
             self.context.get_array(self.superrun_name, "peaks", chunk_number={"raw_records": [0]})
 
     def test_bare_combining_subruns(self):
-        """Test that _combining_subruns does not work with non-superrun."""
+        """Test that combining does not work with non-superrun."""
         with self.assertRaises(ValueError):
-            self.context.get_array(self.subrun_ids[0], "peaks", _combining_subruns=True)
+            self.context.get_array(self.subrun_ids[0], "peaks", combining=True)
 
     def test_superrun_mutiple_targets(self):
         """Test that multiple targets does not work with superrun."""
@@ -340,8 +340,10 @@ class TestSuperRuns(unittest.TestCase):
         self.context.tree
         self.context.inversed_tree
         self.context.check_superrun()
-        sum_super = self.context.get_array(self.superrun_name, "sum")
-        _sum_super = self.context.get_array(self.superrun_name, "sum", _combining_subruns=True)
+        sum_super = self.context.get_array(self.superrun_name, "sum", save="sum")
+        assert self.context.is_stored(self.superrun_name, "sum")
+        assert not self.context.is_stored(self.superrun_name, "sum", combining=True)
+        _sum_super = self.context.get_array(self.superrun_name, "sum", save="sum", combining=True)
 
         # superruns will still load and make subruns together
         assert np.unique(sum_super["sum"]).size == 1


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

To solve the caveat in https://github.com/AxFoundation/strax/pull/871, this PR saves the `combining` (True or False) in `strax.DataKey` to distinguish whether superrun is in only combining mode.

Also, change `_combining_subruns` to `combining` because it will be an argument frequently used.

**Can you briefly describe how it works?**

PR first simplifies `get_components` and adds another attribute `combining` in `strax.DataKey`.

**Can you give a minimal working example (or illustrate with a figure)?**


Please find the example at `test_only_combining_superruns` modified by this PR.

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
