### PR TITLE
Set single thread of zstd and blosc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ pymongo = "*"
 scipy = "*"
 tqdm = ">=4.46.0"
 zarr = "*"
-zstd = "*"
+zstandard = "*"
 sharedarray = { url = "https://xenon.isi.edu/python/SharedArray-3.2.3.tar.gz", optional = true }
 base_environment = { git = "https://github.com/XENONnT/base_environment.git", optional = true }
 sphinx = { version = "*", optional = true }

--- a/strax/io.py
+++ b/strax/io.py
@@ -6,7 +6,7 @@ import json
 
 import numpy as np
 import blosc
-import zstd
+import zstandard
 import lz4.frame as lz4
 from ast import literal_eval
 
@@ -16,11 +16,15 @@ from strax import RUN_METADATA_PATTERN
 export, __all__ = strax.exporter()
 
 blosc.set_releasegil(True)
+blosc.set_nthreads(1)
 
 
 COMPRESSORS = dict(
     bz2=dict(compress=bz2.compress, decompress=bz2.decompress),
-    zstd=dict(compress=zstd.compress, decompress=zstd.decompress),
+    zstd=dict(
+        compress=zstandard.ZstdCompressor(threads=1).compress,
+        decompress=zstandard.ZstdDecompressor().decompress,
+    ),
     blosc=dict(
         compress=None,  # add special function to prevent overflow at bottom module
         decompress=blosc.decompress,


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Only https://github.com/XENONnT/outsource/pull/213 can not limit the usage of CPU because `zstd` and `blosc` by default will use as many as CPU on the machine.

This PR replaces `zstd` with `zstandard` and sets a one-thread constraint of `zstd` and `blosc`.

The reason for replacing `zstd` with `zstandard` is listed here: https://python-zstandard.readthedocs.io/en/latest/projectinfo.html#comparison-to-other-python-bindings and https://github.com/indygreg/python-zstandard/blob/e27f2f49f187f5f698e0a6004bee2aed80fe39e3/docs/projectinfo.rst?plain=1#L30.

I hope this will not make the previously compressed data unable to be decompressed.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
