### PR TITLE
Temporary plugin should keep order of targets

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1583,7 +1583,7 @@ class Context:
         # If multiple targets of the same kind, create a MergeOnlyPlugin
         # to merge the results automatically.
         if isinstance(targets, (list, tuple)) and len(targets) > 1:
-            targets = tuple(set(strax.to_str_tuple(targets)))
+            targets = tuple(strax.set_keep_order(strax.to_str_tuple(targets)))
             plugins = self._get_plugins(targets=targets, run_id=run_id, chunk_number=chunk_number)
             if len(set(plugins[d].data_kind_for(d) for d in targets)) == 1:
                 temp_name = TEMP_DATA_TYPE_PREFIX + strax.deterministic_hash(targets)

--- a/strax/utils.py
+++ b/strax/utils.py
@@ -216,8 +216,7 @@ def merge_arrs(arrs, dtype=None, replacing=False):
     for arr in arrs:
         for fn in arr.dtype.names:
             if fn in result.dtype.names:
-                # the copy here is needed to avoid cross-talk between memory of arrays
-                result[fn] = np.copy(arr[fn])
+                result[fn] = arr[fn]
     return result
 
 
@@ -256,6 +255,13 @@ def profile_threaded(filename):
     p = yappi.convert2pstats(p)
     p.dump_stats(filename)
     yappi.clear_stats()
+
+
+@export
+def set_keep_order(x):
+    """Return sorted set of x."""
+    seen = set()
+    return [i for i in x if not (i in seen or seen.add(i))]
 
 
 @export


### PR DESCRIPTION
And revert https://github.com/AxFoundation/strax/pull/957.

Otherwise, weirdly you will see

`peaklets = st.get_array(run_id, targets=('peaklets', 'peaklet_classification'))` but `peaklets['type']` is sometimes 0 (from `"peaklets"`).