### PR TITLE
Force memory allocation in `merge_arrs`

### DIFF
--- a/strax/utils.py
+++ b/strax/utils.py
@@ -216,7 +216,8 @@ def merge_arrs(arrs, dtype=None, replacing=False):
     for arr in arrs:
         for fn in arr.dtype.names:
             if fn in result.dtype.names:
-                result[fn] = arr[fn]
+                # the copy here is needed to avoid cross-talk between memory of arrays
+                result[fn] = np.copy(arr[fn])
     return result
 
 


### PR DESCRIPTION
Otherwise, weirdly you will see

`peaklets = st.get_array(run_id, targets=('peaklets', 'peaklet_classification'))` but `peaklets['type']` is always 0 (from `"peaklets"`).

This error might happen at https://github.com/AxFoundation/strax/blob/4e13c7a55e033758071f9092dd83c57868fa36c3/strax/context.py#L1823.