### PR TITLE
Remove `max_downsample_factor_waveform_start`, simplify the saving of `data_start`

### DIFF
--- a/strax/dtypes.py
+++ b/strax/dtypes.py
@@ -166,7 +166,7 @@ def peak_dtype(
     n_widths=11,
     digitize_top=True,
     hits_timing=True,
-    save_waveform_start=True,
+    max_downsample_factor_waveform_start=-1,
 ):
     """Data type for peaks - ranges across all channels in a detector
     Remember to set channel to -1 (todo: make enum)
@@ -212,7 +212,7 @@ def peak_dtype(
         )
         dtype.insert(9, top_field)
 
-    if save_waveform_start:
+    if max_downsample_factor_waveform_start > 0:
         dtype += [
             (
                 (

--- a/strax/dtypes.py
+++ b/strax/dtypes.py
@@ -164,7 +164,7 @@ def peak_dtype(
     n_channels=100,
     n_sum_wv_samples=200,
     n_widths=11,
-    digitize_top=True,
+    store_data_top=True,
     hits_timing=True,
     save_waveform_start=True,
 ):
@@ -204,7 +204,7 @@ def peak_dtype(
                 np.int32,
             ),
         ]
-    if digitize_top:
+    if store_data_top:
         top_field = (
             ("Waveform data in PE/sample (not PE/ns!), top array", "data_top"),
             np.float32,

--- a/strax/dtypes.py
+++ b/strax/dtypes.py
@@ -166,7 +166,7 @@ def peak_dtype(
     n_widths=11,
     digitize_top=True,
     hits_timing=True,
-    max_downsample_factor_waveform_start=-1,
+    save_waveform_start=True,
 ):
     """Data type for peaks - ranges across all channels in a detector
     Remember to set channel to -1 (todo: make enum)
@@ -212,17 +212,16 @@ def peak_dtype(
         )
         dtype.insert(9, top_field)
 
