### PR TITLE
Raise error when peaks overlapping in `merge_peaks`

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -25,7 +25,7 @@ __all__.extend(["RUN_DEFAULTS_KEY"])
 RUN_DEFAULTS_KEY = "strax_defaults"
 TEMP_DATA_TYPE_PREFIX = "_temp_"
 
-# use tqdm as loaded in utils (from tqdm.notebook when in a juypyter env)
+# use tqdm as loaded in utils (from tqdm.notebook when in a jupyter env)
 tqdm = strax.utils.tqdm
 
 

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -45,32 +45,11 @@ def merge_peaks(
 
         # re-zero relevant part of buffers (overkill? not sure if
         # this saves much time)
-        buffer[
-            : min(
-                int(
-                    (
-                        last_peak["time"]
-                        - first_peak["time"]
-                        + (last_peak["length"] * old_peaks["dt"].max())
-                    )
-                    / common_dt
-                ),
-                len(buffer),
-            )
-        ] = 0
-        buffer_top[
-            : min(
-                int(
-                    (
-                        last_peak["time"]
-                        - first_peak["time"]
-                        + (last_peak["length"] * old_peaks["dt"].max())
-                    )
-                    / common_dt
-                ),
-                len(buffer_top),
-            )
-        ] = 0
+        bl = last_peak["time"] - first_peak["time"]
+        bl += last_peak["length"] * old_peaks["dt"].max()
+        bl = min(int(bl / common_dt), max_buffer)
+        buffer[:bl] = 0
+        buffer_top[:bl] = 0
 
         for p in old_peaks:
             # Upsample the sum and top/bottom array waveforms into their buffers

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -25,6 +25,8 @@ def merge_peaks(
 
     """
     assert len(start_merge_at) == len(end_merge_at)
+    if np.min(peaks["time"][1:] - strax.endtime(peaks)[:-1]) < 0:
+        raise ValueError("Peaks not disjoint! You have to rewrite this function to handle this.")
     new_peaks = np.zeros(len(start_merge_at), dtype=peaks.dtype)
 
     # Do the merging. Could numbafy this to optimize, probably...

--- a/strax/run_selection.py
+++ b/strax/run_selection.py
@@ -12,7 +12,7 @@ import datetime
 import strax
 from strax import stable_argsort
 
-# use tqdm as loaded in utils (from tqdm.notebook when in a juypyter env)
+# use tqdm as loaded in utils (from tqdm.notebook when in a jupyter env)
 tqdm = strax.utils.tqdm
 
 export, __all__ = strax.exporter()


### PR DESCRIPTION
This PR just adds a safeguard.

If we do need to handle the case where peaks overlap, we need to change two lines:

1. https://github.com/AxFoundation/strax/blob/dd62b13bff1279cbf9683649e93b04f537d0f41c/strax/processing/peak_merging.py#L44, we can not assume `last_peak` has the largest `endtime`
2. https://github.com/AxFoundation/strax/blob/dd62b13bff1279cbf9683649e93b04f537d0f41c/strax/processing/peak_merging.py#L80, should change `=` to `+=`