### PR TITLE
Set default `max_downsample_factor_waveform_start` as not `None`

### DIFF
--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -110,7 +110,7 @@ class PeakSplitter:
         min_area=0,
         n_top_channels=0,
         save_waveform_start=False,
-        max_downsample_factor_waveform_start=None,
+        max_downsample_factor_waveform_start=2,
         **kwargs,
     ):
         if not len(records) or not len(peaks) or not do_iterations:


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Further fix of https://github.com/AxFoundation/strax/pull/867, otherwise you will get error like
```
Exception during processing, closing savers and reraising
Traceback (most recent call last):
  File "/srv/pegasus.zCfx4lR9W/process.py", line 136, in <module>
    main()
  File "/srv/pegasus.zCfx4lR9W/process.py", line 106, in main
    process(st, run_id, data_type, chunks)
  File "/srv/pegasus.zCfx4lR9W/process.py", line 31, in process
    st.make(
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/context.py", line 1755, in make
    for _ in self.get_iter(
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/context.py", line 1646, in get_iter
    generator.throw(e)
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/context.py", line 1613, in get_iter
    for n_chunks, result in enumerate(strax.continuity_check(generator), 1):
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/chunk.py", line 363, in continuity_check
    for chunk in chunk_iter:
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/processors/single_thread.py", line 60, in iter
    yield from final_generator
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/processors/post_office.py", line 198, in _read
    result = self._fetch_new(topic)
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/processors/post_office.py", line 241, in _fetch_new
    msg = next(self._producers[topic])
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/plugins/plugin.py", line 531, in iter
    yield from self._iter_compute(chunk_i=chunk_i, **inputs_merged)
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/plugins/plugin.py", line 558, in _iter_compute
    yield self.do_compute(chunk_i=chunk_i, **inputs_merged)
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/plugins/plugin.py", line 667, in do_compute
    result = self.compute(**kwargs)
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/straxen/plugins/peaklets/peaklets.py", line 273, in compute
    peaklets = strax.split_peaks(
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/processing/peak_splitting.py", line 58, in split_peaks
    return splitter(
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/processing/peak_splitting.py", line 171, in __call__
    new_peaks = self(
  File "/srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/processing/peak_splitting.py", line 153, in __call__
    strax.sum_waveform(
  File "/opt/XENONnT/anaconda/envs/XENONnT_el9.2024.09.1/lib/python3.9/site-packages/numba/core/dispatcher.py", line 423, in _compile_for_args
    error_rewrite(e, 'typing')
  File "/opt/XENONnT/anaconda/envs/XENONnT_el9.2024.09.1/lib/python3.9/site-packages/numba/core/dispatcher.py", line 364, in error_rewrite
    raise e.with_traceback(None)
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
Failed in nopython mode pipeline (step: nopython frontend)
No implementation of function Function(<built-in function le>) found for signature:
 
 >>> le(int64, none)
 
There are 24 candidate implementations:
  - Of which 20 did not match due to:
  Overload of function 'le': File: <numerous>: Line N/A.
    With argument(s): '(int64, none)':
   No match.
  - Of which 2 did not match due to:
  Operator Overload in function 'le': File: unknown: Line unknown.
    With argument(s): '(int64, none)':
   No match for registered cases:
    * (bool, bool) -> bool
    * (int8, int8) -> bool
    * (int16, int16) -> bool
    * (int32, int32) -> bool
    * (int64, int64) -> bool
    * (uint8, uint8) -> bool
    * (uint16, uint16) -> bool
    * (uint32, uint32) -> bool
    * (uint64, uint64) -> bool
    * (float32, float32) -> bool
    * (float64, float64) -> bool
  - Of which 2 did not match due to:
  Overload in function 'set_issubset': File: numba/cpython/setobj.py: Line 1623.
    With argument(s): '(int64, none)':
   Rejected as the implementation raised a specific error:
     TypingError: All arguments must be Sets, got (int64, none)
  raised from /opt/XENONnT/anaconda/envs/XENONnT_el9.2024.09.1/lib/python3.9/site-packages/numba/cpython/setobj.py:108

During: typing of intrinsic-call at /srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/processing/peak_building.py (185)

File ".local/lib/python3.9/site-packages/strax/processing/peak_building.py", line 185:
def store_downsampled_waveform(
    <source elided>
        # If the waveform is downsampled, we can store the first samples of the waveform
        if store_waveform_start and (downsample_factor <= max_downsample_factor_waveform_start):
        ^

During: resolving callee type: type(CPUDispatcher(<function store_downsampled_waveform at 0x1499e16211f0>))
During: typing of call at /srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/processing/peak_building.py (391)

During: resolving callee type: type(CPUDispatcher(<function store_downsampled_waveform at 0x1499e16211f0>))
During: typing of call at /srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/processing/peak_building.py (391)

During: resolving callee type: type(CPUDispatcher(<function store_downsampled_waveform at 0x1499e16211f0>))
During: typing of call at /srv/pegasus.zCfx4lR9W/.local/lib/python3.9/site-packages/strax/processing/peak_building.py (391)


File ".local/lib/python3.9/site-packages/strax/processing/peak_building.py", line 391:
def sum_waveform(
    <source elided>
        if n_top_channels > 0:
            store_downsampled_waveform(
            ^
```

This might be because numba will interpret `and` after calculating the two operands, not like pure python. This might also related to the error you see in https://github.com/XENONnT/straxen/actions/runs/11309064966/job/31453707242.

**Can you briefly describe how it works?**

Set a placeholder default value of `max_downsample_factor_waveform_start`.

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
