### PR TITLE
Save memory when decompressing data

### DIFF
--- a/strax/io.py
+++ b/strax/io.py
@@ -21,21 +21,53 @@ tqdm = strax.utils.tqdm
 blosc.set_releasegil(True)
 blosc.set_nthreads(1)
 
+
+def _bz2_decompress(f, chunk_size=16 * 1024 * 1024):
+    decompressor = bz2.BZ2Decompressor()
+    data = bytearray()  # Efficient mutable storage
+    for d in iter(lambda: f.read(chunk_size), b""):
+        data.extend(decompressor.decompress(d))
+    return data
+
+
 # zstd's default compression level is 3:
 # https://github.com/sergey-dryabzhinsky/python-zstd/blob/eba9e633e0bc0e9c9762c985d0433e08405fd097/src/python-zstd.h#L53
 # we also need to constraint the number of worker threads to 1
 # https://github.com/sergey-dryabzhinsky/python-zstd/blob/eba9e633e0bc0e9c9762c985d0433e08405fd097/src/python-zstd.h#L98
-zstd_compress = lambda data: zstd.compress(data, 3, 1)
+_zstd_compress = lambda data: zstd.compress(data, 3, 1)
+
+
+def _zstd_decompress(f):
+    data = f.read()
+    data = zstd.decompress(data)
+    return data
+
+
+def _blosc_compress(data):
+    if data.nbytes >= blosc.MAX_BUFFERSIZE:
+        raise ValueError("Blosc's input buffer cannot exceed ~2 GB")
+    return blosc.compress(data, shuffle=False)
+
+
+def _blosc_decompress(f):
+    data = f.read()
+    data = blosc.decompress(data)
+    return data
+
+
+def _lz4_decompress(f, chunk_size=16 * 1024 * 1024):
+    decompressor = lz4.LZ4FrameDecompressor()
+    data = bytearray()  # Efficient mutable storage
+    for d in iter(lambda: f.read(chunk_size), b""):
+        data.extend(decompressor.decompress(d))
+    return data
 
 
 COMPRESSORS = dict(
-    bz2=dict(compress=bz2.compress, decompress=bz2.decompress),
-    zstd=dict(compress=zstd_compress, decompress=zstd.decompress),
-    blosc=dict(
-        compress=None,  # add special function to prevent overflow at bottom module
-        decompress=blosc.decompress,
-    ),
-    lz4=dict(compress=lz4.compress, decompress=lz4.decompress),
+    bz2=dict(compress=bz2.compress, decompress=_bz2_decompress),
+    zstd=dict(compress=_zstd_compress, decompress=_zstd_decompress),
+    blosc=dict(compress=_blosc_compress, decompress=_blosc_decompress),
+    lz4=dict(compress=lz4.compress, decompress=_lz4_decompress),
 )
 
 
@@ -58,11 +90,9 @@ def load_file(f, compressor, dtype):
 
 def _load_file(f, compressor, dtype):
     try:
-        data = f.read()
+        data = COMPRESSORS[compressor]["decompress"](f)
         if not len(data):
             return np.zeros(0, dtype=dtype)
-
-        data = COMPRESSORS[compressor]["decompress"](data)
         try:
             return np.frombuffer(data, dtype=dtype)
         except ValueError as e:
@@ -99,15 +129,6 @@ def _save_file(f, data, compressor="zstd"):
     d_comp = COMPRESSORS[compressor]["compress"](data)
     f.write(d_comp)
     return len(d_comp)
-
-
-def _compress_blosc(data):
-    if data.nbytes >= blosc.MAX_BUFFERSIZE:
-        raise ValueError("Blosc's input buffer cannot exceed ~2 GB")
-    return blosc.compress(data, shuffle=False)
-
-
-COMPRESSORS["blosc"]["compress"] = _compress_blosc
 
 
 @export


### PR DESCRIPTION
Streaming decompression can significantly reduce memory usage of `bz2` and `lz4`. To keep backward compatibility, the `decompress` key is kept. The memory-reduced function is assigned to `_decompress` key.