### PR TITLE
Set `chunk_number` as attribute of `Plugin` to pass `chunk_i`

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -997,7 +997,7 @@ class Context:
                             f"Chunk number for {d_depends} is already set in the lineage"
                         )
                     self._check_chunk_number(chunk_number[d_depends])
-                    plugin.chunk_numbers = chunk_number[d_depends]
+                    plugin.chunk_number = chunk_number[d_depends]
                     configs["chunk_number"][d_depends] = chunk_number[d_depends]
 
         plugin.lineage = {last_provide: (plugin.__class__.__name__, plugin.version(), configs)}

--- a/strax/context.py
+++ b/strax/context.py
@@ -886,6 +886,11 @@ class Context:
             d_depends: self.__get_plugin(run_id, d_depends, chunk_number=chunk_number)
             for d_depends in plugin.depends_on
         }
+        if plugin.compute_takes_chunk_i and len(plugin.dependencies_by_kind()) > 1:
+            raise ValueError(
+                f"Plugin {plugin.__class__} has multiple dependencies and takes chunk_i as input, "
+                "which is not supported."
+            )
 
         self.__add_lineage_to_plugin(run_id, plugin, chunk_number=chunk_number)
 
@@ -975,6 +980,11 @@ class Context:
         if chunk_number is not None:
             for d_depends in plugin.depends_on:
                 if d_depends in chunk_number:
+                    if len(plugin.depends_on) > 1:
+                        raise ValueError(
+                            "Can not assign chunk_number for multi-dependencies plugins "
+                            "because it is not clear which input should be assigned."
+                        )
                     not_allowed_plugins = (strax.LoopPlugin, strax.OverlapWindowPlugin)
                     if issubclass(plugin.__class__, not_allowed_plugins):
                         raise ValueError(
@@ -987,6 +997,7 @@ class Context:
                             f"Chunk number for {d_depends} is already set in the lineage"
                         )
                     self._check_chunk_number(chunk_number[d_depends])
+                    plugin.chunk_numbers = chunk_number[d_depends]
                     configs["chunk_number"][d_depends] = chunk_number[d_depends]
 
         plugin.lineage = {last_provide: (plugin.__class__.__name__, plugin.version(), configs)}

--- a/strax/plugins/exhaust_plugin.py
+++ b/strax/plugins/exhaust_plugin.py
@@ -10,7 +10,7 @@ class ExhaustPlugin(Plugin):
         return False
 
     def do_compute(self, chunk_i=None, **kwargs):
-        if chunk_i != 0:
+        if chunk_i != self.first_chunk:
             raise RuntimeError(
                 f"{self.__class__.__name__} is an ExhaustPlugin. "
                 "It should read all chunks together can process them together."

--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -104,7 +104,7 @@ class Plugin:
     compute_takes_chunk_i = False  # Autoinferred, no need to set yourself
     compute_takes_start_end = False
 
-    chunk_numbers = None
+    chunk_number = None
     allow_superrun = False
     clean_chunk_after_compute = False
     gc_collect_after_compute = False
@@ -216,9 +216,9 @@ class Plugin:
 
     @property
     def first_chunk(self):
-        if self.chunk_numbers is None:
+        if self.chunk_number is None:
             return 0
-        return self.chunk_numbers[0]
+        return self.chunk_number[0]
 
     @property
     def is_superrun(self):
@@ -454,7 +454,7 @@ class Plugin:
             pass
 
         try:
-            for chunk_i in itertools.count() if self.chunk_numbers is None else self.chunk_numbers:
+            for chunk_i in itertools.count() if self.chunk_number is None else self.chunk_number:
                 # Online input support
                 while not self.is_ready(chunk_i):
                     if self.source_finished():

--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -104,6 +104,7 @@ class Plugin:
     compute_takes_chunk_i = False  # Autoinferred, no need to set yourself
     compute_takes_start_end = False
 
+    chunk_numbers = None
     allow_superrun = False
     clean_chunk_after_compute = False
     gc_collect_after_compute = False
@@ -212,6 +213,12 @@ class Plugin:
     def run_id(self, run_id):
         self._run_id = run_id
         self.__run_id = strax.Context._process_superrun_id(run_id)
+
+    @property
+    def first_chunk(self):
+        if self.chunk_numbers is None:
+            return 0
+        return self.chunk_numbers[0]
 
     @property
     def is_superrun(self):
@@ -447,7 +454,7 @@ class Plugin:
             pass
 
         try:
-            for chunk_i in itertools.count():
+            for chunk_i in itertools.count() if self.chunk_numbers is None else self.chunk_numbers:
                 # Online input support
                 while not self.is_ready(chunk_i):
                     if self.source_finished():
@@ -472,7 +479,7 @@ class Plugin:
                 if pacemaker is None:
                     inputs_merged = dict()
                 else:
-                    if chunk_i != 0:
+                    if chunk_i != self.first_chunk:
                         # Fetch the pacemaker, to figure out when this chunk ends
                         # (don't do it for chunk 0, for which we already fetched)
                         if not self._fetch_chunk(pacemaker, iters):


### PR DESCRIPTION
Then the `chunk_i` argument will be correct for `Plugin.compute`.