-    if max_downsample_factor_waveform_start > 0:
-        dtype += [
+    if save_waveform_start:
+        start_field = (
             (
-                (
-                    "Waveform data in PE/sample (not PE/ns!), first 200 not downsampled samples",
-                    "data_start",
-                ),
-                np.float32,
-                n_sum_wv_samples,
-            )
-        ]
+                "Waveform data in PE/sample (not PE/ns!), first 200 not downsampled samples",
+                "data_start",
+            ),
+            np.float32,
+            n_sum_wv_samples,
+        )
+        dtype.insert(10, start_field)
 
     return dtype
 

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -380,13 +380,16 @@ def sum_waveform(
             area_per_channel[ch] += area_pe
             p["area"] += area_pe
 
-        store_downsampled_waveform(
-            p,
-            swv_buffer,
-            n_top_channels > 0,
-            store_data_start,
-            twv_buffer,
-        )
+        if n_top_channels > 0:
+            store_downsampled_waveform(
+                p,
+                swv_buffer,
+                True,
+                store_data_start,
+                twv_buffer,
+            )
+        else:
+            store_downsampled_waveform(p, swv_buffer, False, store_data_start)
 
         p["n_saturated_channels"] = p["saturated_channel"].sum()
         p["area_per_channel"][:] = area_per_channel

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -141,7 +141,7 @@ def store_downsampled_waveform(
     p,
     wv_buffer,
     store_in_data_top=False,
-    max_downsample_factor_waveform_start=2,
+    store_in_data_start=False,
     wv_buffer_top=np.ones(1, dtype=np.float32),
 ):
     """Downsample the waveform in buffer and store it in p['data'] and in p['data_top'] if indicated
@@ -154,9 +154,8 @@ def store_downsampled_waveform(
     :param store_in_data_top: Boolean which indicates whether to also store into p['data_top'] When
         downsampling results in a fractional number of samples, the peak is shortened rather than
         extended. This causes data loss, but it is necessary to prevent overlaps between peaks.
-    :param max_downsample_factor_waveform_start: Maximum downsample factor for storing the first
-        samples of the waveform. It should cover basically all S1s while keeping the disk usage low.
-        If negative, it will not store the first samples of the waveform.
+    :param store_in_data_start: Boolean which indicates whether to store the first samples of the
+        waveform in the peak.
 
     """
 
@@ -179,7 +178,7 @@ def store_downsampled_waveform(
         p["dt"] *= downsample_factor
 
         # If the waveform is downsampled, we can store the first samples of the waveform
-        if downsample_factor <= max_downsample_factor_waveform_start:
+        if store_in_data_start:
             if p["length"] > len(p["data_start"]):
                 p["data_start"] = wv_buffer[: len(p["data_start"])]
             else:
@@ -250,8 +249,8 @@ def sum_waveform(
     record_links,
     adc_to_pe,
     n_top_channels=0,
+    store_in_data_start=False,
     select_peaks_indices=None,
-    max_downsample_factor_waveform_start=2,
 ):
     """Compute sum waveforms for all peaks in peaks. Only builds summed waveform other regions in
     which hits were found. This is required to avoid any bias due to zero-padding and baselining.
@@ -262,12 +261,11 @@ def sum_waveform(
     :param records: Records to be used to build peaks.
     :param record_links: Tuple of previous and next records.
     :param n_top_channels: Number of top array channels.
+    :param store_in_data_start: Boolean which indicates whether to store the first samples of the
+        waveform in the peak.
     :param select_peaks_indices: Indices of the peaks for partial processing. In the form of
         np.array([np.int, np.int, ..]). If None (default), all the peaks are used for the summation.
         Assumes all peaks AND pulses have the same dt!
-    :param max_downsample_factor_waveform_start: Maximum downsample factor for storing the first
-        samples of the waveform. It should cover basically all S1s while keeping the disk usage low.
-        If negative, it will not store the first samples of the waveform.
 
     """
     if not len(records):
@@ -381,16 +379,13 @@ def sum_waveform(
             area_per_channel[ch] += area_pe
             p["area"] += area_pe
 
-        if n_top_channels > 0:
-            store_downsampled_waveform(
-                p,
-                swv_buffer,
-                True,
-                max_downsample_factor_waveform_start,
-                twv_buffer,
-            )
-        else:
-            store_downsampled_waveform(p, swv_buffer, False, max_downsample_factor_waveform_start)
+        store_downsampled_waveform(
+            p,
+            swv_buffer,
+            n_top_channels > 0,
+            store_in_data_start,
+            twv_buffer,
+        )
 
         p["n_saturated_channels"] = p["saturated_channel"].sum()
         p["area_per_channel"][:] = area_per_channel

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -141,7 +141,7 @@ def store_downsampled_waveform(
     p,
     wv_buffer,
     store_in_data_top=False,
-    max_downsample_factor_waveform_start=-1,
+    max_downsample_factor_waveform_start=2,
     wv_buffer_top=np.ones(1, dtype=np.float32),
 ):
     """Downsample the waveform in buffer and store it in p['data'] and in p['data_top'] if indicated
@@ -251,7 +251,7 @@ def sum_waveform(
     adc_to_pe,
     n_top_channels=0,
     select_peaks_indices=None,
-    max_downsample_factor_waveform_start=-1,
+    max_downsample_factor_waveform_start=2,
 ):
     """Compute sum waveforms for all peaks in peaks. Only builds summed waveform other regions in
     which hits were found. This is required to avoid any bias due to zero-padding and baselining.

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -174,7 +174,7 @@ def _replace_merged(result, orig, merge, skip_windows):
 
 
 @export
-def add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_in_data_start=False):
+def add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_data_start=False):
     """Function which adds information from lone hits to peaks if lone hit is inside a peak (e.g.
     after merging.). Modifies peak area and data inplace.
 
@@ -182,7 +182,7 @@ def add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_in_data_start
     :param lone_hits: Numpy array of lone_hits
     :param to_pe: Gain values to convert lone hit area into PE.
     :param n_top_channels: Number of top array channels.
-    :param store_in_data_start: Boolean which indicates whether to store the first samples of the
+    :param store_data_start: Boolean which indicates whether to store the first samples of the
         waveform in the peak.
 
     """
@@ -192,12 +192,12 @@ def add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_in_data_start
         lone_hits,
         to_pe,
         n_top_channels=n_top_channels,
-        store_in_data_start=store_in_data_start,
+        store_data_start=store_data_start,
     )
 
 
 @numba.njit(cache=True, nogil=True)
