### PR TITLE
Better performance lineage `chunk_number` assignment

### DIFF
--- a/strax/plugins/plugin.py
+++ b/strax/plugins/plugin.py
@@ -196,9 +196,6 @@ class Plugin:
                 plugin_copy.__setattr__(attribute, copy(source_value))
         return plugin_copy
 
-    def __deepcopy__(self):
-        return self.__copy__(_deep_copy=True)
-
     def __getattr__(self, name):
         """Allow access to config parameters as attributes this allows backwards compatibility in
         cases where a descriptor style config depends on a non descriptor style config."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -514,7 +514,7 @@ def test_per_chunk_storage():
         # Per-chunk storage not allowed for some plugins
         p = type("whatever", (strax.OverlapWindowPlugin,), dict(depends_on="records"))
         st.register(p)
-        with pytest.raises(ValueError):
+        with pytest.raises(NotImplementedError):
             st.make(run_id, "whatever", chunk_number={"records": [0]})
 
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

```
import straxen  # e9fe5dd7fb61fb537d35732730b41639ebc39980
import saltax  # e100810ad106351ef1180499889257d59c97ed90

st = saltax.contexts.sxenonnt(
    saltax_mode="salt",
    generator_name="ybe",
    recoil=0,
    rate=10,
    simu_mode="all",
    simulation_config="sr2_dev",
    corrections_version="global_v18",
    output_folder="strax_data",
)

run_id = "047967"
st.is_stored(run_id, "peaklets", chunk_number={"raw_records": [0, 1, 2]})
```

First get the efficiency of the above codes:

```
python -m cProfile -o output.prof test_chunks.py
gprof2dot -f pstats output.prof | dot -Tsvg -o profile.svg
```

The most significant part is

<img width="528" height="472" alt="image" src="https://github.com/user-attachments/assets/475d242f-089a-4af9-8a0f-21a801f19a23" />

This is because when `chunk_number` is not None, strax before this PR will not cache plugins, so every time building the lineage of a higher plugin, the `__get_plugin` will be called.

**Can you briefly describe how it works?**

This PR makes sure that whenever `chunk_number` is None or not, the plugin (whose lineage does not include `chunk_number`) is cached. Then I designed a dedicated function to assign the `chunk_number` in lineage afterwards.

**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
