### PR TITLE
When loader is available, do not save anything

### DIFF
--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -297,6 +297,7 @@ class Chunk:
             data_kind=data_kind,
             run_id=run_id,
             data=data,
+            subruns=_merge_subruns_in_chunk(chunks, merge=True),
             superrun=_merge_superrun_in_chunk(chunks, merge=True),
             target_size_mb=max([c.target_size_mb for c in chunks]),
         )
@@ -487,7 +488,7 @@ def _mergable_check(merged_runs, merge=False):
         }
 
 
-def _merge_subruns_in_chunk(chunks):
+def _merge_subruns_in_chunk(chunks, merge=False):
     """Merge list of subruns in a superrun chunk during concatenation.
 
     Updates also their start/ends too.
@@ -496,7 +497,7 @@ def _merge_subruns_in_chunk(chunks):
     subruns = dict()
     for c_i, c in enumerate(chunks):
         _merge_runs_in_chunk(c.subruns, subruns)
-    _mergable_check(subruns)
+    _mergable_check(subruns, merge)
     if subruns:
         return subruns
     else:

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -1,4 +1,5 @@
 import typing as ty
+from warnings import warn
 
 import numpy as np
 import numba
@@ -330,7 +331,11 @@ class Chunk:
         else:
             run_id = None
             superrun = _merge_superrun_in_chunk(chunks)
-        subruns = _merge_subruns_in_chunk(chunks)
+        try:
+            subruns = _merge_subruns_in_chunk(chunks, merge=False)
+        except ValueError:
+            warn("The subruns are not continuous, try merge mode.")
+            subruns = _merge_subruns_in_chunk(chunks, merge=True)
 
         prev_end = 0
         for c in chunks:

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -222,27 +222,24 @@ class Chunk:
 
         if self.first_subrun["start"] != self.start or self.last_subrun["end"] != self.end:
             # TODO: be more clever on this?
-            warn(
-                "Subruns start and end does not match with chunk start and end. "
-                "This might mean that you are using ExhaustPlugin. "
-                "So the split will not update the subruns or superrun."
-            )
+            # Subruns start and end does not match with chunk start and end.
+            # This might mean that you are using ExhaustPlugin.
+            # So the split will not update the subruns or superrun.
             subruns_first_chunk = subruns_second_chunk = self.subruns
-            superrun_first_chunk = superrun_second_chunk = self.superrun
-            run_id_first_chunk = run_id_second_chunk = self.run_id
         else:
             subruns_first_chunk, subruns_second_chunk = _split_runs_in_chunk(self.subruns, t)
-            superrun_first_chunk, superrun_second_chunk = _split_runs_in_chunk(self.superrun, t)
-            # If the superrun is split and the fragment cover only one run,
-            # you need to recover the run_id
-            if superrun_first_chunk is None or len(superrun_first_chunk) == 1:
-                run_id_first_chunk = list(self.superrun.keys())[0]
-            else:
-                run_id_first_chunk = self.run_id
-            if superrun_second_chunk is None or len(superrun_second_chunk) == 1:
-                run_id_second_chunk = list(self.superrun.keys())[-1]
-            else:
-                run_id_second_chunk = self.run_id
+
+        superrun_first_chunk, superrun_second_chunk = _split_runs_in_chunk(self.superrun, t)
+        # If the superrun is split and the fragment cover only one run,
+        # you need to recover the run_id
+        if superrun_first_chunk is None or len(superrun_first_chunk) == 1:
+            run_id_first_chunk = list(self.superrun.keys())[0]
+        else:
+            run_id_first_chunk = self.run_id
+        if superrun_second_chunk is None or len(superrun_second_chunk) == 1:
+            run_id_second_chunk = list(self.superrun.keys())[-1]
+        else:
+            run_id_second_chunk = self.run_id
 
         c1 = strax.Chunk(
             start=self.start,

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -220,7 +220,11 @@ class Chunk:
             target_size_mb=self.target_size_mb,
         )
 
-        if self.first_subrun["start"] != self.start or self.last_subrun["end"] != self.end:
+        if (
+            self.is_superrun
+            and self.first_subrun["start"] != self.start
+            or self.last_subrun["end"] != self.end
+        ):
             # TODO: be more clever on this?
             # Subruns start and end does not match with chunk start and end.
             # This might mean that you are using ExhaustPlugin.

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -220,18 +220,29 @@ class Chunk:
             target_size_mb=self.target_size_mb,
         )
 
-        subruns_first_chunk, subruns_second_chunk = _split_runs_in_chunk(self.subruns, t)
-        superrun_first_chunk, superrun_second_chunk = _split_runs_in_chunk(self.superrun, t)
-        # If the superrun is split and the fragment cover only one run,
-        # you need to recover the run_id
-        if superrun_first_chunk is None or len(superrun_first_chunk) == 1:
-            run_id_first_chunk = list(self.superrun.keys())[0]
+        if self.first_subrun["start"] != self.start or self.last_subrun["end"] != self.end:
+            # TODO: be more clever on this?
+            warn(
+                "Subruns start and end does not match with chunk start and end. "
+                "This might mean that you are using ExhaustPlugin. "
+                "So the split will not update the subruns or superrun."
+            )
+            subruns_first_chunk = subruns_second_chunk = self.subruns
+            superrun_first_chunk = superrun_second_chunk = self.superrun
+            run_id_first_chunk = run_id_second_chunk = self.run_id
         else:
-            run_id_first_chunk = self.run_id
-        if superrun_second_chunk is None or len(superrun_second_chunk) == 1:
-            run_id_second_chunk = list(self.superrun.keys())[-1]
-        else:
-            run_id_second_chunk = self.run_id
+            subruns_first_chunk, subruns_second_chunk = _split_runs_in_chunk(self.subruns, t)
+            superrun_first_chunk, superrun_second_chunk = _split_runs_in_chunk(self.superrun, t)
+            # If the superrun is split and the fragment cover only one run,
+            # you need to recover the run_id
+            if superrun_first_chunk is None or len(superrun_first_chunk) == 1:
+                run_id_first_chunk = list(self.superrun.keys())[0]
+            else:
+                run_id_first_chunk = self.run_id
+            if superrun_second_chunk is None or len(superrun_second_chunk) == 1:
+                run_id_second_chunk = list(self.superrun.keys())[-1]
+            else:
+                run_id_second_chunk = self.run_id
 
         c1 = strax.Chunk(
             start=self.start,

--- a/strax/chunk.py
+++ b/strax/chunk.py
@@ -220,10 +220,8 @@ class Chunk:
             target_size_mb=self.target_size_mb,
         )
 
-        if (
-            self.is_superrun
-            and self.first_subrun["start"] != self.start
-            or self.last_subrun["end"] != self.end
+        if self.is_superrun and (
+            self.first_subrun["start"] != self.start or self.last_subrun["end"] != self.end
         ):
             # TODO: be more clever on this?
             # Subruns start and end does not match with chunk start and end.

--- a/strax/context.py
+++ b/strax/context.py
@@ -711,10 +711,10 @@ class Context:
                     parent_name = opt.parent_option_name
 
                     mes = (
-                        f'Cannot find "{parent_name}" among the options of the parent.'
-                        f" Either you specified by accident {option_name} as child option"
-                        " or you specified the wrong parent_option_name. Have you specified "
-                        "the correct parent option name?"
+                        f'Cannot find "{parent_name}" among the options of the parent. '
+                        f"Either you specified by accident {option_name} as child option "
+                        "or you specified the wrong parent_option_name. Have you specified "
+                        "the correct parent_option_name?"
                     )
                     assert parent_name in p.config, mes
                     p.config[parent_name] = option_value
@@ -1160,7 +1160,7 @@ class Context:
             )
 
             allow_superrun = plugins[target_i].allow_superrun
-            if not loader and is_superrun and not allow_superrun or combining:
+            if not loader and (is_superrun and not allow_superrun or combining):
                 # allow_superrun is False so we start to collect the subruns' data_types,
                 # which are the depends_on of the superrun's data_type.
                 if time_range is not None:
@@ -1248,8 +1248,13 @@ class Context:
                 for dep_d in target_plugin.depends_on:
                     check_cache(dep_d)
 
-            # In case we can load the data already we want make a new superrun.
-            if loader and not (is_superrun and self.context_config["write_superruns"]):
+            # In case the target is already loaded we do not have to save it.
+            # Except for the case of combining mode.
+            if loader and not combining:
+                return
+
+            # In case wrinting superruns is disabled we do not have to save it.
+            if is_superrun and not self.context_config["write_superruns"]:
                 return
 
             # Now we should check whether we meet the saving requirements.

--- a/strax/context.py
+++ b/strax/context.py
@@ -1158,6 +1158,7 @@ class Context:
             loader = self._get_partial_loader_for(
                 key, time_range=time_range, chunk_number=_chunk_number
             )
+            loadable = loader is not False
 
             allow_superrun = plugins[target_i].allow_superrun
             if not loader and (is_superrun and not allow_superrun or combining):
@@ -1249,8 +1250,8 @@ class Context:
                     check_cache(dep_d)
 
             # In case the target is already loaded we do not have to save it.
-            # Except for the case of combining mode.
-            if loader and not combining:
+            # Except when the target is originally not loadable (in combining mode).
+            if loader and ((combining and loadable) or not combining):
                 return
 
             # In case wrinting superruns is disabled we do not have to save it.

--- a/strax/context.py
+++ b/strax/context.py
@@ -1101,8 +1101,6 @@ class Context:
                 raise ValueError(f"Plugin names must be more than one letter, not {t}")
 
         is_superrun = run_id.startswith("_")
-        if len(targets) > 1 and combining:
-            raise ValueError("Combining subruns is only supported for a single target")
         if is_superrun and chunk_number is not None:
             raise ValueError("Per chunk processing is only allowed when not processing superrun.")
         if not is_superrun and combining:

--- a/strax/context.py
+++ b/strax/context.py
@@ -1090,8 +1090,11 @@ class Context:
         {get_docs}
 
         """