-def _add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_in_data_start=False):
+def _add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_data_start=False):
     """The core function of add_lone_hits."""
     fully_contained_index = _fully_contained_in(lone_hits, peaks)
 
@@ -219,7 +219,7 @@ def _add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_in_data_star
             if lh_i["channel"] < n_top_channels:
                 p["data_top"][index] += lh_area
 
-        if store_in_data_start:
+        if store_data_start:
             # Non-downsampled waveforms have a fixed dt of 10 ns
             index_wf_start = (lh_i["time"] - p["time"]) // 10
 

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -13,8 +13,7 @@ def merge_peaks(
     start_merge_at,
     end_merge_at,
     max_buffer=int(1e5),
-    save_waveform_start=False,
-    max_downsample_factor_waveform_start=2,
+    max_downsample_factor_waveform_start=-1,
 ):
     """Merge specified peaks with their neighbors, return merged peaks.
 
@@ -24,11 +23,9 @@ def merge_peaks(
     :param max_buffer: Maximum number of samples in the sum_waveforms and other waveforms of the
         resulting peaks (after merging). Peaks must be constructed based on the properties of
         constituent peaks, it being too time-consuming to revert to records/hits.
-    :param save_waveform_start: Boolean which indicates whether to store the first samples of the
-        waveform in the peak. It will only store the first samples if the waveform is downsampled
-        and the downsample factor is smaller equal to max_downsample_factor_waveform_start.
     :param max_downsample_factor_waveform_start: Maximum downsample factor for storing the first
         samples of the waveform. It should cover basically all S1s while keeping the disk usage low.
+        If negative, it will not store the first samples of the waveform.
 
     """
     assert len(start_merge_at) == len(end_merge_at)
@@ -101,7 +98,6 @@ def merge_peaks(
             new_p,
             buffer,
             True,
-            save_waveform_start,
             max_downsample_factor_waveform_start,
             buffer_top,
         )

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -13,7 +13,7 @@ def merge_peaks(
     start_merge_at,
     end_merge_at,
     max_buffer=int(1e5),
-    max_downsample_factor_waveform_start=-1,
+    max_downsample_factor_waveform_start=2,
 ):
     """Merge specified peaks with their neighbors, return merged peaks.
 
@@ -179,7 +179,7 @@ def _replace_merged(result, orig, merge, skip_windows):
 
 @export
 def add_lone_hits(
-    peaks, lone_hits, to_pe, n_top_channels=0, max_downsample_factor_waveform_start=-1
+    peaks, lone_hits, to_pe, n_top_channels=0, max_downsample_factor_waveform_start=2
 ):
     """Function which adds information from lone hits to peaks if lone hit is inside a peak (e.g.
     after merging.). Modifies peak area and data inplace.
@@ -204,7 +204,7 @@ def add_lone_hits(
 
 @numba.njit(cache=True, nogil=True)
 def _add_lone_hits(
-    peaks, lone_hits, to_pe, n_top_channels=0, max_downsample_factor_waveform_start=-1
+    peaks, lone_hits, to_pe, n_top_channels=0, max_downsample_factor_waveform_start=2
 ):
     """The core function of add_lone_hits."""
     fully_contained_index = _fully_contained_in(lone_hits, peaks)

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -193,7 +193,7 @@ def add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0):
 
     """
     _fully_contained_in_sanity(lone_hits, peaks)
-    _add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0)
+    _add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=n_top_channels)
 
 
 @numba.njit(cache=True, nogil=True)

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -13,7 +13,6 @@ def merge_peaks(
     start_merge_at,
     end_merge_at,
     max_buffer=int(1e5),
-    max_downsample_factor_waveform_start=2,
 ):
     """Merge specified peaks with their neighbors, return merged peaks.
 
