### PR TITLE
Reduce RAM usage of `find_hit_integration_bounds`

### DIFF
--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -490,9 +490,10 @@ def find_hit_integration_bounds(
         boundaries. E.g. to negative samples for left side.
 
     """
-    result = np.zeros((len(hits), 2), dtype=np.int64)
     if not len(hits):
-        return result
+        return
+
+    result = np.zeros((len(hits), 2), dtype=np.int64)
 
     # By default, use save_outside_hits to determine bounds
     result[:, 0] = hits["time"] - save_outside_hits[0]

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -543,11 +543,11 @@ def find_hit_integration_bounds(
         last_hit_index[ch] = hit_i
 
     # Convert to index in record and store
-    t0 = records[hits["record_i"]]["time"]
-    dt = records[hits["record_i"]]["dt"]
     for hit_i, h in enumerate(hits):
-        h["left_integration"] = (result[hit_i, 0] - t0[hit_i]) // dt[hit_i]
-        h["right_integration"] = (result[hit_i, 1] - t0[hit_i]) // dt[hit_i]
+        t0 = records["time"][hits["record_i"][hit_i]]
+        dt = records["dt"][hits["record_i"][hit_i]]
+        h["left_integration"] = (result[hit_i, 0] - t0) // dt
+        h["right_integration"] = (result[hit_i, 1] - t0) // dt
 
 
 @export

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -208,7 +208,7 @@ def _add_lone_hits(
                 p["data_top"][index] += lh_area
 
         if store_data_start:
-            # Non-downsampled waveforms have a fixed dt of 10 ns
+            # Non-downsampled waveforms have a fixed minimum dt
             index_wf_start = (lh_i["time"] - p["time"]) // 10
 
             if index_wf_start < 0:


### PR DESCRIPTION
`t0 = records[hits["record_i"]]["time"]` and `dt = records[hits["record_i"]]["dt"]` will create a temporary array that takes a lot of memory.