### PR TITLE
First concert to int then add float to keep precision

### DIFF
--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -78,9 +78,8 @@ def compute_center_time(peaks):
         t = 0
         for t_i, weight in enumerate(p["data"]):
             t += t_i * p["dt"] * weight
-        result[p_i] = (
-            t / p["area"] + p["dt"] / 2 + p["time"]
-        )  # converting from float to int, implicit floor
+        result[p_i] = t / p["area"] + p["dt"] / 2
+        result[p_i] += p["time"]  # converting from float to int, implicit floor
     return result
 
 

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -75,10 +75,9 @@ def compute_index_of_fraction(peak, fractions_desired, result):
 def compute_center_time(peaks):
     result = np.zeros(len(peaks), dtype=np.int64)
     for p_i, p in enumerate(peaks):
-        t = 0
-        for t_i, weight in enumerate(p["data"]):
-            t += t_i * p["dt"] * weight
-        result[p_i] = t / p["area"] + p["dt"] / 2
+        data = p["data"][: p["length"]]
+        t = np.average(np.arange(p["length"]), weights=data)
+        result[p_i] = (t + 1 / 2) * p["dt"]
         result[p_i] += p["time"]  # converting from float to int, implicit floor
     return result
 


### PR DESCRIPTION
Just a minor improvement.

If using the previous approach, the `center_time` will be first converted to float then int. But the large `time` might cause the numerical error.

Following https://github.com/AxFoundation/strax/pull/938