### PR TITLE
Move `compute_center_times` from straxen to strax

### DIFF
--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -71,6 +71,20 @@ def compute_index_of_fraction(peak, fractions_desired, result):
 
 
 @export
+@numba.njit(cache=True, nogil=True)
+def compute_center_times(peaks):
+    result = np.zeros(len(peaks), dtype=np.int64)
+    for p_i, p in enumerate(peaks):
+        t = 0
+        for t_i, weight in enumerate(p["data"]):
+            t += t_i * p["dt"] * weight
+        result[p_i] = (
+            t / p["area"] + p["dt"] / 2 + p["time"]
+        )  # converting from float to int, implicit floor
+    return result
+
+
+@export
 def compute_widths(peaks, select_peaks_indices=None):
     """Compute widths in ns at desired area fractions for peaks.
 

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -72,7 +72,7 @@ def compute_index_of_fraction(peak, fractions_desired, result):
 
 @export
 @numba.njit(cache=True, nogil=True)
-def compute_center_times(peaks):
+def compute_center_time(peaks):
     result = np.zeros(len(peaks), dtype=np.int64)
     for p_i, p in enumerate(peaks):
         t = 0


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

**Can you briefly describe how it works?**

Besides moving, two small changes are made:
1. add `dt / 2` to `center_time`
2. add `time` in the function (so `center_time` should be `np.int64`)

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
