### PR TITLE
Fixing store_data_start in recursive peak splitter calls and peaklet["length'] fix in store_downsampled_waveform

### DIFF
--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -190,7 +190,7 @@ def store_downsampled_waveform(
         if p_length > len(p["data_start"]):
             p["data_start"] = waveform_buffer[: len(p["data_start"])]
         else:
-            p["data_start"][: p_length] = waveform_buffer[: p_length]
+            p["data_start"][:p_length] = waveform_buffer[:p_length]
 
 
 @export

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -161,6 +161,8 @@ def store_downsampled_waveform(
 
     n_samples = len(p["data"])
 
+    p_length = p["length"]
+
     downsample_factor = int(np.ceil(p["length"] / n_samples))
     if downsample_factor > 1:
         # Compute peak length after downsampling.
@@ -185,10 +187,10 @@ def store_downsampled_waveform(
 
     # If the waveform is downsampled, we can store the first samples of the waveform
     if store_data_start:
-        if p["length"] > len(p["data_start"]):
+        if p_length > len(p["data_start"]):
             p["data_start"] = waveform_buffer[: len(p["data_start"])]
         else:
-            p["data_start"][: p["length"]] = waveform_buffer[: p["length"]]
+            p["data_start"][: p_length] = waveform_buffer[: p_length]
 
 
 @export

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -168,6 +168,7 @@ class PeakSplitter:
                 do_iterations=do_iterations - 1,
                 min_area=min_area,
                 n_top_channels=n_top_channels,
+                store_data_start=store_data_start,
                 **kwargs,
             )
             if np.any(new_peaks["length"] == 0):


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

This PR fixes some smaller problems related to the `data_start` handling in the `peaklets` building/ splitting. 

- The flag `store_data_start` was not passed to recursive calls of the peak splitter. As a result some `peaklets` had `data_start` always set to 0. 
- `peaklet["length']` is used in `store_downsampled_waveform` to select the part of the waveform that is stored in `data_start`. If the waveform is downsampled, `peaklet["length']` is overwritten. When saving  `data_start` we need to take the initial length of the peaklet not the downsampled length. 