### PR TITLE
Add option to merge `lone_hits` into `data_start`

### DIFF
--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -190,11 +190,14 @@ def add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, waveform_start=Fals
     :param lone_hits: Numpy array of lone_hits
     :param to_pe: Gain values to convert lone hit area into PE.
     :param n_top_channels: Number of top array channels.
-    :param waveform_start: Boolean indicating if a lone hit should be added to the data_start field of peaks
+    :param waveform_start: Boolean indicating if a lone hit should be added to the data_start field
+        of peaks
 
     """
     _fully_contained_in_sanity(lone_hits, peaks)
-    _add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=n_top_channels, waveform_start=waveform_start)
+    _add_lone_hits(
+        peaks, lone_hits, to_pe, n_top_channels=n_top_channels, waveform_start=waveform_start
+    )
 
 
 @numba.njit(cache=True, nogil=True)
@@ -226,6 +229,6 @@ def _add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, waveform_start=Fal
 
             if index_wf_start < 0:
                 raise ValueError("Hit outside of full containment!")
-            
+
             if index_wf_start < len(p["data_start"]):
                 p["data_start"][index_wf_start] += lh_area


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

This PR is a follow-up of https://github.com/AxFoundation/strax/pull/867 adding the option to merge lone hits into the non-downsampled waveforms. 