### PR TITLE
Add function of dependency level of `data_types`

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -555,7 +555,7 @@ class Context:
 
         :param data_type: Data type name
         :param pattern: Show only options that match (fnmatch) pattern
-        :param run_id: Run id to use for run-dependent config options. If omitted, will show
+        :param run_id: run id to use for run-dependent config options. If omitted, will show
             defaults active for new runs.
 
         """
@@ -1925,7 +1925,7 @@ class Context:
         cannot fit in memory zarr is very compatible with dask. Targets are loaded into separate
         arrays and runs are merged. the data is added to any existing data in the storage location.
 
-        :param run_ids: (Iterable) Run ids you wish to load.
+        :param run_ids: (Iterable) run ids you wish to load.
         :param targets: (Iterable) targets to load.
         :param storage: (str, optional) fsspec path to store array. Defaults to './strax_temp_data'.
         :param overwrite: (boolean, optional) whether to overwrite existing arrays for targets at
@@ -2396,7 +2396,7 @@ class Context:
 
         chunks = self.get_metadata(run_id, per_chunked_dependency)["chunks"]
         if chunk_number_group is not None:
-            combined_chunk_numbers = list(itertools.chain(*chunk_number_group))
+            combined_chunk_numbers = list(itertools.chain.from_iterable(chunk_number_group))
             if len(combined_chunk_numbers) != len(set(combined_chunk_numbers)):
                 raise ValueError(f"Duplicate chunk numbers found in {chunk_number_group}")
             if min(combined_chunk_numbers) == 0 and max(combined_chunk_numbers) == len(chunks) - 1:

--- a/strax/context.py
+++ b/strax/context.py
@@ -2542,8 +2542,7 @@ class Context:
 
         # Need to init the class e.g. if we want to allow depends_on which is not a class attribute
         plugin = self._plugin_class_registry[target]()
-        dependencies = strax.to_str_tuple(plugin.depends_on)
-        if not dependencies:
+        if not plugin.depends_on:
             raise strax.DataNotAvailable(f"Lowest level dependency {target} is not stored")
 
         forbidden = strax.to_str_tuple(self.context_config["forbid_creation_of"])
@@ -2562,7 +2561,7 @@ class Context:
 
         self.stored_dependencies(
             run_id,
-            target=dependencies,
+            target=plugin.depends_on,
             check_forbidden=check_forbidden,
             _targets_stored=_targets_stored,
         )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -510,3 +510,15 @@ def test_per_chunk_storage():
         st.register(p)
         with pytest.raises(ValueError):
             st.make(run_id, "whatever", chunk_number={"records": [0]})
+
+
+def test_dependency_tree():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        st = strax.Context(
+            storage=strax.DataDirectory(temp_dir, deep_scan=True),
+            register=[Records, Peaks],
+            use_per_run_defaults=True,
+        )
+        st.tree
+        st.inversed_tree
+        st.tree_levels

--- a/tests/test_superruns.py
+++ b/tests/test_superruns.py
@@ -337,8 +337,6 @@ class TestSuperRuns(unittest.TestCase):
         The test also shows the difference between the two.
 
         """
-        self.context.tree
-        self.context.inversed_tree
         self.context.check_superrun()
         sum_super = self.context.get_array(self.superrun_name, "sum", save="sum")
         assert self.context.is_stored(self.superrun_name, "sum")


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Sometimes we want to know which plugin is higher in the dependency tree than another. This PR adds the `tree_levels` function of `Context`, which returns the dictionary containing relative information.

For Example, for a given class with Records, Peaks registered, the tree_levels will return:
```
{'records': {'level': 0, 'class': 'Records', 'index': 0, 'order': 0}, 'peaks': {'level': 1, 'class': 'Peaks', 'index': 0, 'order': 1}}
```

**Can you briefly describe how it works?**

Go through the dependency tree and assign `level` for the `data_type`s first. The `level` of a `data_type` will be higher by at least 1 than its dependencies.

Then the `data_type`s will be sorted by `level`, `class`, and `index`. Where the `index` is the index of this `data_type` in `provides`.

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
