### PR TITLE
Do not initialize any saver when dropping columns

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -1113,6 +1113,9 @@ class Context:
         targets=tuple(),
         save=tuple(),
         time_range=None,
+        selection=None,
+        keep_columns=None,
+        drop_columns=None,
         chunk_number=None,
         multi_run_progress_bar=False,
         combining=False,
@@ -1314,9 +1317,15 @@ class Context:
 
             # Warn about conditions that preclude saving, but the user
             # might not expect.
+            # We're not even getting the whole data.
             if time_range is not None:
-                # We're not even getting the whole data.
                 self.log.warning(f"Not saving {target_i} while selecting a time range in the run")
+                return
+            if selection is not None:
+                self.log.warning(f"Not saving {target_i} while applying selections in the run")
+                return
+            if keep_columns is not None or drop_columns is not None:
+                self.log.warning(f"Not saving {target_i} while dropping fields in the run")
                 return
             if any([len(v) > 0 for k, v in self._find_options.items() if "fuzzy" in k]):
                 # In fuzzy matching mode, we cannot (yet) derive the
@@ -1637,6 +1646,9 @@ class Context:
             targets=targets,
             save=save,
             time_range=time_range,
+            selection=selection,
+            keep_columns=keep_columns,
+            drop_columns=drop_columns,
             chunk_number=chunk_number,
             multi_run_progress_bar=multi_run_progress_bar,
             combining=combining,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -95,6 +95,10 @@ def test_filestore(allow_multiprocess, max_workers, processor):
         mystrax.scan_runs()
         assert mystrax.list_available("peaks") == []
 
+        # Create it with dropping columns
+        mystrax.get_array(run_id=run_id, targets="peaks", keep_columns=["time"])
+        assert not mystrax.is_stored(run_id, "peaks")
+
         # Create it
         peaks_1 = mystrax.get_array(run_id=run_id, targets="peaks")
         p = mystrax.get_single_plugin(run_id, "records")


### PR DESCRIPTION
The yield results would be saved: https://github.com/AxFoundation/strax/blob/40777da3bffd2054583c997402ca623bf782a784/strax/context.py#L1679 without this PR.