### PR TITLE
Do not concatenate empty dataframes

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1128,7 +1128,7 @@ class Context:
             if targets[0].startswith(TEMP_DATA_TYPE_PREFIX):
                 raise ValueError(
                     "When only combining subruns, you can only assign one target, "
-                    f"but got{plugins[targets[0]].depends_on}!"
+                    f"but got {plugins[targets[0]].depends_on}!"
                 )
             raise ValueError(f"Plugin {targets} does not allowed superrun!")
 

--- a/strax/run_selection.py
+++ b/strax/run_selection.py
@@ -193,8 +193,10 @@ def scan_runs(
             docs = new_docs
         else:
             # Keep only new runs (not found by earlier frontends)
-            docs = pd.concat([docs, new_docs[~np.in1d(new_docs["name"], docs["name"])]], sort=False)
-            docs.reset_index(drop=True, inplace=True)
+            mask = ~np.in1d(new_docs["name"], docs["name"])
+            if np.any(mask):
+                docs = pd.concat([docs, new_docs[mask]], sort=False)
+                docs.reset_index(drop=True, inplace=True)
 
     # Rearrange columns
     if not self.context_config["use_per_run_defaults"] and strax.RUN_DEFAULTS_KEY in docs.columns:


### PR DESCRIPTION
Otherwise, you will see

```
/home/xudc/strax/strax/run_selection.py:196: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
  docs = pd.concat([docs, new_docs[~np.in1d(new_docs["name"], docs["name"])]], sort=False)
```