### PR TITLE
Do not add producer that has been added by saver

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1006,7 +1006,7 @@ class Context:
         """Get the datatype that is provided by a plugin but not depended on by any other plugin."""
         provides = [prov for p in plugins.values() for prov in strax.to_str_tuple(p.provides)]
         depends_on = [dep for p in plugins.values() for dep in strax.to_str_tuple(p.depends_on)]
-        uniques = list(set(provides) ^ set(depends_on))
+        uniques = list(set(provides) - set(depends_on))
         return strax.to_str_tuple(uniques)
 
     @property
@@ -1310,7 +1310,8 @@ class Context:
         if len(intersec):
             raise RuntimeError(f"{intersec} both computed and loaded?!")
         if len(targets) > 1:
-            final_plugin = [t for t in targets if t in self._get_end_targets(plugins)][:1]
+            pendants = set(targets) & set(self._get_end_targets(plugins))
+            final_plugin = tuple(pendants - set(loaders))[:1]
             self.log.warning(
                 "Multiple targets detected! This is only suitable for mass "
                 f"producing dataypes since only {final_plugin} will be "

--- a/strax/processors/post_office.py
+++ b/strax/processors/post_office.py
@@ -113,7 +113,12 @@ class PostOffice:
         result.append(f"Total time spent: {sum(self.time_spent.values())}")
         return "\n".join(result)
 
-    def register_producer(self, iterator: ty.Iterator[ty.Any], topic: ty.Union[str, ty.Tuple[str]]):
+    def register_producer(
+        self,
+        iterator: ty.Iterator[ty.Any],
+        topic: ty.Union[str, ty.Tuple[str]],
+        registered: ty.Tuple[str, ...] = tuple(),
+    ):
         """Register iterator as the source of messages for topic.
 
         If topic is a tuple of strings, the iterator should produce (topic -> message) dicts, with
@@ -128,7 +133,8 @@ class PostOffice:
                 # Multi-output producer, recurse
                 for sub_topic in topic:
                     self._multi_output_topics[sub_topic] = topic
-                    self.register_producer(iterator, sub_topic)
+                    if sub_topic not in registered:
+                        self.register_producer(iterator, sub_topic)
                 return
         assert isinstance(topic, str)
         if topic in self._producers:

--- a/strax/processors/single_thread.py
+++ b/strax/processors/single_thread.py
@@ -35,9 +35,15 @@ class SingleThreadProcessor(BaseProcessor):
                 continue
             plugins_seen.append(p)
 
+            # Some data_types might be already saved and can be loaded;
+            # remove them from the list of provides
+            provides = strax.to_str_tuple(
+                list(set(strax.to_str_tuple(p.provides)) - set(components.loaders))
+            )
+
             self.post_office.register_producer(
                 p.iter(iters={dep: self.post_office.get_iter(dep, d) for dep in p.depends_on}),
-                topic=strax.to_str_tuple(p.provides),
+                topic=strax.to_str_tuple(provides),
             )
 
         dtypes_built = {d: p for p in components.plugins.values() for d in p.provides}

--- a/strax/processors/single_thread.py
+++ b/strax/processors/single_thread.py
@@ -37,13 +37,10 @@ class SingleThreadProcessor(BaseProcessor):
 
             # Some data_types might be already saved and can be loaded;
             # remove them from the list of provides
-            provides = strax.to_str_tuple(
-                list(set(strax.to_str_tuple(p.provides)) - set(components.loaders))
-            )
-
             self.post_office.register_producer(
                 p.iter(iters={dep: self.post_office.get_iter(dep, d) for dep in p.depends_on}),
-                topic=strax.to_str_tuple(provides),
+                topic=strax.to_str_tuple(p.provides),
+                registered=tuple(components.loaders),
             )
 
         dtypes_built = {d: p for p in components.plugins.values() for d in p.provides}


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

This is to solve the error when `processor = "single_thread"` in https://github.com/AxFoundation/strax/issues/903.

In the example of https://github.com/AxFoundation/strax/issues/903, after `st.make(nt_test_run_id, "peaklets", processor="single_thread")`, the `pulse_counts` is saved. So the loader will load this plugin because `peaklets` need `records` and `pulse_counts` are produced along with `records`. So `pulse_counts` is in `components.loaders`.

But before this PR, since `records` is also in `components.plugins`, https://github.com/AxFoundation/strax/blob/dca35457bea07b278e331b07fefb98cea842e60a/strax/processors/single_thread.py#L38 will register `pulse_counts` in the producer so this caused the bug.

**Can you briefly describe how it works?**

This PR prevents the producer registration if a `data_type` is already in `components.loaders`.

**Can you give a minimal working example (or illustrate with a figure)?**

Please check https://github.com/AxFoundation/strax/issues/903.

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