-        save = strax.to_str_tuple(save)
         targets = strax.to_str_tuple(targets)
+        save = strax.to_str_tuple(save)
+
+        if save and combining:
+            raise ValueError("You can not save data when combining subruns.")
 
         for t in targets:
             if len(t) == 1:
@@ -1153,7 +1156,6 @@ class Context:
             loader = self._get_partial_loader_for(
                 key, time_range=time_range, chunk_number=_chunk_number
             )
-            loadable = loader is not False
 
             allow_superrun = plugins[target_i].allow_superrun
             if (
@@ -1253,8 +1255,7 @@ class Context:
                 return
 
             # In case the target is already loaded we do not have to save it.
-            # Except when the target is originally not loadable (in combining mode).
-            if loader and ((combining and loadable) or not combining):
+            if loader:
                 return
 
             # In case wrinting superruns is disabled we do not have to save it.
@@ -1579,6 +1580,7 @@ class Context:
                 temp_name = TEMP_DATA_TYPE_PREFIX + strax.deterministic_hash(targets)
                 p = type(temp_name, (strax.MergeOnlyPlugin,), dict(depends_on=tuple(targets)))
                 if is_superrun:
+                    # In case the checking about allow_superrun shows error
                     p.allow_superrun = True
                 self.register(p)
                 targets = (temp_name,)

--- a/tests/test_superruns.py
+++ b/tests/test_superruns.py
@@ -126,14 +126,9 @@ class TestSuperRuns(unittest.TestCase):
             self.superrun_name, "peak_classification", combining=True
         )
         assert len(components.loaders) == 1