@@ -23,9 +22,6 @@ def merge_peaks(
     :param max_buffer: Maximum number of samples in the sum_waveforms and other waveforms of the
         resulting peaks (after merging). Peaks must be constructed based on the properties of
         constituent peaks, it being too time-consuming to revert to records/hits.
-    :param max_downsample_factor_waveform_start: Maximum downsample factor for storing the first
-        samples of the waveform. It should cover basically all S1s while keeping the disk usage low.
-        If negative, it will not store the first samples of the waveform.
 
     """
     assert len(start_merge_at) == len(end_merge_at)
@@ -98,7 +94,7 @@ def merge_peaks(
             new_p,
             buffer,
             True,
-            max_downsample_factor_waveform_start,
+            True,
             buffer_top,
         )
 
@@ -178,9 +174,7 @@ def _replace_merged(result, orig, merge, skip_windows):
 
 
 @export
-def add_lone_hits(
-    peaks, lone_hits, to_pe, n_top_channels=0, max_downsample_factor_waveform_start=2
-):
+def add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_in_data_start=False):
     """Function which adds information from lone hits to peaks if lone hit is inside a peak (e.g.
     after merging.). Modifies peak area and data inplace.
 
@@ -188,8 +182,8 @@ def add_lone_hits(
     :param lone_hits: Numpy array of lone_hits
     :param to_pe: Gain values to convert lone hit area into PE.
     :param n_top_channels: Number of top array channels.
-    :param max_downsample_factor_waveform_start: Maximum downsample factor for storing the first
-        samples of the waveform.
+    :param store_in_data_start: Boolean which indicates whether to store the first samples of the
+        waveform in the peak.
 
     """
     _fully_contained_in_sanity(lone_hits, peaks)
@@ -198,14 +192,12 @@ def add_lone_hits(
         lone_hits,
         to_pe,
         n_top_channels=n_top_channels,
-        max_downsample_factor_waveform_start=max_downsample_factor_waveform_start,
+        store_in_data_start=store_in_data_start,
     )
 
 
 @numba.njit(cache=True, nogil=True)
-def _add_lone_hits(
-    peaks, lone_hits, to_pe, n_top_channels=0, max_downsample_factor_waveform_start=2
-):
+def _add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_in_data_start=False):
     """The core function of add_lone_hits."""
     fully_contained_index = _fully_contained_in(lone_hits, peaks)
 
@@ -227,7 +219,7 @@ def _add_lone_hits(
             if lh_i["channel"] < n_top_channels:
                 p["data_top"][index] += lh_area
 
-        if max_downsample_factor_waveform_start > 0:
+        if store_in_data_start:
             # Non-downsampled waveforms have a fixed dt of 10 ns
             index_wf_start = (lh_i["time"] - p["time"]) // 10
 

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -15,8 +15,7 @@ def split_peaks(
     algorithm="local_minimum",
     data_type="peaks",
     n_top_channels=0,
-    save_waveform_start=False,
-    max_downsample_factor_waveform_start=2,
+    max_downsample_factor_waveform_start=-1,
     **kwargs,
 ):
     """Return peaks split according to algorithm, with waveforms summed and widths computed.
@@ -39,11 +38,9 @@ def split_peaks(
         the new split peaks/hitlets.
     :param n_top_channels: Number of top array channels.
     :param result_dtype: dtype of the result.
-    :param save_waveform_start: Boolean which indicates whether to store the first samples of the
-        waveform in the peak. It will only store the first samples if the waveform is downsampled
-        and the downsample factor is smaller equal to max_downsample_factor_waveform_start.
     :param max_downsample_factor_waveform_start: Maximum downsample factor for storing the first
         samples of the waveform. It should cover basically all S1s while keeping the disk usage low.
+        If negative, it will not store the first samples of the waveform.
 
     Any other options are passed to the algorithm.
 
@@ -63,7 +60,6 @@ def split_peaks(
         to_pe,
         data_type,
         n_top_channels=n_top_channels,
-        save_waveform_start=save_waveform_start,
         max_downsample_factor_waveform_start=max_downsample_factor_waveform_start,
         **kwargs,
     )
@@ -88,11 +84,9 @@ class PeakSplitter:
         implemented in each subclass defines the algorithm, which takes in a peak's waveform and
         returns the index to split the peak at, if a split point is found. Otherwise NO_MORE_SPLITS
         is returned and the peak is left as is.
-    :param save_waveform_start: Boolean which indicates whether to store the first samples of the
-        waveform in the peak. It will only store the first samples if the waveform is downsampled
-        and the downsample factor is smaller equal to max_downsample_factor_waveform_start.
     :param max_downsample_factor_waveform_start: Maximum downsample factor for storing the first
         samples of the waveform. It should cover basically all S1s while keeping the disk usage low.
+        If negative, it will not store the first samples of the waveform.
 
     """
 
@@ -109,8 +103,7 @@ class PeakSplitter:
         do_iterations=1,
         min_area=0,
         n_top_channels=0,
-        save_waveform_start=False,
-        max_downsample_factor_waveform_start=2,
+        max_downsample_factor_waveform_start=-1,
         **kwargs,
     ):
         if not len(records) or not len(peaks) or not do_iterations:
@@ -157,7 +150,6 @@ class PeakSplitter:
                     rlinks,
                     to_pe,
                     n_top_channels,
-                    save_waveform_start=save_waveform_start,
                     max_downsample_factor_waveform_start=max_downsample_factor_waveform_start,
                 )
                 strax.compute_widths(new_peaks)

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -15,7 +15,7 @@ def split_peaks(
     algorithm="local_minimum",
     data_type="peaks",
     n_top_channels=0,
-    store_in_data_start=False,
+    store_data_start=False,
     **kwargs,
 ):
     """Return peaks split according to algorithm, with waveforms summed and widths computed.
@@ -38,7 +38,7 @@ def split_peaks(
         the new split peaks/hitlets.
     :param n_top_channels: Number of top array channels.
     :param result_dtype: dtype of the result.
-    :param store_in_data_start: Boolean which indicates whether to store the first samples of the
+    :param store_data_start: Boolean which indicates whether to store the first samples of the
         waveform in the peak.
 
     Any other options are passed to the algorithm.
@@ -59,7 +59,7 @@ def split_peaks(
         to_pe,
         data_type,
         n_top_channels=n_top_channels,
-        store_in_data_start=store_in_data_start,
+        store_data_start=store_data_start,
         **kwargs,
     )
 
@@ -83,7 +83,7 @@ class PeakSplitter:
         implemented in each subclass defines the algorithm, which takes in a peak's waveform and
         returns the index to split the peak at, if a split point is found. Otherwise NO_MORE_SPLITS
         is returned and the peak is left as is.
-    :param store_in_data_start: Boolean which indicates whether to store the first samples of the
+    :param store_data_start: Boolean which indicates whether to store the first samples of the
         waveform in the peak.
 
     """
@@ -101,7 +101,7 @@ class PeakSplitter:
         do_iterations=1,
         min_area=0,
         n_top_channels=0,
-        store_in_data_start=False,
+        store_data_start=False,
         **kwargs,
     ):
         if not len(records) or not len(peaks) or not do_iterations:
@@ -148,7 +148,7 @@ class PeakSplitter:
                     rlinks,
                     to_pe,
                     n_top_channels,
-                    store_in_data_start,
+                    store_data_start,
                 )
                 strax.compute_widths(new_peaks)
             elif data_type == "hitlets":

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -15,7 +15,7 @@ def split_peaks(
     algorithm="local_minimum",
     data_type="peaks",
     n_top_channels=0,
-    max_downsample_factor_waveform_start=-1,
+    max_downsample_factor_waveform_start=2,
     **kwargs,
 ):
     """Return peaks split according to algorithm, with waveforms summed and widths computed.
@@ -103,7 +103,7 @@ class PeakSplitter:
         do_iterations=1,
         min_area=0,
         n_top_channels=0,
-        max_downsample_factor_waveform_start=-1,
+        max_downsample_factor_waveform_start=2,
         **kwargs,
     ):
         if not len(records) or not len(peaks) or not do_iterations:

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -15,7 +15,7 @@ def split_peaks(
     algorithm="local_minimum",
     data_type="peaks",
     n_top_channels=0,
-    max_downsample_factor_waveform_start=2,
+    store_in_data_start=False,
     **kwargs,
 ):
     """Return peaks split according to algorithm, with waveforms summed and widths computed.
@@ -38,9 +38,8 @@ def split_peaks(
         the new split peaks/hitlets.
     :param n_top_channels: Number of top array channels.
     :param result_dtype: dtype of the result.
-    :param max_downsample_factor_waveform_start: Maximum downsample factor for storing the first
-        samples of the waveform. It should cover basically all S1s while keeping the disk usage low.
-        If negative, it will not store the first samples of the waveform.
+    :param store_in_data_start: Boolean which indicates whether to store the first samples of the
+        waveform in the peak.
 
     Any other options are passed to the algorithm.
 
@@ -60,7 +59,7 @@ def split_peaks(
         to_pe,
         data_type,
         n_top_channels=n_top_channels,
-        max_downsample_factor_waveform_start=max_downsample_factor_waveform_start,
+        store_in_data_start=store_in_data_start,
         **kwargs,
     )
 
@@ -84,9 +83,8 @@ class PeakSplitter:
         implemented in each subclass defines the algorithm, which takes in a peak's waveform and
         returns the index to split the peak at, if a split point is found. Otherwise NO_MORE_SPLITS
         is returned and the peak is left as is.
-    :param max_downsample_factor_waveform_start: Maximum downsample factor for storing the first
-        samples of the waveform. It should cover basically all S1s while keeping the disk usage low.
-        If negative, it will not store the first samples of the waveform.
+    :param store_in_data_start: Boolean which indicates whether to store the first samples of the
+        waveform in the peak.
 
     """
 
@@ -103,7 +101,7 @@ class PeakSplitter:
         do_iterations=1,
         min_area=0,
         n_top_channels=0,
-        max_downsample_factor_waveform_start=2,
+        store_in_data_start=False,
         **kwargs,
     ):
         if not len(records) or not len(peaks) or not do_iterations:
@@ -150,7 +148,7 @@ class PeakSplitter:
                     rlinks,
                     to_pe,
                     n_top_channels,
-                    max_downsample_factor_waveform_start=max_downsample_factor_waveform_start,
+                    store_in_data_start,
                 )
                 strax.compute_widths(new_peaks)
             elif data_type == "hitlets":

--- a/tests/test_general_processing.py
+++ b/tests/test_general_processing.py
@@ -284,14 +284,14 @@ def test_raw_to_records(r):
 def test_dtype_change_copy_to_buffer():
     """Tests if dtype change does not let copy to buffer fail, even if copy function name stays the
     same."""
-    peaks = np.ones(1, dtype=strax.peak_dtype(digitize_top=True))
-    buffer = np.zeros(1, dtype=strax.peak_dtype(digitize_top=True))
+    peaks = np.ones(1, dtype=strax.peak_dtype(store_data_top=True))
+    buffer = np.zeros(1, dtype=strax.peak_dtype(store_data_top=True))
 
     strax.copy_to_buffer(peaks, buffer, "_test_copy_to_buffer")
     assert np.all(peaks == buffer)
 
-    peaks = np.ones(1, dtype=strax.peak_dtype(digitize_top=False))
-    buffer = np.zeros(1, dtype=strax.peak_dtype(digitize_top=False))
+    peaks = np.ones(1, dtype=strax.peak_dtype(store_data_top=False))
+    buffer = np.zeros(1, dtype=strax.peak_dtype(store_data_top=False))
 
     strax.copy_to_buffer(peaks, buffer, "_test_copy_to_buffer")
     assert np.all(peaks == buffer)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

`max_downsample_factor_waveform_start` is not strictly needed. We can use the following logic: if `store_in_data_start` is `False`, do not save the `data_start`.

Also, change `digitize_top` to `store_data_top`, `store_in_data_top` to `store_data_top` to unify the variable names.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
