### PR TITLE
Do not assign `_multi_output_topics` when the topic is from a loader

### DIFF
--- a/strax/processors/post_office.py
+++ b/strax/processors/post_office.py
@@ -268,7 +268,7 @@ class PostOffice:
             log.debug(f"Got submessage {sub_msg} for sub topic {sub_msg_topic}")
             # sub_msg_topic not in self._multi_output_topics means
             # it already has a loader (as producer)
-            if sub_msg_topic not in self._multi_output_topics:
+            if sub_msg_topic in self._multi_output_topics:
                 self._ack_msg_produced(sub_msg, sub_msg_topic)
         return desired_sub_msg
 

--- a/strax/processors/post_office.py
+++ b/strax/processors/post_office.py
@@ -132,8 +132,10 @@ class PostOffice:
             else:
                 # Multi-output producer, recurse
                 for sub_topic in topic:
-                    self._multi_output_topics[sub_topic] = topic
+                    # if sub_topic is already registered as loader,
+                    # we can not handle it as _multi_output_topics
                     if sub_topic not in registered:
+                        self._multi_output_topics[sub_topic] = topic
                         self.register_producer(iterator, sub_topic)
                 return
         assert isinstance(topic, str)
@@ -264,7 +266,10 @@ class PostOffice:
                 # This is what our caller wants
                 desired_sub_msg = sub_msg
             log.debug(f"Got submessage {sub_msg} for sub topic {sub_msg_topic}")
-            self._ack_msg_produced(sub_msg, sub_msg_topic)
+            # sub_msg_topic not in self._multi_output_topics means
+            # it already has a loader (as producer)
+            if sub_msg_topic not in self._multi_output_topics:
+                self._ack_msg_produced(sub_msg, sub_msg_topic)
         return desired_sub_msg
 
     def _ack_msg_produced(self, msg, topic):


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Before this PR, when running:

```
import fuse
run_id = '058169'
st = fuse.xenonnt_fuse_full_chain_simulation(corrections_run_id=run_id)
for data_type in ['microphysics_summary', 'drifted_electrons', 'extracted_electrons', 's2_photons_sum', 'photo_ionization_electrons']:
    st.make(run_id, data_type, save=data_type)
```

got error:

```
...
  File "/home/xudc/strax/strax/processors/post_office.py", line 204, in _read
    result = self._fetch_new(topic)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xudc/strax/strax/processors/post_office.py", line 261, in _fetch_new
    assert isinstance(msg, dict)
AssertionError
```

This PR fixes this.

The dependency tree looks like this

<img width="544" alt="image" src="https://github.com/user-attachments/assets/aa98660c-64a7-43e9-b772-c136957a45ba" />

And `s2_photons` is not saved because its `save_when` is not `ALWAYS`. When `data_type` is `photo_ionization_electrons`, the `msg` in `_fetch_new("s2_photons_sum")` is loaded from storage but not calculated from a plugin. In this PR, we do not assign topic that has loaders to `_multi_output_topics` to prevent this error. Also, only call `_ack_msg_produced` when `sub_msg_topic` is in `_multi_output_topics` because if `sub_msg_topic` is not in `_multi_output_topics`, it already has a loader.

**Can you briefly describe how it works?**

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
