### PR TITLE
Delete input chunks after compute method to save memory

### DIFF
--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -206,9 +206,9 @@ class Chunk:
         """
         t = max(min(t, self.end), self.start)  # type: ignore
         if t == self.end:
-            data1, data2 = self.data, self.data[:0]
+            data1, data2 = self.data, self.data[:0].copy()
         elif t == self.start:
-            data1, data2 = self.data[:0], self.data
+            data1, data2 = self.data[:0].copy(), self.data
         else:
             data1, data2, t = split_array(data=self.data, t=t, allow_early_split=allow_early_split)
 
@@ -249,9 +249,6 @@ class Chunk:
             **{**common_kwargs, "run_id": run_id_second_chunk},
         )
         return c1, c2
-
-    def __del__(self):
-        del self.data
 
     @classmethod
     def merge(cls, chunks, data_type="<UNKNOWN>"):

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -250,6 +250,9 @@ class Chunk:
         )
         return c1, c2
 
+    def __del__(self):
+        del self.data
+
     @classmethod
     def merge(cls, chunks, data_type="<UNKNOWN>"):
         """Create chunk by merging columns of chunks of same data kind.

--- a/strax/plugins/overlap_window_plugin.py
+++ b/strax/plugins/overlap_window_plugin.py
@@ -17,13 +17,16 @@ class OverlapWindowPlugin(Plugin):
     """
 
     parallel = False
-    clean_chunk_after_compute = False
 
     def __init__(self):
         super().__init__()
         self.cached_input = {}
         self.cached_results = None
         self.sent_until = 0
+        if self.clean_chunk_after_compute:
+            raise ValueError(
+                "OverlapWindowPlugin cannot clean chunks after compute because you need them later."
+            )
         # This guy can have a logger, it's not parallelized anyway
 
     def get_window_size(self):

--- a/strax/plugins/overlap_window_plugin.py
+++ b/strax/plugins/overlap_window_plugin.py
@@ -17,6 +17,7 @@ class OverlapWindowPlugin(Plugin):
     """
 
     parallel = False
+    clean_chunk_after_compute = False
 
     def __init__(self):
         super().__init__()

--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -667,7 +667,7 @@ class Plugin:
         )
         subruns = self._check_subruns_uniqueness(kwargs, {k: v.subruns for k, v in kwargs.items()})
 
-        chunks = list(kwargs.items())
+        chunks = list(kwargs.values())
 
         kwargs = {k: v.data for k, v in kwargs.items()}
         if self.compute_takes_chunk_i:

--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -667,6 +667,8 @@ class Plugin:
         )
         subruns = self._check_subruns_uniqueness(kwargs, {k: v.subruns for k, v in kwargs.items()})
 
+        chunks = list(kwargs.items())
+
         kwargs = {k: v.data for k, v in kwargs.items()}
         if self.compute_takes_chunk_i:
             kwargs["chunk_i"] = chunk_i
@@ -674,6 +676,10 @@ class Plugin:
             kwargs["start"] = start
             kwargs["end"] = end
         result = self.compute(**kwargs)
+
+        # Free memory by deleting the input chunks
+        for c in chunks:
+            del c
         return self._fix_output(result, start, end, superrun, subruns)
 
     @staticmethod

--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -4,6 +4,7 @@ A 'plugin' is something that outputs an array and gets arrays from one or more o
 
 """
 
+import sys
 from enum import IntEnum
 from collections import Counter
 import inspect
@@ -667,19 +668,26 @@ class Plugin:
         )
         subruns = self._check_subruns_uniqueness(kwargs, {k: v.subruns for k, v in kwargs.items()})
 
-        chunks = list(kwargs.values())
-
-        kwargs = {k: v.data for k, v in kwargs.items()}
+        _kwargs = {k: v.data for k, v in kwargs.items()}
         if self.compute_takes_chunk_i:
-            kwargs["chunk_i"] = chunk_i
+            _kwargs["chunk_i"] = chunk_i
         if self.compute_takes_start_end:
-            kwargs["start"] = start
-            kwargs["end"] = end
-        result = self.compute(**kwargs)
+            _kwargs["start"] = start
+            _kwargs["end"] = end
+        result = self.compute(**_kwargs)
+        del _kwargs
 
         # Free memory by deleting the input chunks
-        for c in chunks:
-            del c
+        keys = list(kwargs.keys())
+        for k in keys:
+            # Minus one accounts for reference created by sys.getrefcount itself
+            n = sys.getrefcount(kwargs[k].data) - 1
+            if n != 1:
+                raise ValueError(
+                    f"Reference count of input {k} is {n} "
+                    "and should be 1. This is a memory leak."
+                )
+            del kwargs[k].data
         return self._fix_output(result, start, end, superrun, subruns)
 
     @staticmethod

--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -105,7 +105,7 @@ class Plugin:
     compute_takes_start_end = False
 
     allow_superrun = False
-    clean_chunk_after_compute = True
+    clean_chunk_after_compute = False
     gc_collect_after_compute = False
 
     def __init__(self):


### PR DESCRIPTION
This will lower the memory usage of `st.make(run_id, 'peaklets')` of XENONnT by 1 / 6, if set `clean_chunk_after_compute = True`.

Note: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:straxen:optimize_outsource_resources#optimized_memory_usage