### PR TITLE
Small fix of dtype description

### DIFF
--- a/strax/dtypes.py
+++ b/strax/dtypes.py
@@ -216,7 +216,7 @@ def peak_dtype(
     if store_data_start:
         start_field = (
             (
-                "Waveform data in PE/sample (not PE/ns!), first 200 not downsampled samples",
+                "Waveform data in PE/sample (not PE/ns!), starting not downsampled samples",
                 "data_start",
             ),
             np.float32,


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

If the not downsampled sample length is less than 200, the length of `data_start` can not be 200 of course.