### PR TITLE
Topological level and shortest dependency path of dependency tree (directed acyclic graph)

### DIFF
--- a/strax/context.py
+++ b/strax/context.py
@@ -987,7 +987,7 @@ class Context:
         # Set chunk_number in the lineage
         if chunk_number is not None:
             for d_depends in plugin.depends_on:
-                dependencies = self.get_dependencies(d_depends)
+                dependencies = self.get_dependencies(d_depends) | {d_depends}
                 for d in chunk_number.keys():
                     if d not in dependencies:
                         continue
@@ -1026,15 +1026,6 @@ class Context:
                                 )
                             if not mask:
                                 raise ValueError(msg)
-                            for _d in dependencies:
-                                if _d == d_depends:
-                                    continue
-                                if self.is_stored(run_id, _d):
-                                    raise ValueError(
-                                        f"Can not assign chunk_number for {plugin.__class__} "
-                                        "because it has multiple dependencies and one of the "
-                                        f"dependencies {d} will be made from stored {_d}."
-                                    )
                     configs.setdefault("chunk_number", {})
                     if d_depends in configs["chunk_number"]:
                         raise ValueError(

--- a/strax/context.py
+++ b/strax/context.py
@@ -24,6 +24,7 @@ __all__.extend(["RUN_DEFAULTS_KEY"])
 
 RUN_DEFAULTS_KEY = "strax_defaults"
 TEMP_DATA_TYPE_PREFIX = "_temp_"
+NOT_ALLOWED_PLUGINS = (strax.LoopPlugin, strax.OverlapWindowPlugin)
 
 # use tqdm as loaded in utils (from tqdm.notebook when in a jupyter env)
 tqdm = strax.utils.tqdm
@@ -986,18 +987,54 @@ class Context:
         # Set chunk_number in the lineage
         if chunk_number is not None:
             for d_depends in plugin.depends_on:
+                dependencies = self.get_dependencies(d_depends)
+                for d in chunk_number.keys():
+                    if d not in dependencies:
+                        continue
+                    if issubclass(plugin.__class__, NOT_ALLOWED_PLUGINS):
+                        raise ValueError(
+                            f"Can not load per-chunk storage from {d} for {plugin.__class__} "
+                            f"because it is subclass of one of {NOT_ALLOWED_PLUGINS}!"
+                        )
                 if d_depends in chunk_number:
                     if len(plugin.depends_on) > 1:
-                        raise ValueError(
-                            "Can not assign chunk_number for multi-dependencies plugins "
-                            "because it is not clear which input should be assigned."
-                        )
-                    not_allowed_plugins = (strax.LoopPlugin, strax.OverlapWindowPlugin)
-                    if issubclass(plugin.__class__, not_allowed_plugins):
-                        raise ValueError(
-                            f"Can not assign chunk_number for {plugin.__class__} "
-                            f"because it is subclass of one of {not_allowed_plugins}!"
-                        )
+                        for d in plugin.depends_on:
+                            dependencies = self.get_dependencies(d) | {d}
+                            msg = (
+                                f"Can not assign chunk_number for {plugin.__class__} "
+                                "because it has multiple dependencies and one of the "
+                                f"dependencies {d} does not (eventually) depend on {d_depends}."
+                            )
+                            mask = d_depends in dependencies
+                            if not mask:
+                                raise ValueError(msg)
+                            # Make sure other dependencies depend on the same per-chunk data_type
+                            for shortest in [False, True]:
+                                levels = {
+                                    _d: self.tree_levels[shortest][_d]["level"]
+                                    for _d in dependencies
+                                }
+                                mask &= (
+                                    len(
+                                        [
+                                            k
+                                            for k, v in levels.items()
+                                            if v == levels.get(d_depends, -1)
+                                        ]
+                                    )
+                                    == 1
+                                )
+                            if not mask:
+                                raise ValueError(msg)
+                            for _d in dependencies:
+                                if _d == d_depends:
+                                    continue
+                                if self.is_stored(run_id, _d):
+                                    raise ValueError(
+                                        f"Can not assign chunk_number for {plugin.__class__} "
+                                        "because it has multiple dependencies and one of the "
+                                        f"dependencies {d} will be made from stored {_d}."
+                                    )
                     configs.setdefault("chunk_number", {})
                     if d_depends in configs["chunk_number"]:
                         raise ValueError(
@@ -2848,17 +2885,32 @@ class Context:
         if self._fixed_level_cache is not None and context_hash in self._fixed_level_cache:
             return self._fixed_level_cache[context_hash]
 
-        def _get_levels(data_type=None, results=None):
+        def _get_levels(data_type=None, results=None, shortest=False):
             """Get the level data_type in the context."""
             if results is None:
                 results = dict()
             for k in [data_type] if data_type else self._plugin_class_registry.keys():
+                if k in results:
+                    continue
                 results[k] = dict()
                 _v = self._plugin_class_registry[k]()
                 if _v.depends_on:
-                    results[k]["level"] = (
-                        max(_get_levels(d, results)[d]["level"] for d in _v.depends_on) + 1
-                    )
+                    if shortest:
+                        results[k]["level"] = (
+                            min(
+                                _get_levels(d, results, shortest=shortest)[d]["level"]
+                                for d in _v.depends_on
+                            )
+                            + 1
+                        )
+                    else:
+                        results[k]["level"] = (
+                            max(
+                                _get_levels(d, results, shortest=shortest)[d]["level"]
+                                for d in _v.depends_on
+                            )
+                            + 1
+                        )
                 else:
                     results[k]["level"] = 0
                 results[k]["class"] = self._plugin_class_registry[k].__name__
@@ -2866,14 +2918,17 @@ class Context:
             return results
 
         # Sort the results by level, class, and index in provides
-        _results = sorted(
-            _get_levels().items(), key=lambda x: (x[1]["level"], x[1]["class"], x[1]["index"])
-        )
+        results = dict()
+        for shortest in [False, True]:
+            results[shortest] = sorted(
+                _get_levels(shortest=shortest).items(),
+                key=lambda x: (x[1]["level"], x[1]["class"], x[1]["index"]),
+            )
 
-        # Assign order to the results
-        for order, (key, value) in enumerate(_results):
-            value["order"] = order
-        results = dict(_results)
+            # Assign order to the results
+            for order, (key, value) in enumerate(results[shortest]):
+                value["order"] = order
+            results[shortest] = dict(results[shortest])
 
         if self._fixed_level_cache is None:
             self._fixed_level_cache = {context_hash: results}


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

The dependency structure forms a directed acyclic graph (DAG), allowing us to define a topological level for each node, as implemented in https://github.com/AxFoundation/strax/pull/896. This new PR extends that by also computing the shortest dependency path within the DAG:

1. Topological level: `level(node) = 1 + max(level(dep))` Represents the longest path from any source node to the given node — useful for understanding how late a node occurs in the dependency chain.
2. Shortest dependency path: `level(node) = 1 + min(level(dep))` Captures the minimum number of steps from a source node to the current node, identifying the shallowest point of dependency.

By combining both metrics, we can better analyze the structure of the dependency tree. In particular, we can identify key nodes that act as "connectors" or "cut points": if we divide the tree at such a node, one of the resulting subtrees will contain all nodes that depend on it, effectively capturing a full dependency closure.

That node is the node with a unique topological level and shortest dependency path among all nodes.

Previously, in reprocessing, only `data_type`s that depend on one `depends_on` are allowed in per-chunk storage. Now we allow multiple `depends_on`, if all `depends_on` eventually depend on a single `data_type`, and all intermediate `data_type`s are not stored.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
