### PR TITLE
Fix bug of numbafied `merge_peaks`

### DIFF
--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -75,13 +75,14 @@ def _merge_peaks(
     if np.min(peaks["time"][1:] - strax.endtime(peaks)[:-1]) < 0:
         raise ValueError("Peaks not disjoint! You have to rewrite this function to handle this.")
     new_peaks = np.zeros(len(start_merge_at), dtype=peaks.dtype)
-    new_peaks["min_diff"] = 2147483647  # inf of int32
 
     # Do the merging. Could numbafy this to optimize, probably...
     buffer = np.zeros(max_buffer, dtype=np.float32)
     buffer_top = np.zeros(max_buffer, dtype=np.float32)
 
     for new_i, new_p in enumerate(new_peaks):
+        new_p["min_diff"] = 2147483647  # inf of int32
+
         sl = slice(start_merge_at[new_i], end_merge_at[new_i])
         old_peaks = peaks[sl]
         # if merged is not None, we have to only take the merged peaks
@@ -146,8 +147,8 @@ def _merge_peaks(
         new_p["n_saturated_channels"] = new_p["saturated_channel"].sum()
 
         # too lazy to compute these
-        new_peaks["max_gap"] = -1
-        new_peaks["max_goodness_of_split"] = np.nan
+        # new_p["max_gap"] = -1
+        new_p["max_goodness_of_split"] = np.nan
 
         # Use tight_coincidence of the peak with the highest amplitude
         new_p["tight_coincidence"] = old_peaks["tight_coincidence"][np.argmax(max_data)]

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -147,7 +147,7 @@ def _merge_peaks(
         new_p["n_saturated_channels"] = new_p["saturated_channel"].sum()
 
         # too lazy to compute these
-        # new_p["max_gap"] = -1
+        new_p["max_gap"] = -1
         new_p["max_goodness_of_split"] = np.nan
 
         # Use tight_coincidence of the peak with the highest amplitude


### PR DESCRIPTION
To solve errors in https://github.com/XENONnT/straxen/actions/runs/12668685734/job/35309542822?pr=1513

```
       Rejected as the implementation raised a specific error:
         NumbaTypeError: Unsupported array index type unicode_type in [unicode_type]
  raised from /opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/numba/core/typing/arraydecl.py:104
      - Of which 1 did not match due to:
      Overload in function 'SetItemBuffer.generic': File: numba/core/typing/arraydecl.py: Line 221.
        With argument(s): '(unaligned array(Record(Start time since unix epoch [ns][type=int64;offset=0;title=Start time since unix epoch [ns]],time[type=int64;offset=0;title=Start time since unix epoch [ns]],Length of the interval in samples[type=int32;offset=8;title=Length of the interval in samples],length[type=int32;offset=8;title=Length of the interval in samples],Width of one sample [ns][type=int32;offset=12;title=Width of one sample [ns]],dt[type=int32;offset=12;title=Width of one sample [ns]],Channel/PMT number[type=int16;offset=16;title=Channel/PMT number],channel[type=int16;offset=16;title=Channel/PMT number],Classification of the peak(let)[type=int8;offset=18;title=Classification of the peak(let)],type[type=int8;offset=18;title=Classification of the peak(let)],SOM subtype of the peak(let)[type=int32;offset=19;title=SOM subtype of the peak(let)],som_sub_type[type=int32;offset=19;title=SOM subtype of the peak(let)],Vanilla type of the peak(let)[type=int8;offset=23;title=Vanilla type of the peak(let)],vanilla_type[type=int8;offset=23;title=Vanilla type of the peak(let)],loc_x_som[type=int16;offset=24;title=x location of the peak(let) in the SOM],x location of the peak(let) in the SOM[type=int16;offset=24;title=x location of the peak(let) in the SOM],loc_y_som[type=int16;offset=26;title=y location of the peak(let) in the SOM],y location of the peak(let) in the SOM[type=int16;offset=26;title=y location of the peak(let) in the SOM],Reconstructed cnf S2 X position (cm), uncorrected[type=float32;offset=28;title=Reconstructed cnf S2 X position (cm), uncorrected],x_cnf[type=float32;offset=28;title=Reconstructed cnf S2 X position (cm), uncorrected],Reconstructed cnf S2 Y position (cm), uncorrected[type=float32;offset=32;title=Reconstructed cnf S2 Y position (cm), uncorrected],y_cnf[type=float32;offset=32;title=Reconstructed cnf S2 Y position (cm), uncorrected],Position uncertainty contour (cm)[type=nestedarray(float32, (17, 2));offset=36;title=Position uncertainty contour (cm)],position_contour_cnf[type=nestedarray(float32, (17, 2));offset=36;title=Position uncertainty contour (cm)],Position uncertainty in r (cm)[type=float32;offset=172;title=Position uncertainty in r (cm)],r_uncertainty_cnf[type=float32;offset=172;title=Position uncertainty in r (cm)],Position uncertainty in theta (rad)[type=float32;offset=176;title=Position uncertainty in theta (rad)],theta_uncertainty_cnf[type=float32;offset=176;title=Position uncertainty in theta (rad)],Exclusive end time since unix epoch [ns][type=int64;offset=180;title=Exclusive end time since unix epoch [ns]],endtime[type=int64;offset=180;title=Exclusive end time since unix epoch [ns]],Integral across channels [PE][type=float32;offset=188;title=Integral across channels [PE]],area[type=float32;offset=188;title=Integral across channels [PE]],Fraction of area seen by the top array[type=float32;offset=192;title=Fraction of area seen by the top array],area_fraction_top[type=float32;offset=192;title=Fraction of area seen by the top array],Integral per channel [PE][type=nestedarray(float32, (494,));offset=196;title=Integral per channel [PE]],area_per_channel[type=nestedarray(float32, (494,));offset=196;title=Integral per channel [PE]],Number of hits contributing at least one sample to the peak [type=int32;offset=2172;title=Number of hits contributing at least one sample to the peak ],n_hits[type=int32;offset=2172;title=Number of hits contributing at least one sample to the peak ],Waveform data in PE/sample (not PE/ns!), top array[type=nestedarray(float32, (200,));offset=2176;title=Waveform data in PE/sample (not PE/ns!), top array],data_top[type=nestedarray(float32, (200,));offset=2176;title=Waveform data in PE/sample (not PE/ns!), top array],Waveform data in PE/sample (not PE/ns!), starting not downsampled samples[type=nestedarray(float32, (200,));offset=2976;title=Waveform data in PE/sample (not PE/ns!), starting not downsampled samples],data_start[type=nestedarray(float32, (200,));offset=2976;title=Waveform data in PE/sample (not PE/ns!), starting not downsampled samples],Waveform data in PE/sample (not PE/ns!)[type=nestedarray(float32, (200,));offset=3776;title=Waveform data in PE/sample (not PE/ns!)],data[type=nestedarray(float32, (200,));offset=3776;title=Waveform data in PE/sample (not PE/ns!)],Weighted average center time of the peak [ns][type=int64;offset=4576;title=Weighted average center time of the peak [ns]],center_time[type=int64;offset=4576;title=Weighted average center time of the peak [ns]],Weighted relative median time of the peak [ns][type=float32;offset=4584;title=Weighted relative median time of the peak [ns]],median_time[type=float32;offset=4584;title=Weighted relative median time of the peak [ns]],Peak widths in range of central area fraction [ns][type=nestedarray(float32, (11,));offset=4588;title=Peak widths in range of central area fraction [ns]],width[type=nestedarray(float32, (11,));offset=4588;title=Peak widths in range of central area fraction [ns]],Peak widths: time between nth and 5th area decile [ns][type=nestedarray(float32, (11,));offset=4632;title=Peak widths: time between nth and 5th area decile [ns]],area_decile_from_midpoint[type=nestedarray(float32, (11,));offset=4632;title=Peak widths: time between nth and 5th area decile [ns]],Does the channel reach ADC saturation?[type=nestedarray(int8, (494,));offset=4676;title=Does the channel reach ADC saturation?],saturated_channel[type=nestedarray(int8, (494,));offset=4676;title=Does the channel reach ADC saturation?],Total number of saturated channels[type=int16;offset=5170;title=Total number of saturated channels],n_saturated_channels[type=int16;offset=5170;title=Total number of saturated channels],Channel within tight range of mean[type=int16;offset=5172;title=Channel within tight range of mean],tight_coincidence[type=int16;offset=5172;title=Channel within tight range of mean],Largest gap between hits inside peak [ns][type=int32;offset=5174;title=Largest gap between hits inside peak [ns]],max_gap[type=int32;offset=5174;title=Largest gap between hits inside peak [ns]],Maximum interior goodness of split[type=float32;offset=5178;title=Maximum interior goodness of split],max_goodness_of_split[type=float32;offset=5178;title=Maximum interior goodness of split],Largest time difference between apexes of hits inside peak [ns][type=int32;offset=5182;title=Largest time difference between apexes of hits inside peak [ns]],max_diff[type=int32;offset=5182;title=Largest time difference between apexes of hits inside peak [ns]],Smallest time difference between apexes of hits inside peak [ns][type=int32;offset=5186;title=Smallest time difference between apexes of hits inside peak [ns]],min_diff[type=int32;offset=5186;title=Smallest time difference between apexes of hits inside peak [ns]];5190;False), 1d, C), Literal[str](min_diff), Literal[int](2147483647))':
       Rejected as the implementation raised a specific error:
         NumbaTypeError: Unsupported array index type Literal[str](min_diff) in [Literal[str](min_diff)]
  raised from /opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/numba/core/typing/arraydecl.py:104

During: typing of staticsetitem at /opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/strax/processing/peak_merging.py (78)

File "../../../../../opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/strax/processing/peak_merging.py", line 78:
def _merge_peaks(
    <source elided>
    new_peaks = np.zeros(len(start_merge_at), dtype=peaks.dtype)
    new_peaks["min_diff"] = 2147483647  # inf of int32
    ^
```