### PR TITLE
Cancel usage of `chunk_number` if loading the whole dependency

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -2454,6 +2454,7 @@ class Context:
         data_key = self.key_for(run_id, target, chunk_number=_chunk_number)
         target_plugin = self.__get_plugin(run_id, target, chunk_number=_chunk_number)
         target_md = target_plugin.metadata(run_id, target)
+        target_md["strax_version"] = strax.__version__
         # Copied from StorageBackend.saver
         if "dtype" in target_md:
             target_md["dtype"] = target_md["dtype"].descr.__repr__()

--- a/strax/context.py
+++ b/strax/context.py
@@ -2384,10 +2384,11 @@ class Context:
         rechunk=True,
         chunk_number_group: ty.Optional[ty.List[ty.List[int]]] = None,
         target_frontend_id: ty.Optional[int] = None,
+        check_is_stored: bool = True,
     ):
         """Merge the per-chunked data from the per-chunked dependency into the target storage."""
 
-        if self.is_stored(run_id, target):
+        if check_is_stored and self.is_stored(run_id, target):
             raise ValueError(f"Data {target} for {run_id} already exists.")
 
         self._check_merge_per_chunk_storage_kwargs(run_id, target, target_frontend_id)

--- a/strax/context.py
+++ b/strax/context.py
@@ -2392,14 +2392,18 @@ class Context:
 
         self._check_merge_per_chunk_storage_kwargs(run_id, target, target_frontend_id)
 
+        chunks = self.get_metadata(run_id, per_chunked_dependency)["chunks"]
         if chunk_number_group is not None:
             combined_chunk_numbers = list(itertools.chain(*chunk_number_group))
             if len(combined_chunk_numbers) != len(set(combined_chunk_numbers)):
                 raise ValueError(f"Duplicate chunk numbers found in {chunk_number_group}")
-            _chunk_number = {per_chunked_dependency: combined_chunk_numbers}
+            if min(combined_chunk_numbers) == 0 and max(combined_chunk_numbers) == len(chunks) - 1:
+                # If the chunks are all the chunks of the dependency, we can drop the chunk_number
+                _chunk_number = None
+            else:
+                _chunk_number = {per_chunked_dependency: combined_chunk_numbers}
         else:
             # if no chunk numbers are given, use information from the dependency
-            chunks = self.get_metadata(run_id, per_chunked_dependency)["chunks"]
             chunk_number_group = [[c["chunk_i"]] for c in chunks]
             _chunk_number = None
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

To make the lineage unchanged after merging per-chunk storage, we need to set `chunk_number` to `None` to keep lineage hash the same as non-per-chunk storage.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