-        assert len(components.savers) == 1
+        # no savers in combining mode
+        assert len(components.savers) == 0
         assert "peak_classification" in components.loaders
-        assert "peak_classification" in components.savers
-
-        with self.assertRaises(ValueError):
-            self.context.get_components(
-                self.superrun_name, ("peaks", "peak_classification"), combining=True
-            )
 
     def test_create_and_load_superruns(self):
         """Creates "new" superrun data from already existing data.
@@ -335,7 +330,7 @@ class TestSuperRuns(unittest.TestCase):
         sum_super = self.context.get_array(self.superrun_name, "sum", save="sum")
         assert self.context.is_stored(self.superrun_name, "sum")
         assert not self.context.is_stored(self.superrun_name, "sum", combining=True)
-        _sum_super = self.context.get_array(self.superrun_name, "sum", save="sum", combining=True)
+        _sum_super = self.context.get_array(self.superrun_name, "sum", combining=True)
 
         # superruns will still load and make subruns together
         assert np.unique(sum_super["sum"]).size == 1

--- a/tests/test_superruns.py
+++ b/tests/test_superruns.py
@@ -325,11 +325,6 @@ class TestSuperRuns(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.context.get_array(self.subrun_ids[0], "peaks", combining=True)
 
-    def test_superrun_mutiple_targets(self):
-        """Test that multiple targets does not work with superrun."""
-        with self.assertRaises(ValueError):
-            self.context.get_array(self.superrun_name, ("peaks", "peak_classification"))
-
     def test_only_combining_superruns(self):
         """Test loading superruns when only combining subruns.
 

--- a/tests/test_superruns.py
+++ b/tests/test_superruns.py
@@ -160,7 +160,6 @@ class TestSuperRuns(unittest.TestCase):
         assert chunk["last_endtime"] == np.max(strax.endtime(subrun_data))
 
         # Check if subruns and superrun have the same time stamps
-        self.context.set_context_config({"write_superruns": False})
         subrun_data = self.context.get_array(self.subrun_ids, "peaks", progress_bar=False)
         superrun_data = self.context.get_array(self.superrun_name, "peaks")
         assert np.all(subrun_data["time"] == superrun_data["time"])


### PR DESCRIPTION
This is a bug fix for https://github.com/AxFoundation/strax/pull/871.

Do not allow `save` in `combining` mode.