### PR TITLE
Add `run_id`  independent function to get the dependencies `datat_type`

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -2641,12 +2641,28 @@ class Context:
             for data_type, _hash, save_when, version in hashes
         }
 
+    def get_dependencies(self, data_type):
+        """Get the dependencies of a data_type."""
+        dependencies = set()
+
+        def _get_dependencies(_data_type):
+            if _data_type in self.root_data_types:
+                return
+            plugin = self._plugin_class_registry[_data_type]()
+            dependencies.update(plugin.depends_on)
+            for d in plugin.depends_on:
+                _get_dependencies(d)
+
+        _get_dependencies(data_type)
+        return dependencies
+
     @property
     def root_data_types(self):
         """Root data_type that does not depend on anything."""
         _root_data_types = set()
         for k, v in self._plugin_class_registry.items():
-            if not v.depends_on:
+            _v = v()
+            if not _v.depends_on:
                 _root_data_types |= set((k,))
         return _root_data_types
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -520,3 +520,10 @@ class TestContext(unittest.TestCase):
             "cut_peaks": "peaks",
         }
         assert data_type_collection == expected_data_type_collection
+
+    def test_get_dependencies(self):
+        st = self.get_context(True)
+        st.register(Records)
+        st.register(Peaks)
+        st.register(self.get_dummy_peaks_dependency())
+        assert "records" in st.get_dependencies("cut_peaks")


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

You can use `st._get_plugins(targets=(data_type,), run_id=run_id)` to get the dependencies of `data_type`, but this is too complicated, we need a simplified `run_id` independent function.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
