### PR TITLE
Calculate `area_fraction_top`, `center_time` and `median_time` at peaklet level

### DIFF
--- a/strax/dtypes.py
+++ b/strax/dtypes.py
@@ -179,9 +179,12 @@ def peak_dtype(
         # For peaklets this is likely to be overwritten:
         (("Classification of the peak(let)", "type"), np.int8),
         (("Integral across channels [PE]", "area"), np.float32),
+        (("Fraction of area seen by the top array", "area_fraction_top"), np.float32),
         (("Integral per channel [PE]", "area_per_channel"), np.float32, n_channels),
         (("Number of hits contributing at least one sample to the peak ", "n_hits"), np.int32),
         (("Waveform data in PE/sample (not PE/ns!)", "data"), np.float32, n_sum_wv_samples),
+        (("Weighted average center time of the peak [ns]", "center_time"), np.int64),
+        (("Weighted relative median time of the peak [ns]", "median_time"), np.float32),
         (("Peak widths in range of central area fraction [ns]", "width"), np.float32, n_widths),
         (
             ("Peak widths: time between nth and 5th area decile [ns]", "area_decile_from_midpoint"),

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -3,6 +3,7 @@ import numba
 
 import strax
 from strax.dtypes import DIGITAL_SUM_WAVEFORM_CHANNEL
+from strax.processing.peak_properties import compute_area_fraction_top
 
 export, __all__ = strax.exporter()
 
@@ -278,7 +279,7 @@ def sum_waveform(
     if not len(peaks):
         return
     if select_peaks_indices is None:
-        select_peaks_indices = np.arange(len(peaks))
+        select_peaks_indices = range(len(peaks))
     if not len(select_peaks_indices):
         return
     dt = records[0]["dt"]
@@ -398,13 +399,8 @@ def sum_waveform(
         p["n_saturated_channels"] = p["saturated_channel"].sum()
         p["area_per_channel"][:] = area_per_channel
 
-        if n_top_channels > 0:
-            area_top = area_per_channel[:n_top_channels].sum()
-            # Negative-area peaks get NaN AFT
-            if p["area"] > 0:
-                p["area_fraction_top"] = area_top / p["area"]
-            else:
-                p["area_fraction_top"] = np.nan
+    if n_top_channels > 0:
+        compute_area_fraction_top(peaks, n_top_channels)
 
 
 @numba.njit(cache=True, nogil=True)

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -399,7 +399,7 @@ def sum_waveform(
         p["area_per_channel"][:] = area_per_channel
 
         if n_top_channels > 0:
-            area_top = area_per_channel[:n_top_channels]
+            area_top = area_per_channel[:n_top_channels].sum()
             # Negative-area peaks get NaN AFT
             if p["area"] > 0:
                 p["area_fraction_top"] = area_top / p["area"]

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -251,6 +251,7 @@ def sum_waveform(
     record_links,
     adc_to_pe,
     n_top_channels=0,
+    store_data_top=False,
     store_data_start=False,
     select_peaks_indices=None,
 ):
@@ -263,6 +264,8 @@ def sum_waveform(
     :param records: Records to be used to build peaks.
     :param record_links: Tuple of previous and next records.
     :param n_top_channels: Number of top array channels.
+    :param store_data_top: Boolean which indicates whether to store the top array waveform in the
+        peak.
     :param store_data_start: Boolean which indicates whether to store the first samples of the
         waveform in the peak.
     :param select_peaks_indices: Indices of the peaks for partial processing. In the form of
@@ -286,7 +289,7 @@ def sum_waveform(
     # Need a little more even for downsampling..
     swv_buffer = np.zeros(peaks["length"].max() * 2, dtype=np.float32)
 
-    if n_top_channels > 0:
+    if store_data_top:
         twv_buffer = np.zeros(peaks["length"].max() * 2, dtype=np.float32)
 
     n_channels = len(peaks[0]["area_per_channel"])
@@ -304,7 +307,7 @@ def sum_waveform(
         p_length = p["length"]
         swv_buffer[: min(2 * p_length, len(swv_buffer))] = 0
 
-        if n_top_channels > 0:
+        if store_data_top:
             twv_buffer[: min(2 * p_length, len(twv_buffer))] = 0
 
         # Clear area and area per channel
@@ -373,7 +376,7 @@ def sum_waveform(
             hit_data *= adc_to_pe[ch]
             swv_buffer[p_start:p_end] += hit_data
 
-            if n_top_channels > 0:
+            if store_data_top:
                 if ch < n_top_channels:
                     twv_buffer[p_start:p_end] += hit_data
 
@@ -381,7 +384,7 @@ def sum_waveform(
             area_per_channel[ch] += area_pe
             p["area"] += area_pe
 
-        if n_top_channels > 0:
+        if store_data_top:
             store_downsampled_waveform(
                 p,
                 swv_buffer,
@@ -394,6 +397,14 @@ def sum_waveform(
 
         p["n_saturated_channels"] = p["saturated_channel"].sum()
         p["area_per_channel"][:] = area_per_channel
+
+        if n_top_channels > 0:
+            area_top = area_per_channel[:n_top_channels]
+            # Negative-area peaks get NaN AFT
+            if p["area"] > 0:
+                p["area_fraction_top"] = area_top / p["area"]
+            else:
+                p["area_fraction_top"] = np.nan
 
 
 @numba.njit(cache=True, nogil=True)

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -3,7 +3,6 @@ import numba
 
 import strax
 from strax.dtypes import DIGITAL_SUM_WAVEFORM_CHANNEL
-from strax.processing.peak_properties import compute_area_fraction_top
 
 export, __all__ = strax.exporter()
 
@@ -279,7 +278,7 @@ def sum_waveform(
     if not len(peaks):
         return
     if select_peaks_indices is None:
-        select_peaks_indices = range(len(peaks))
+        select_peaks_indices = np.arange(len(peaks))
     if not len(select_peaks_indices):
         return
     dt = records[0]["dt"]
@@ -398,9 +397,6 @@ def sum_waveform(
 
         p["n_saturated_channels"] = p["saturated_channel"].sum()
         p["area_per_channel"][:] = area_per_channel
-
-    if n_top_channels > 0:
-        compute_area_fraction_top(peaks, n_top_channels)
 
 
 @numba.njit(cache=True, nogil=True)

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -155,7 +155,9 @@ def _replace_merged(result, orig, merge, skip_windows):
 
 
 @export
-def add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_data_start=False):
+def add_lone_hits(
+    peaks, lone_hits, to_pe, n_top_channels=0, store_data_top=False, store_data_start=False
+):
     """Function which adds information from lone hits to peaks if lone hit is inside a peak (e.g.
     after merging.). Modifies peak area and data inplace.
 
@@ -163,6 +165,8 @@ def add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_data_start=Fa
     :param lone_hits: Numpy array of lone_hits
     :param to_pe: Gain values to convert lone hit area into PE.
     :param n_top_channels: Number of top array channels.
+    :param store_data_top: Boolean which indicates whether to store the top array waveform in the
+        peak.
     :param store_data_start: Boolean which indicates whether to store the first samples of the
         waveform in the peak.
 
@@ -173,12 +177,15 @@ def add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_data_start=Fa
         lone_hits,
         to_pe,
         n_top_channels=n_top_channels,
+        store_data_top=store_data_top,
         store_data_start=store_data_start,
     )
 
 
 @numba.njit(cache=True, nogil=True)
-def _add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_data_start=False):
+def _add_lone_hits(
+    peaks, lone_hits, to_pe, n_top_channels=0, store_data_top=False, store_data_start=False
+):
     """The core function of add_lone_hits."""
     fully_contained_index = _fully_contained_in(lone_hits, peaks)
 
@@ -196,7 +203,7 @@ def _add_lone_hits(peaks, lone_hits, to_pe, n_top_channels=0, store_data_start=F
             raise ValueError("Hit outside of full containment!")
         p["data"][index] += lh_area
 
-        if n_top_channels > 0:
+        if store_data_top:
             if lh_i["channel"] < n_top_channels:
                 p["data_top"][index] += lh_area
 

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -3,6 +3,7 @@ import numpy as np
 
 import strax
 from strax.processing.general import _fully_contained_in, _fully_contained_in_sanity
+from strax.processing.peak_properties import compute_area_fraction_top
 
 export, __all__ = strax.exporter()
 
@@ -218,12 +219,4 @@ def _add_lone_hits(
                 p["data_start"][index_wf_start] += lh_area
 
     if n_top_channels > 0:
-        unique_index = np.unique(fully_contained_index[fully_contained_index != -1])
-        for fc_i in unique_index:
-            p = peaks[fc_i]
-            area_top = p["area_per_channel"][:n_top_channels].sum()
-            # Negative-area peaks get NaN AFT
-            if p["area"] > 0:
-                p["area_fraction_top"] = area_top / p["area"]
-            else:
-                p["area_fraction_top"] = np.nan
+        compute_area_fraction_top(peaks, n_top_channels)

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -188,6 +188,7 @@ def _add_lone_hits(
 ):
     """The core function of add_lone_hits."""
     fully_contained_index = _fully_contained_in(lone_hits, peaks)
+    unique_index = np.unique(fully_contained_index[fully_contained_index != -1])
 
     for fc_i, lh_i in zip(fully_contained_index, lone_hits):
         if fc_i == -1:
@@ -216,3 +217,13 @@ def _add_lone_hits(
 
             if index_wf_start < len(p["data_start"]):
                 p["data_start"][index_wf_start] += lh_area
+
+    if n_top_channels > 0:
+        for fc_i in unique_index:
+            p = peaks[fc_i]
+            area_top = p["area_per_channel"][:n_top_channels].sum()
+            # Negative-area peaks get NaN AFT
+            if p["area"] > 0:
+                p["area_fraction_top"] = area_top / p["area"]
+            else:
+                p["area_fraction_top"] = np.nan

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -3,7 +3,6 @@ import numpy as np
 
 import strax
 from strax.processing.general import _fully_contained_in, _fully_contained_in_sanity
-from strax.processing.peak_properties import compute_area_fraction_top
 
 export, __all__ = strax.exporter()
 
@@ -217,6 +216,3 @@ def _add_lone_hits(
 
             if index_wf_start < len(p["data_start"]):
                 p["data_start"][index_wf_start] += lh_area
-
-    if n_top_channels > 0:
-        compute_area_fraction_top(peaks, n_top_channels)

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -188,7 +188,6 @@ def _add_lone_hits(
 ):
     """The core function of add_lone_hits."""
     fully_contained_index = _fully_contained_in(lone_hits, peaks)
-    unique_index = np.unique(fully_contained_index[fully_contained_index != -1])
 
     for fc_i, lh_i in zip(fully_contained_index, lone_hits):
         if fc_i == -1:
@@ -219,6 +218,7 @@ def _add_lone_hits(
                 p["data_start"][index_wf_start] += lh_area
 
     if n_top_channels > 0:
+        unique_index = np.unique(fully_contained_index[fully_contained_index != -1])
         for fc_i in unique_index:
             p = peaks[fc_i]
             area_top = p["area_per_channel"][:n_top_channels].sum()

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -126,7 +126,7 @@ def compute_center_time_widths(peaks, select_peaks_indices=None):
         in which case compute for all peaks
 
     """
-    if not len(peaks) or not len(select_peaks_indices):
+    if not len(peaks) or (not select_peaks_indices and select_peaks_indices is not None):
         return
 
     if select_peaks_indices is None:

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -119,8 +119,23 @@ def compute_center_time(peaks):
 
 
 @export
-def compute_center_time_widths(peaks, select_peaks_indices=None):
-    """Compute center time and widths in ns at desired area fractions for peaks.
+@numba.njit(cache=True, nogil=True)
+def compute_area_fraction_top(peaks, n_top_channels):
+    """Compute the area fraction top for peaks."""
+    for peak_i in range(len(peaks)):
+        p = peaks[peak_i]
+        area_top = p["area_per_channel"][:n_top_channels].sum()
+        # Non-positive-area peaks get NaN AFT
+        if p["area"] > 0:
+            p["area_fraction_top"] = area_top / p["area"]
+        else:
+            p["area_fraction_top"] = np.nan
+
+
+@export
+def compute_properties(peaks, n_top_channels=0, select_peaks_indices=None):
+    """Compute properties: median_time, width, area_decile_from_midpoint,
+    center_time, and area_fraction_top for peaks.
 
     :param peaks: single strax peak(let) or other data-bearing dtype
     :param select_peaks_indices: array of integers informing which peaks to compute default to None
@@ -141,15 +156,6 @@ def compute_center_time_widths(peaks, select_peaks_indices=None):
     center_time = compute_center_time(peaks[select_peaks_indices])
     peaks["center_time"][select_peaks_indices] = center_time
 
-
-@export
-@numba.njit(cache=True, nogil=True)
-def compute_area_fraction_top(peaks, n_top_channels):
-    for peak_i in range(len(peaks)):
-        p = peaks[peak_i]
-        area_top = p["area_per_channel"][:n_top_channels].sum()
-        # Non-positive-area peaks get NaN AFT
-        if p["area"] > 0:
-            p["area_fraction_top"] = area_top / p["area"]
-        else:
-            p["area_fraction_top"] = np.nan
+    if n_top_channels > 0:
+        area_fraction_top = compute_area_fraction_top(peaks[select_peaks_indices], n_top_channels)
+        peaks["area_fraction_top"][select_peaks_indices] = area_fraction_top

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -140,3 +140,16 @@ def compute_center_time_widths(peaks, select_peaks_indices=None):
 
     center_time = compute_center_time(peaks[select_peaks_indices])
     peaks["center_time"][select_peaks_indices] = center_time
+
+
+@export
+@numba.njit(cache=True, nogil=True)
+def compute_area_fraction_top(peaks, n_top_channels):
+    for peak_i in range(len(peaks)):
+        p = peaks[peak_i]
+        area_top = p["area_per_channel"][:n_top_channels].sum()
+        # Non-positive-area peaks get NaN AFT
+        if p["area"] > 0:
+            p["area_fraction_top"] = area_top / p["area"]
+        else:
+            p["area_fraction_top"] = np.nan

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -127,7 +127,7 @@ def compute_center_time_widths(peaks, select_peaks_indices=None):
         in which case compute for all peaks
 
     """
-    if not len(peaks) or (select_peaks_indices is not None and len(select_peaks_indices)):
+    if not len(peaks) or (select_peaks_indices is not None and not len(select_peaks_indices)):
         return
 
     if select_peaks_indices is None:

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -122,14 +122,16 @@ def compute_center_time(peaks):
 @numba.njit(cache=True, nogil=True)
 def compute_area_fraction_top(peaks, n_top_channels):
     """Compute the area fraction top for peaks."""
+    area_fraction_top = np.zeros(len(peaks), dtype=np.float32)
     for peak_i in range(len(peaks)):
         p = peaks[peak_i]
         area_top = p["area_per_channel"][:n_top_channels].sum()
         # Non-positive-area peaks get NaN AFT
         if p["area"] > 0:
-            p["area_fraction_top"] = area_top / p["area"]
+            area_fraction_top[peak_i] = area_top / p["area"]
         else:
-            p["area_fraction_top"] = np.nan
+            area_fraction_top[peak_i] = np.nan
+    return area_fraction_top
 
 
 @export

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -136,9 +136,9 @@ def compute_center_time_widths(peaks, select_peaks_indices=None):
         _peaks = peaks[select_peaks_indices]
 
     median_time, width, area_decile_from_midpoint = compute_widths(_peaks)
-    peaks["median_time"][select_peaks_indices] = median_time
-    peaks["width"][select_peaks_indices] = width
-    peaks["area_decile_from_midpoint"][select_peaks_indices] = area_decile_from_midpoint
+    _peaks["median_time"] = median_time
+    _peaks["width"] = width
+    _peaks["area_decile_from_midpoint"] = area_decile_from_midpoint
 
     center_time = compute_center_time(_peaks)
-    peaks["center_time"][select_peaks_indices] = center_time
+    _peaks["center_time"] = center_time

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -126,7 +126,7 @@ def compute_center_time_widths(peaks, select_peaks_indices=None):
         in which case compute for all peaks
 
     """
-    if not len(peaks) or (not select_peaks_indices and select_peaks_indices is not None):
+    if not len(peaks) or (select_peaks_indices is not None and len(select_peaks_indices)):
         return
 
     if select_peaks_indices is None:

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -131,14 +131,12 @@ def compute_center_time_widths(peaks, select_peaks_indices=None):
         return
 
     if select_peaks_indices is None:
-        _peaks = peaks
-    if isinstance(select_peaks_indices, list):
-        _peaks = peaks[select_peaks_indices]
+        select_peaks_indices = slice(None)
 
-    median_time, width, area_decile_from_midpoint = compute_widths(_peaks)
-    _peaks["median_time"] = median_time
-    _peaks["width"] = width
-    _peaks["area_decile_from_midpoint"] = area_decile_from_midpoint
+    median_time, width, area_decile_from_midpoint = compute_widths(peaks[select_peaks_indices])
+    peaks["median_time"][select_peaks_indices] = median_time
+    peaks["width"][select_peaks_indices] = width
+    peaks["area_decile_from_midpoint"][select_peaks_indices] = area_decile_from_midpoint
 
-    center_time = compute_center_time(_peaks)
-    _peaks["center_time"] = center_time
+    center_time = compute_center_time(peaks[select_peaks_indices])
+    peaks["center_time"][select_peaks_indices] = center_time

--- a/strax/processing/peak_properties.py
+++ b/strax/processing/peak_properties.py
@@ -88,7 +88,8 @@ def compute_widths(peaks):
     # We lose the 50% fraction with this operation, let's add it back
     desired_fr = strax.stable_sort(np.unique(np.append(desired_fr, [0.5])))
 
-    fr_times = index_of_fraction(peaks, desired_fr) * peaks["dt"].reshape(-1, 1)
+    fr_times = index_of_fraction(peaks, desired_fr)
+    fr_times *= peaks["dt"].reshape(-1, 1)
 
     i = len(desired_fr) // 2
     median_time = fr_times[:, i]

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -158,7 +158,7 @@ class PeakSplitter:
                     store_data_top=store_data_top,
                     store_data_start=store_data_start,
                 )
-                strax.compute_center_time_widths(new_peaks)
+                strax.compute_properties(new_peaks, n_top_channels=n_top_channels)
             elif data_type == "hitlets":
                 # Add record fields here
                 new_peaks = strax.sort_by_time(

--- a/strax/processing/peak_splitting.py
+++ b/strax/processing/peak_splitting.py
@@ -15,6 +15,7 @@ def split_peaks(
     algorithm="local_minimum",
     data_type="peaks",
     n_top_channels=0,
+    store_data_top=False,
     store_data_start=False,
     **kwargs,
 ):
@@ -38,6 +39,8 @@ def split_peaks(
         the new split peaks/hitlets.
     :param n_top_channels: Number of top array channels.
     :param result_dtype: dtype of the result.
+    :param store_data_top: Boolean which indicates whether to store the top array
+        waveform in the peak.
     :param store_data_start: Boolean which indicates whether to store the first samples of the
         waveform in the peak.
 
@@ -59,6 +62,7 @@ def split_peaks(
         to_pe,
         data_type,
         n_top_channels=n_top_channels,
+        store_data_top=store_data_top,
         store_data_start=store_data_start,
         **kwargs,
     )
@@ -83,6 +87,8 @@ class PeakSplitter:
         implemented in each subclass defines the algorithm, which takes in a peak's waveform and
         returns the index to split the peak at, if a split point is found. Otherwise NO_MORE_SPLITS
         is returned and the peak is left as is.
+    :param store_data_top: Boolean which indicates whether to store the top array waveform in the
+        peak.
     :param store_data_start: Boolean which indicates whether to store the first samples of the
         waveform in the peak.
 
@@ -101,6 +107,7 @@ class PeakSplitter:
         do_iterations=1,
         min_area=0,
         n_top_channels=0,
+        store_data_top=False,
         store_data_start=False,
         **kwargs,
     ):
@@ -148,9 +155,10 @@ class PeakSplitter:
                     rlinks,
                     to_pe,
                     n_top_channels=n_top_channels,
+                    store_data_top=store_data_top,
                     store_data_start=store_data_start,
                 )
-                strax.compute_widths(new_peaks)
+                strax.compute_center_time_widths(new_peaks)
             elif data_type == "hitlets":
                 # Add record fields here
                 new_peaks = strax.sort_by_time(
@@ -168,6 +176,7 @@ class PeakSplitter:
                 do_iterations=do_iterations - 1,
                 min_area=min_area,
                 n_top_channels=n_top_channels,
+                store_data_top=store_data_top,
                 store_data_start=store_data_start,
                 **kwargs,
             )

--- a/tests/test_peak_processing.py
+++ b/tests/test_peak_processing.py
@@ -88,7 +88,15 @@ def test_sum_waveform(records):
         min_channels=1,
         max_duration=10_000_000,
     )
-    strax.sum_waveform(peaks, hits, records, rlinks, np.ones(n_ch), n_top_channels=n_top_channels)
+    strax.sum_waveform(
+        peaks,
+        hits,
+        records,
+        rlinks,
+        np.ones(n_ch),
+        n_top_channels=n_top_channels,
+        store_data_top=True,
+    )
 
     for p in peaks:
         # Area measures must be consistent
@@ -118,6 +126,7 @@ def test_sum_waveform(records):
             rlinks,
             np.ones(n_ch),
             n_top_channels=n_top_channels,
+            store_data_top=True,
             select_peaks_indices=np.array([0]),
         )
 
@@ -268,7 +277,7 @@ def test_peak_overflow(
     hits["right_integration"] = hits["right"]
     rlinks = strax.record_links(r)
     strax.sum_waveform(p, hits, r, rlinks, to_pe)
-    strax.compute_widths(p)
+    strax.compute_center_time_widths(p)
 
     try:
         print("Split peaks")

--- a/tests/test_peak_processing.py
+++ b/tests/test_peak_processing.py
@@ -277,7 +277,7 @@ def test_peak_overflow(
     hits["right_integration"] = hits["right"]
     rlinks = strax.record_links(r)
     strax.sum_waveform(p, hits, r, rlinks, to_pe)
-    strax.compute_center_time_widths(p)
+    strax.compute_properties(p)
 
     try:
         print("Split peaks")

--- a/tests/test_peak_properties.py
+++ b/tests/test_peak_properties.py
@@ -66,12 +66,12 @@ def test_index_of_fraction(peak_length, data_length):
     strategies.integers(min_value=2, max_value=10),
 )
 def test_compute_center_time_widths(peak_length, data_length, n_widths):
-    """Test strax.compute_center_time_widths."""
+    """Test strax.compute_properties."""
     peaks = get_filled_peaks(peak_length, data_length, n_widths)
 
     # Make a copy of peaks to test that they don't remain the same later
     pre_peaks = peaks.copy()
-    strax.compute_center_time_widths(peaks)
+    strax.compute_properties(peaks)
 
     assert len(pre_peaks) == len(peaks), "Lost peaks"
     if np.sum(peaks["area"] > 0) > 10:

--- a/tests/test_peak_properties.py
+++ b/tests/test_peak_properties.py
@@ -13,6 +13,7 @@ def get_filled_peaks(peak_length, data_length, n_widths):
     ]
     if n_widths is not None:
         dtype += [
+            (("median_time of p", "median_time"), np.float64),
             (("width of p", "width"), (np.float64, n_widths)),
             (
                 ("area_decile_from_midpoint of p", "area_decile_from_midpoint"),
@@ -63,13 +64,13 @@ def test_index_of_fraction(peak_length, data_length):
     # Number of widths to compute
     strategies.integers(min_value=2, max_value=10),
 )
-def test_compute_widths(peak_length, data_length, n_widths):
-    """Test strax.compute_widths."""
+def test_compute_center_time_widths(peak_length, data_length, n_widths):
+    """Test strax.compute_center_time_widths."""
     peaks = get_filled_peaks(peak_length, data_length, n_widths)
 
     # Make a copy of peaks to test that they don't remain the same later
     pre_peaks = peaks.copy()
-    strax.compute_widths(peaks)
+    strax.compute_center_time_widths(peaks)
 
     assert len(pre_peaks) == len(peaks), "Lost peaks"
     if np.sum(peaks["area"] > 0) > 10:

--- a/tests/test_peak_properties.py
+++ b/tests/test_peak_properties.py
@@ -13,6 +13,7 @@ def get_filled_peaks(peak_length, data_length, n_widths):
     ]
     if n_widths is not None:
         dtype += [
+            (("center_time of p", "center_time"), np.int64),
             (("median_time of p", "median_time"), np.float64),
             (("width of p", "width"), (np.float64, n_widths)),
             (


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Add `area_fraction_top`, `center_time`, and `median_time` to `peak_dtype`. They will be calculated by `compute_properties`.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
