### PR TITLE
Fix merge peaks field detection

### DIFF
--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -184,12 +184,11 @@ def store_downsampled_waveform(
             p["data_top"][: p["length"]] = waveform_buffer_top[: p["length"]]
         p["data"][: p["length"]] = waveform_buffer[: p["length"]]
 
-    # If the waveform is downsampled, we can store the first samples of the waveform
+    # Store the first samples of the waveform if requested
     if store_data_start:
-        if p_length > len(p["data_start"]):
-            p["data_start"] = waveform_buffer[: len(p["data_start"])]
-        else:
-            p["data_start"][:p_length] = waveform_buffer[:p_length]
+        # Choose the appropriate copy based on available space
+        n_store = min(p_length, len(p["data_start"]))
+        p["data_start"][:n_store] = waveform_buffer[:n_store]
 
 
 @export

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -189,7 +189,7 @@ def store_downsampled_waveform(
     if store_data_start:
         # Avoid accessing p["data_start"] to get length (fails if field missing)
         # data_start field is typically 200 samples in strax peak dtype
-        n_store = min(p_length, 200)  
+        n_store = min(p_length, 200)
         p["data_start"][:n_store] = waveform_buffer[:n_store]
 
 

--- a/strax/processing/peak_building.py
+++ b/strax/processing/peak_building.py
@@ -185,9 +185,11 @@ def store_downsampled_waveform(
         p["data"][: p["length"]] = waveform_buffer[: p["length"]]
 
     # Store the first samples of the waveform if requested
+    # Note: data_start is typically 200 samples, but we store min(p_length, 200)
     if store_data_start:
-        # Choose the appropriate copy based on available space
-        n_store = min(p_length, len(p["data_start"]))
+        # Avoid accessing p["data_start"] to get length (fails if field missing)
+        # data_start field is typically 200 samples in strax peak dtype
+        n_store = min(p_length, 200)  
         p["data_start"][:n_store] = waveform_buffer[:n_store]
 
 

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -93,10 +93,6 @@ def _merge_peaks(
     # Do the merging. Could numbafy this to optimize, probably...
     buffer = np.zeros(max_buffer, dtype=np.float32)
     buffer_top = np.zeros(max_buffer, dtype=np.float32)
-    
-    # Check which optional waveform fields exist in the dtype
-    has_data_top = "data_top" in peaks.dtype.names
-    has_data_start = "data_start" in peaks.dtype.names
 
     for new_i, new_p in enumerate(new_peaks):
         new_p["min_diff"] = 2147483647  # inf of int32

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -83,6 +83,10 @@ def _merge_peaks(
     # Do the merging. Could numbafy this to optimize, probably...
     buffer = np.zeros(max_buffer, dtype=np.float32)
     buffer_top = np.zeros(max_buffer, dtype=np.float32)
+    
+    # Check which optional waveform fields exist in the dtype
+    has_data_top = "data_top" in peaks.dtype.names
+    has_data_start = "data_start" in peaks.dtype.names
 
     for new_i, new_p in enumerate(new_peaks):
         new_p["min_diff"] = 2147483647  # inf of int32
@@ -119,9 +123,10 @@ def _merge_peaks(
             n_after = p["length"] * upsample
             i0 = (p["time"] - new_p["time"]) // common_dt
             buffer[i0 : i0 + n_after] = np.repeat(p["data"][: p["length"]], upsample) / upsample
-            buffer_top[i0 : i0 + n_after] = (
-                np.repeat(p["data_top"][: p["length"]], upsample) / upsample
-            )
+            if has_data_top:
+                buffer_top[i0 : i0 + n_after] = (
+                    np.repeat(p["data_top"][: p["length"]], upsample) / upsample
+                )
 
             # Handle the other peak attributes
             new_p["area"] += p["area"]
@@ -138,13 +143,13 @@ def _merge_peaks(
             new_p["min_diff"] = min(new_p["min_diff"], p["min_diff"])
         max_data = np.array(max_data)
 
-        # Downsample the buffers into
-        # new_p['data'], new_p['data_top'], and new_p['data_start']
+        # Downsample the buffers into new_p['data'], and optionally
+        # new_p['data_top'] and new_p['data_start'] if those fields exist
         strax.store_downsampled_waveform(
             new_p,
             buffer,
-            True,
-            True,
+            has_data_top,
+            has_data_start,
             buffer_top,
         )
 

--- a/strax/processing/peak_merging.py
+++ b/strax/processing/peak_merging.py
@@ -36,6 +36,10 @@ def merge_peaks(
         constituent peaks, it being too time-consuming to revert to records/hits.
 
     """
+    # Check which optional waveform fields exist in the input dtype
+    # (must be done here, before calling numba-compiled function)
+    has_data_top = "data_top" in peaks.dtype.names
+    has_data_start = "data_start" in peaks.dtype.names
 
     new_peaks, endtime = _merge_peaks(
         peaks,
@@ -43,6 +47,8 @@ def merge_peaks(
         end_merge_at,
         merged=merged,
         max_buffer=max_buffer,
+        has_data_top=has_data_top,
+        has_data_start=has_data_start,
     )
     # If the endtime was in the peaks we have to recompute it here
     # because otherwise it will stay set to zero due to the buffer
@@ -60,6 +66,8 @@ def _merge_peaks(
     end_merge_at,
     merged=None,
     max_buffer=int(1e5),
+    has_data_top=True,
+    has_data_start=True,
 ):
     """Merge specified peaks with their neighbors, return merged peaks.
 
@@ -69,6 +77,8 @@ def _merge_peaks(
     :param max_buffer: Maximum number of samples in the sum_waveforms and other waveforms of the
         resulting peaks (after merging). Peaks must be constructed based on the properties of
         constituent peaks, it being too time-consuming to revert to records/hits.
+    :param has_data_top: Whether data_top field exists in peaks dtype
+    :param has_data_start: Whether data_start field exists in peaks dtype
 
     """
     assert len(start_merge_at) == len(end_merge_at)
@@ -119,9 +129,10 @@ def _merge_peaks(
             n_after = p["length"] * upsample
             i0 = (p["time"] - new_p["time"]) // common_dt
             buffer[i0 : i0 + n_after] = np.repeat(p["data"][: p["length"]], upsample) / upsample
-            buffer_top[i0 : i0 + n_after] = (
-                np.repeat(p["data_top"][: p["length"]], upsample) / upsample
-            )
+            if has_data_top:
+                buffer_top[i0 : i0 + n_after] = (
+                    np.repeat(p["data_top"][: p["length"]], upsample) / upsample
+                )
 
             # Handle the other peak attributes
             new_p["area"] += p["area"]
@@ -138,13 +149,13 @@ def _merge_peaks(
             new_p["min_diff"] = min(new_p["min_diff"], p["min_diff"])
         max_data = np.array(max_data)
 
-        # Downsample the buffers into
-        # new_p['data'], new_p['data_top'], and new_p['data_start']
+        # Downsample the buffers into new_p['data'], and optionally
+        # new_p['data_top'] and new_p['data_start'] if those fields exist
         strax.store_downsampled_waveform(
             new_p,
             buffer,
-            True,
-            True,
+            has_data_top,
+            has_data_start,
             buffer_top,
         )
 


### PR DESCRIPTION
This pull request improves the handling of optional waveform fields (`data_top` and `data_start`) in the peak merging and waveform storage logic. The main changes ensure that code only attempts to access or store these fields if they exist in the data structure, making the code more robust and flexible for different data types.

**Handling of optional waveform fields:**

* In `merge_peaks` and `_merge_peaks` (`strax/processing/peak_merging.py`), added logic to check for the existence of `data_top` and `data_start` fields in the input data type, and propagate this information through the merging process. This prevents errors when these fields are missing. [[1]](diffhunk://#diff-cfb8429d1600b2c4fcc34ff1ebd5aecffb975a7162c53ca6f0bb50eef1999617R39-R51) [[2]](diffhunk://#diff-cfb8429d1600b2c4fcc34ff1ebd5aecffb975a7162c53ca6f0bb50eef1999617R69-R70) [[3]](diffhunk://#diff-cfb8429d1600b2c4fcc34ff1ebd5aecffb975a7162c53ca6f0bb50eef1999617R80-R81)
* Modified the waveform merging and downsampling logic to only process `data_top` and `data_start` if those fields exist, avoiding unnecessary or invalid operations. [[1]](diffhunk://#diff-cfb8429d1600b2c4fcc34ff1ebd5aecffb975a7162c53ca6f0bb50eef1999617R132) [[2]](diffhunk://#diff-cfb8429d1600b2c4fcc34ff1ebd5aecffb975a7162c53ca6f0bb50eef1999617L141-R158)

**Waveform storage improvements:**

* Updated `store_downsampled_waveform` (`strax/processing/peak_building.py`) to use a safer and clearer approach for storing the `data_start` field, avoiding direct length checks on potentially missing fields and always storing up to 200 samples or the available length.