### PR TITLE
Save `data_start` even there is no downsampling

### DIFF
--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -180,18 +180,17 @@ def store_downsampled_waveform(
             wv_buffer[: p["length"] * downsample_factor].reshape(-1, downsample_factor).sum(axis=1)
         )
         p["dt"] *= downsample_factor
-
-        # If the waveform is downsampled, we can store the first samples of the waveform
-        if store_waveform_start and (downsample_factor <= max_downsample_factor_waveform_start):
-            if p["length"] > len(p["data_start"]):
-                p["data_start"] = wv_buffer[: len(p["data_start"])]
-            else:
-                p["data_start"][: p["length"]] = wv_buffer[: p["length"]]
-
     else:
         if store_in_data_top:
             p["data_top"][: p["length"]] = wv_buffer_top[: p["length"]]
         p["data"][: p["length"]] = wv_buffer[: p["length"]]
+
+    # If the waveform is downsampled, we can store the first samples of the waveform
+    if store_waveform_start and (downsample_factor <= max_downsample_factor_waveform_start):
+        if p["length"] > len(p["data_start"]):
+            p["data_start"] = wv_buffer[: len(p["data_start"])]
+        else:
+            p["data_start"][: p["length"]] = wv_buffer[: p["length"]]
 
 
 @export


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Further, fix https://github.com/AxFoundation/strax/pull/867#discussion_r1797770537. As said in that conversation, People might misunderstand the non-downsampled `data_start` if they are zero.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
