### PR TITLE
Allow get_df on all data_types

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1909,7 +1909,7 @@ class Context:
         """
         df = self.get_array(run_id, targets, save=save, max_workers=max_workers, **kwargs)
 
-        return strax.convert_structured_array_to_df(df)
+        return strax.convert_structured_array_to_df(df, log=self.log)
 
     def get_zarr(
         self,

--- a/strax/context.py
+++ b/strax/context.py
@@ -1910,15 +1910,9 @@ class Context:
 
         """
         df = self.get_array(run_id, targets, save=save, max_workers=max_workers, **kwargs)
-        try:
-            return pd.DataFrame.from_records(df)
-        except Exception as e:
-            if "Data must be 1-dimensional" in str(e):
-                raise ValueError(
-                    f"Cannot load '{targets}' as a dataframe because it has "
-                    "array fields. Please use get_array."
-                )
-            raise
+
+        return strax.convert_structured_array_to_df(df)
+
 
     def get_zarr(
         self,

--- a/strax/context.py
+++ b/strax/context.py
@@ -1913,7 +1913,6 @@ class Context:
 
         return strax.convert_structured_array_to_df(df)
 
-
     def get_zarr(
         self,
         run_ids,

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -807,9 +807,9 @@ def convert_tuple_to_list(init_func_input):
 
 
 @export
-def convert_structured_array_to_df(structured_array):
-    """Convert a structured numpy array to a pandas DataFrame.
-
+def convert_structured_array_to_df(structured_array, log=None):
+    """
+    Convert a structured numpy array to a pandas DataFrame.
     Parameters:
     structured_array (numpy.ndarray): The structured array to be converted.
     Returns:
@@ -817,12 +817,26 @@ def convert_structured_array_to_df(structured_array):
 
     """
 
+    if log is None:
+        import logging
+
+        log = logging.getLogger("strax_array_to_df")
+    
     data_dict = {}
+    converted_cols = []
     for name in structured_array.dtype.names:
         col = structured_array[name]
         if col.ndim > 1:
             # Convert n-dimensional columns to lists of ndarrays
             data_dict[name] = [np.array(row) for row in col]
+            converted_cols.append(name)
         else:
             data_dict[name] = col
+
+    if converted_cols:
+        log.warning(
+            f"Columns {converted_cols} contain non-scalar entries. "
+            "Some pandas functions (e.g., groupby, apply) might not perform as expected on these columns."
+        )
+
     return pd.DataFrame(data_dict)

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -808,8 +808,8 @@ def convert_tuple_to_list(init_func_input):
 
 @export
 def convert_structured_array_to_df(structured_array, log=None):
-    """
-    Convert a structured numpy array to a pandas DataFrame.
+    """Convert a structured numpy array to a pandas DataFrame.
+
     Parameters:
     structured_array (numpy.ndarray): The structured array to be converted.
     Returns:
@@ -821,7 +821,7 @@ def convert_structured_array_to_df(structured_array, log=None):
         import logging
 
         log = logging.getLogger("strax_array_to_df")
-    
+
     data_dict = {}
     converted_cols = []
     for name in structured_array.dtype.names:

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -836,7 +836,8 @@ def convert_structured_array_to_df(structured_array, log=None):
     if converted_cols:
         log.warning(
             f"Columns {converted_cols} contain non-scalar entries. "
-            "Some pandas functions (e.g., groupby, apply) might not perform as expected on these columns."
+            "Some pandas functions (e.g., groupby, apply) might "
+            "not perform as expected on these columns."
         )
 
     return pd.DataFrame(data_dict)

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -813,3 +813,23 @@ def convert_tuple_to_list(init_func_input):
     else:
         # if not a container, return. i.e. int, float, bytes, str etc.
         return func_input
+
+@export
+def convert_structured_array_to_df(structured_array):
+    """
+    Convert a structured numpy array to a pandas DataFrame.
+    Parameters:
+    structured_array (numpy.ndarray): The structured array to be converted.
+    Returns:
+    pandas.DataFrame: The converted DataFrame.
+    """
+    
+    data_dict = {}
+    for name in structured_array.dtype.names:
+        col = structured_array[name]
+        if col.ndim > 1:
+            # Convert n-dimensional columns to lists of ndarrays
+            data_dict[name] = [np.array(row) for row in col]
+        else:
+            data_dict[name] = col
+    return pd.DataFrame(data_dict)

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -814,16 +814,18 @@ def convert_tuple_to_list(init_func_input):
         # if not a container, return. i.e. int, float, bytes, str etc.
         return func_input
 
+
 @export
 def convert_structured_array_to_df(structured_array):
-    """
-    Convert a structured numpy array to a pandas DataFrame.
+    """Convert a structured numpy array to a pandas DataFrame.
+
     Parameters:
     structured_array (numpy.ndarray): The structured array to be converted.
     Returns:
     pandas.DataFrame: The converted DataFrame.
+
     """
-    
+
     data_dict = {}
     for name in structured_array.dtype.names:
         col = structured_array[name]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,6 +35,7 @@ def test_core(allow_multiprocess, max_workers, processor):
 @processing_conditions
 def test_core_df(allow_multiprocess, max_workers, processor, caplog):
     """Test that get_df works with N-dimensional data."""
+    """Test that get_df works with N-dimensional data."""
     mystrax = strax.Context(
         storage=[],
         register=[Records, Peaks],
@@ -48,7 +49,8 @@ def test_core_df(allow_multiprocess, max_workers, processor, caplog):
     assert len(df.loc[0, "data"]) == 200
     assert len(df) == p.config["recs_per_chunk"] * p.config["n_chunks"]
     assert (
-        "contain non-scalar entries. Some pandas functions (e.g., groupby, apply) might not perform as expected on these columns."
+        "contain non-scalar entries. Some pandas functions (e.g., groupby, apply)"
+        " might not perform as expected on these columns." 
         in caplog.text
     )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -34,7 +34,7 @@ def test_core(allow_multiprocess, max_workers, processor):
 
 @processing_conditions
 def test_core_df(allow_multiprocess, max_workers, processor, caplog):
-    """Test that get_df works with N-dimensional data"""
+    """Test that get_df works with N-dimensional data."""
     mystrax = strax.Context(
         storage=[],
         register=[Records, Peaks],
@@ -47,7 +47,10 @@ def test_core_df(allow_multiprocess, max_workers, processor, caplog):
     p = mystrax.get_single_plugin(run_id, "records")
     assert len(df.loc[0, "data"]) == 200
     assert len(df) == p.config["recs_per_chunk"] * p.config["n_chunks"]
-    assert "contain non-scalar entries. Some pandas functions (e.g., groupby, apply) might not perform as expected on these columns." in caplog.text
+    assert (
+        "contain non-scalar entries. Some pandas functions (e.g., groupby, apply) might not perform as expected on these columns."
+        in caplog.text
+    )
 
 
 def test_post_office_state():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -34,7 +34,7 @@ def test_core(allow_multiprocess, max_workers, processor):
 
 @processing_conditions
 def test_core_df(allow_multiprocess, max_workers, processor):
-    """Test that get_df works with N-dimensional data"""
+    """Test that get_df works with N-dimensional data."""
     mystrax = strax.Context(
         storage=[],
         register=[Records, Peaks],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -32,6 +32,23 @@ def test_core(allow_multiprocess, max_workers, processor):
     assert bla.dtype == strax.peak_dtype()
 
 
+@processing_conditions
+def test_core_df(allow_multiprocess, max_workers, processor):
+    """Test that get_df works with N-dimensional data"""
+    mystrax = strax.Context(
+        storage=[],
+        register=[Records, Peaks],
+        processors=[processor],
+        allow_multiprocess=allow_multiprocess,
+        use_per_run_defaults=True,
+    )
+
+    df = mystrax.get_df(run_id=run_id, targets="peaks", max_workers=max_workers)
+    p = mystrax.get_single_plugin(run_id, "records")
+    assert len(df.loc[0, "data"]) == 200
+    assert len(df) == p.config["recs_per_chunk"] * p.config["n_chunks"]
+
+
 def test_post_office_state():
     mystrax = strax.Context(
         storage=[],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -50,8 +50,7 @@ def test_core_df(allow_multiprocess, max_workers, processor, caplog):
     assert len(df) == p.config["recs_per_chunk"] * p.config["n_chunks"]
     assert (
         "contain non-scalar entries. Some pandas functions (e.g., groupby, apply)"
-        " might not perform as expected on these columns." 
-        in caplog.text
+        " might not perform as expected on these columns." in caplog.text
     )
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -33,8 +33,8 @@ def test_core(allow_multiprocess, max_workers, processor):
 
 
 @processing_conditions
-def test_core_df(allow_multiprocess, max_workers, processor):
-    """Test that get_df works with N-dimensional data."""
+def test_core_df(allow_multiprocess, max_workers, processor, caplog):
+    """Test that get_df works with N-dimensional data"""
     mystrax = strax.Context(
         storage=[],
         register=[Records, Peaks],
@@ -47,6 +47,7 @@ def test_core_df(allow_multiprocess, max_workers, processor):
     p = mystrax.get_single_plugin(run_id, "records")
     assert len(df.loc[0, "data"]) == 200
     assert len(df) == p.config["recs_per_chunk"] * p.config["n_chunks"]
+    assert "contain non-scalar entries. Some pandas functions (e.g., groupby, apply) might not perform as expected on these columns." in caplog.text
 
 
 def test_post_office_state():


### PR DESCRIPTION
# What is the problem / what does the code in this PR do

Pandas' data strucutres can contain any type of Python objects. Therefore, there should be no issues in having np.arrays as element of a Pandas DataFrame.
Currently, the implementation of the Pandas method to convert from strucutred arrays to Pandas DataFrames is not optimal (it just doesn't work well). While we wait for them to fix it, I propose a fix myself just for our code.

This PR adds a function to properly convert between Numpy's structured arrays and pandas' DataFrames, allowing the user to use the `get_df()` method on any data type.

The PR also adds a simple test in `test_core.py`. Further tests can be implemented if deemed necessary.

# Can you briefly describe how it works?
For each column in the strucutred array, the function `convert_structured_array_to_dataframe()` in `strax/utils.py` checks the dimensionality of the column data (`col.ndim`). If  `col.ndim>1`, convert the column data so that each row contains and np.ndarray object that can be held by the Pandas dataframe. Otherwise, leave as is.

For event-type data, nothing changes, and the overhead is basically null. For loading peak-type n-dimensional data, there might be a very slight increase in computation time to convert the structured array to Pandas DataFrame. However, this was not possible before thsi PR, so it's an improvement nonetheless.

# Can you give a minimal working example (or illustrate with a figure)?

Setup in `montecarlo-development` using strax as in the PR:

```
import strax
import fuse
import getpass
user = getpass.getuser()

st = fuse.context.full_chain_context(
    output_folder=f"/scratch/midway3/{user}/fuse_data", corrections_version=15
)
st.set_config(
    {
        "path": "/project2/lgrandi/xenonnt/simulations/testing",
        "file_name": "pmt_neutrons_100.root",
        "entry_stop": 10,
    }
)

arr = st.get_array(["00000","00001"], "peaks")
df = st.get_df(["00001", "00000"], "peaks")
```

Both `arr` and `df` are populated with the same data.


```
type(arr[0]["area_per_channel"])

type(df["area_per_channel"][0])

type(df.loc[0, "area_per_channel"])
```

These all equal `numpy.ndarray`.